### PR TITLE
correctly handle edge case in tableswitch, where highIndex is Integer.MAX_VALUE

### DIFF
--- a/src/soot/baf/internal/BTableSwitchInst.java
+++ b/src/soot/baf/internal/BTableSwitchInst.java
@@ -161,11 +161,17 @@ public class BTableSwitchInst extends AbstractInst implements TableSwitchInst
             
         buffer.append("{" + endOfLine);
         
-        for(int i = lowIndex; i <= highIndex; i++)
+        for(int i = lowIndex; i < highIndex; i++)
         {
             buffer.append("    case " + i + ": goto " + 
                 getTarget(i - lowIndex) + ";" 
                           + endOfLine);
+        }
+        // in the for loop above, we cannot use "<=" since 'i' would wrap around
+        if (highIndex == Integer.MAX_VALUE) {
+        	buffer.append("    case " + highIndex + ": goto " + 
+                    getTarget(highIndex - lowIndex) + ";" 
+                              + endOfLine);
         }
 
         buffer.append("    default: goto " + getDefaultTarget() + ";" + endOfLine);
@@ -182,12 +188,11 @@ public class BTableSwitchInst extends AbstractInst implements TableSwitchInst
         
         for(int i = lowIndex; i <= highIndex; i++)
         {
-            up.literal("    case ");
-            up.literal(new Integer(i).toString());
-            up.literal(": goto ");
-            targetBoxes[i-lowIndex].toString(up);
-            up.literal(";");
-            up.newline();
+            printCaseTarget(up, i);
+        }
+        // in the for loop above, we cannot use "<=" since 'i' would wrap around
+        if (highIndex == Integer.MAX_VALUE) {
+        	printCaseTarget(up, highIndex);
         }
 
         up.literal("    default: goto ");
@@ -196,6 +201,15 @@ public class BTableSwitchInst extends AbstractInst implements TableSwitchInst
         up.newline();
         up.literal("}");
     }
+
+	private void printCaseTarget(UnitPrinter up, int targetIndex) {
+		up.literal("    case ");
+		up.literal(new Integer(targetIndex).toString());
+		up.literal(": goto ");
+		targetBoxes[targetIndex-lowIndex].toString(up);
+		up.literal(";");
+		up.newline();
+	}
 
     public List getUnitBoxes()
     {

--- a/src/soot/jimple/internal/JTableSwitchStmt.java
+++ b/src/soot/jimple/internal/JTableSwitchStmt.java
@@ -128,11 +128,17 @@ public class JTableSwitchStmt extends AbstractStmt
             
         buffer.append("{" + endOfLine);
         
-        for(int i = lowIndex; i <= highIndex; i++)
+        for(int i = lowIndex; i < highIndex; i++)
         {
             buffer.append(
                           "    " + Jimple.CASE + " " + i + ": " + Jimple.GOTO + 
                           " " + getTarget(i - lowIndex) + ";" + endOfLine);
+        }
+        // in the for loop above, we cannot use "<=" since 'i' would wrap around
+        if (highIndex == Integer.MAX_VALUE) {
+        	buffer.append(
+                    "    " + Jimple.CASE + " " + highIndex + ": " + Jimple.GOTO + 
+                    " " + getTarget(highIndex - lowIndex) + ";" + endOfLine);
         }
 
         buffer.append("    " +  Jimple.DEFAULT + 
@@ -153,17 +159,12 @@ public class JTableSwitchStmt extends AbstractStmt
         up.newline();
         up.literal("{");
         up.newline();
-        for(int i = lowIndex; i <= highIndex; i++) {
-            up.literal("    ");
-            up.literal(Jimple.CASE);
-            up.literal(" ");
-            up.literal(new Integer(i).toString());
-            up.literal(": ");
-            up.literal(Jimple.GOTO);
-            up.literal(" ");
-            targetBoxes[i-lowIndex].toString(up);
-            up.literal(";");
-            up.newline();
+        for(int i = lowIndex; i < highIndex; i++) {
+            printCaseTarget(up, i);
+        }
+        // in the for loop above, we cannot use "<=" since 'i' would wrap around
+        if (highIndex == Integer.MAX_VALUE) {
+        	printCaseTarget(up, highIndex);
         }
         
         up.literal("    ");
@@ -176,6 +177,20 @@ public class JTableSwitchStmt extends AbstractStmt
         up.newline();
         up.literal("}");
     }
+
+
+	private void printCaseTarget(UnitPrinter up, int targetIndex) {
+		up.literal("    ");
+		up.literal(Jimple.CASE);
+		up.literal(" ");
+		up.literal(new Integer(targetIndex).toString());
+		up.literal(": ");
+		up.literal(Jimple.GOTO);
+		up.literal(" ");
+		targetBoxes[targetIndex-lowIndex].toString(up);
+		up.literal(";");
+		up.newline();
+	}
 
 
     public Unit getDefaultTarget()


### PR DESCRIPTION
The toString()-Methods of JTableSwitchStmt and BTableSwitchInst do not handle an edge case, where the highIndex is Integer.MAX_VALUE: A for loop wraps around to Integer.MIN_VALUE, leading to ArrayIndexOutOfBoundsException or an infinite loop.

I came across this while recreating a [bug](http://code.google.com/p/android/issues/detail?id=22344) in Android with Jimple. The example there leads to a LookupSwitchStmt, but one can easily reproduce the situation mentioned above with this Java code:

``` java
switch (0x7fffffff) {
    case 0x7fffffff - 1:
    case 0x7fffffff:
        break;
    default:
        throw new AssertionError();
}
```

I'm not sure if the incorrect handling of Integer.MAX_VALUE as highIndex is present in other classes than JTableSwitchStmt and BTableSwitchInst because I'm not familiar with all the intermediate representations in Soot. Someone with that knowledge should check for similiar "edgy" uses of highIndex for a TableSwitch.

Note that the JVM spec permits the "low" and "high" tableswitch indices to range from Integer.MIN_VALUE to Integer.MAX_VALUE, so I guess there is no other solution than the one proposed, to check for one of the edge cases, in my case for highIndex == Integer.MAX_VALUE
