### PR TITLE
Adds BitVector.intersects

### DIFF
--- a/src/soot/util/BitVector.java
+++ b/src/soot/util/BitVector.java
@@ -175,6 +175,22 @@ public class BitVector
 		}
 		return c;
 	}
+	
+	/**Returns true if the both the current and the specified
+   * bitvectors have at least one bit set in common.
+   * @author Quentin Sabah
+   * Inspired by the BitVector.and method.
+	*/
+	public boolean intersects(BitVector other) {
+	  long[] otherBits = other.bits;
+	  int numToCheck = otherBits.length;
+	  if(bits.length < numToCheck) numToCheck = bits.length;
+	  int i;
+	  for( i = 0; i < numToCheck; i++) {
+	    if((bits[i] & otherBits[i]) != 0) return true;
+	  }
+	  return false;
+  }
 
     private void expand( int bit ) {
         int n = indexOf( bit )+1;

--- a/tests/soot/util/BitVector_intersects_Test.java
+++ b/tests/soot/util/BitVector_intersects_Test.java
@@ -1,0 +1,110 @@
+package soot.util;
+
+import soot.util.BitVector;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * JUnit test suite for the BitVector.intersects() method
+ * @Author Quentin Sabah
+*/
+public class BitVector_intersects_Test extends TestCase {
+
+  public BitVector_intersects_Test(String name) {
+    super(name);
+  }
+
+  public void testEmptyBitvectorDontIntersectsItself() {
+    BitVector a = new BitVector();
+    assertFalse(a.intersects(a));
+  }
+
+  public void testEmptyBitVectorsDontIntersects() {
+    BitVector a = new BitVector();
+    BitVector b = new BitVector();
+    assertFalse(a.intersects(b));
+    assertFalse(b.intersects(a));
+  }
+
+  public void testEquallySizedEmptyBitVectorsDontIntersects() {
+    BitVector a = new BitVector(1024);
+    BitVector b = new BitVector(1024);
+    assertFalse(a.intersects(b));
+    assertFalse(b.intersects(a));
+  }
+
+  public void testNotEquallySizedEmptyBitVectorsDontIntersects() {
+    BitVector a = new BitVector(2048);
+    BitVector b = new BitVector(1024);
+    assertFalse(a.intersects(b));
+    assertFalse(b.intersects(a));
+  }
+
+  public void testSizedEmptyBitVectorDontIntersectsItself() {
+    BitVector a = new BitVector(1024);
+    assertFalse(a.intersects(a));
+  }
+
+  public void testNonOverlappingBitVectorsDontIntersects() {
+    BitVector a = new BitVector();
+    BitVector b = new BitVector();
+    int i;
+    for(i = 0; i < 512; i++) {
+      if(i % 2 == 0)
+        a.set(i);
+      else
+        b.set(i);
+    }
+    assertFalse(a.intersects(b));
+    assertFalse(b.intersects(a));
+  }
+
+  public void testNotEquallySizedNonOverlappingBitVectorsDontIntersects() {
+    BitVector a = new BitVector();
+    BitVector b = new BitVector();
+    int i;
+    for(i = 0; i < 512; i++) {
+      a.set(i);
+    }
+    for(; i < 1024; i++) {
+      b.set(i);
+    }
+    assertFalse(a.intersects(b));
+    assertFalse(b.intersects(a));
+  }
+
+  public void testNonEmptyBitVectorIntersectsItself() {
+    BitVector a = new BitVector();
+    a.set(337);
+    assertTrue(a.intersects(a));
+  }
+
+  public void testNotEquallySizedOverlappingBitVectorsIntersects() {
+    BitVector a = new BitVector(1024);
+    BitVector b = new BitVector(512);
+
+    a.set(337);
+    b.set(337);
+    assertTrue(a.intersects(b));
+    assertTrue(b.intersects(a));
+    a.clear(337);
+    b.clear(337);
+
+    for(int i = 0; i < 512; i++) {
+      a.set(i); b.set(i);
+      assertTrue(a.intersects(b));
+      assertTrue(b.intersects(a));
+      a.clear(i); b.clear(i);
+    }
+  }
+
+  public static Test suite() {
+    TestSuite suite = new TestSuite(BitVector_intersects_Test.class);
+    return suite;
+  }
+
+  public static void main(String[] args) {
+    junit.textui.TestRunner.run(suite());
+  }
+}


### PR DESCRIPTION
Hi Eric, I added a modest "intersects" instance method for BitVector, and some unit tests.

It is a fast intersection test between two BitVectors, returning "true" as soon as the method finds a common bit set. It is much more efficient than building the full AND set and then testing the cardinality.

Thought it might be usefull to other users.

Quentin.
