### PR TITLE
fix wrong static-ness bug in on-the-fly method generation

### DIFF
--- a/src/soot/SootMethodRefImpl.java
+++ b/src/soot/SootMethodRefImpl.java
@@ -152,7 +152,7 @@ class SootMethodRefImpl implements SootMethodRef {
         //we simply create the methods on the fly; the method body will throw an appropriate
         //error just in case the code *is* actually reached at runtime
         if(Options.v().allow_phantom_refs()) {
-        	SootMethod m = new SootMethod(name, parameterTypes, returnType);
+        	SootMethod m = new SootMethod(name, parameterTypes, returnType, isStatic()?Modifier.STATIC:0);
         	JimpleBody body = Jimple.v().newBody(m);
 			m.setActiveBody(body);
 			


### PR DESCRIPTION
Hi guys,

I think on-the-fly stub method generation should also follow the static-ness of MethodRef.
Please review the change.
