### PR TITLE
Re: [Soot-list] ExceptionalUnitGraph and nested traps

### DIFF
--- a/src/soot/util/PhaseDumper.java
+++ b/src/soot/util/PhaseDumper.java
@@ -158,7 +158,7 @@ public class PhaseDumper {
 	String className = b.getMethod().getDeclaringClass().getName();
 	buf.append(className);
 	buf.append(File.separatorChar);
-	buf.append(b.getMethod().getSubSignature());
+	buf.append(b.getMethod().getSubSignature().replace('<', '[').replace('>', ']'));
 	java.io.File dir = new java.io.File(buf.toString());
 	if (dir.exists()) {
 	    if (! dir.isDirectory()) {


### PR DESCRIPTION
From the mailing list:

> > One last thing though: When I activated CFG dumping for my
> > `stp.deadlock` pack, I got an exception indicating that a directory
> > could not be created. After some investigation, I found that the
> > PhaseDumper wanted to create a directory named `void<init>()` which is
> > not a valid name (on Windows at least). So in case someone wants to fix
> > this (or point out that I made another stupid mistake), here is the
> > simple change I had to make:
> > 
> > In `java.io.File makeDirectoryIfMissing(final Body b)`, change
> > 
> > ```
> >   buf.append(b.getMethod().getSubSignature());
> > ```
> > 
> > to
> > 
> > ```
> >   buf.append(b.getMethod().getSubSignature()
> >           .replace('<', '[').replace('>', ']'));
> > ```
> 
> Good. Yes, we should commit that. Can you make a git merge request on 
> github?
