### PR TITLE
Fix NullPointerException in MemoryEfficientRasUnion.toString

### DIFF
--- a/src/soot/jimple/toolkits/pointer/MemoryEfficientRasUnion.java
+++ b/src/soot/jimple/toolkits/pointer/MemoryEfficientRasUnion.java
@@ -119,7 +119,11 @@ public class MemoryEfficientRasUnion extends Union {
 	 * {@inheritDoc}
 	 */
 	public String toString() {
-		return subsets.toString();
+	  if(subsets == null){
+	    return "[]";
+	  }else{
+		  return subsets.toString();
+		}
 	}
 
 }


### PR DESCRIPTION
Hi Eric, just fixed a minor bug:

MemoryEfficientRasUnion.toString is calling subsets.toString() however subsets might be null, raising a NullPointerException.

Now the method is returning "[]" (~ empty set) if subsets is null.
