### PR TITLE
Improved AnnotationTag API and refactored some uses

### DIFF
--- a/generated/jastadd/soot/JastAddJ/Annotation.java
+++ b/generated/jastadd/soot/JastAddJ/Annotation.java
@@ -176,14 +176,14 @@ public class Annotation extends Modifier implements Cloneable {
    * @declaredat /Users/eric/Documents/workspaces/clara-soot/JastAddExtensions/Jimple1.5Backend/AnnotationsCodegen.jrag:305
    */
   public void appendAsAttributeTo(Collection list) {
-      soot.tagkit.AnnotationTag tag = new soot.tagkit.AnnotationTag(decl().typeDescriptor(), getNumElementValuePair());
+    
       ArrayList elements = new ArrayList(getNumElementValuePair());
       for(int i = 0; i < getNumElementValuePair(); i++) {
         String name = getElementValuePair(i).getName();
         ElementValue value = getElementValuePair(i).getElementValue();
         value.appendAsAttributeTo(elements, name);
       }
-      tag.setElems(elements);
+      soot.tagkit.AnnotationTag tag = new soot.tagkit.AnnotationTag(decl().typeDescriptor(), elements);
       list.add(tag);
   }
   /**

--- a/src/soot/AbstractJasminClass.java
+++ b/src/soot/AbstractJasminClass.java
@@ -225,8 +225,8 @@ public abstract class AbstractJasminClass
                 AnnotationTag annot = it.next();
                 sb.append(".annotation ");
                 sb.append(soot.util.StringTools.getQuotedStringOf(annot.getType())+"\n");
-                for (int i = 0; i < annot.getNumElems(); i++){
-                    sb.append(getElemAttr(annot.getElemAt(i)));
+                for (AnnotationElem ae : annot.getElems()){
+                  sb.append(getElemAttr(ae));
                 }
                 sb.append(".end .annotation\n");
             }
@@ -364,8 +364,8 @@ public abstract class AbstractJasminClass
                         AnnotationTag annot = ((AnnotationAnnotationElem)elem).getValue();
                         result.append(".annotation ");
                         result.append(soot.util.StringTools.getQuotedStringOf(annot.getType())+"\n");
-                        for (int i = 0; i < annot.getNumElems(); i++){
-                            result.append(getElemAttr(annot.getElemAt(i)));
+                        for (AnnotationElem ae : annot.getElems()){
+                          result.append(getElemAttr(ae));
                         }
                         result.append(".end .annotation\n");
                         result.append(".end .annot_elem\n");

--- a/src/soot/coffi/Util.java
+++ b/src/soot/coffi/Util.java
@@ -985,9 +985,8 @@ swtch:
             String ref = annotType.substring(1, annotType.length()-1);
             ref = ref.replace('/', '.');
             references.add(ref);
-            int numElems = annot.num_element_value_pairs;
-            AnnotationTag annotTag = new AnnotationTag(annotType, numElems);
-            annotTag.setElems(createElementTags(numElems, coffiClass, annot.element_value_pairs));
+            AnnotationTag annotTag = new AnnotationTag(annotType, 
+                createElementTags(annot.num_element_value_pairs, coffiClass, annot.element_value_pairs));
             tag.addAnnotation(annotTag);
         }
     }
@@ -1068,9 +1067,8 @@ swtch:
                 annotation_element_value aev = (annotation_element_value)ev;
                 annotation annot = aev.annotation_value;
                 String annotType = ((CONSTANT_Utf8_info)coffiClass.constant_pool[annot.type_index]).convert();
-                int numElems = annot.num_element_value_pairs;
-                AnnotationTag annotTag = new AnnotationTag(annotType, numElems);
-                annotTag.setElems(createElementTags(numElems, coffiClass, annot.element_value_pairs));
+                AnnotationTag annotTag = new AnnotationTag(annotType, 
+                    createElementTags(annot.num_element_value_pairs, coffiClass, annot.element_value_pairs));
                 
                 AnnotationAnnotationElem elem = new AnnotationAnnotationElem(annotTag, kind, elemName);
                 list.add(elem);

--- a/src/soot/jimple/toolkits/annotation/j5anno/AnnotationGenerator.java
+++ b/src/soot/jimple/toolkits/annotation/j5anno/AnnotationGenerator.java
@@ -148,9 +148,7 @@ public class AnnotationGenerator {
 		if(!annotationName.endsWith(";"))
 			annotationName = "L" + annotationName + ';';
 		VisibilityAnnotationTag tagToAdd = findOrAdd(h, visibility);
-		AnnotationTag at = new AnnotationTag(annotationName, elems.size());
-		for (AnnotationElem elem : elems) 
-			at.addElem(elem);
+		AnnotationTag at = new AnnotationTag(annotationName, elems);
 		tagToAdd.addAnnotation(at);
 	}
 	

--- a/src/soot/tagkit/AnnotationTag.java
+++ b/src/soot/tagkit/AnnotationTag.java
@@ -1,5 +1,6 @@
 /* Soot - a J*va Optimization Framework
  * Copyright (C) 2005 Jennifer Lhotak
+ * Copyright (C) 2013 Tata Consultancy Services & École Polytechnique de Montréal
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,13 +22,16 @@
  * Modified by the Sable Research Group and others 1997-1999.  
  * See the 'credits' file distributed with Soot for the complete list of
  * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
+ * 
+ * Modified by Marc-André Laverdière-Papineau in 2013
+ * 
  */
-
 package soot.tagkit;
 import java.util.*;
 
 
-/** Represents the annotation attribute attatched to a class, method, field,
+/** 
+ * Represents the annotation attribute attached to a class, method, field,
  * method param - they could have many annotations each
  * for Java 1.5.
  */
@@ -57,23 +61,36 @@ public class AnnotationTag implements Tag
     // should probably make a bunch of subclasses for all the 
     // different kinds - with second level for the constant kinds
  
+    /**
+     * The type
+     */
     private String type;
-    private int numElems = 0;
-    private ArrayList<AnnotationElem> elems;
     
-    /*public AnnotationTag(int vis, int numElems){
-        this.visibility = vis;
-        this.numElems = numElems;
-    }*/
+    /**
+     * The annotations
+     */
+    private List<AnnotationElem> elems;
     
-    public AnnotationTag(String type, int numElems){
-        this.type = type;
-        this.numElems = numElems;
+    public AnnotationTag(String type){
+      this(type, new ArrayList<AnnotationElem>());
+    }
+    public AnnotationTag(String type, Collection<AnnotationElem> elements){
+      this.type = type;
+      if (elements instanceof List<?>)
+        this.elems = (List<AnnotationElem>)elements;
+      else
+        this.elems = new ArrayList<AnnotationElem>(elements);
+    }
+    
+    @Deprecated
+    public AnnotationTag(String type, int numElem){
+      this.type = type;
+      this.elems = new ArrayList<AnnotationElem>(numElem);
     }
     
     // should also print here number of annotations and perhaps the annotations themselves
     public String toString() {
-        StringBuffer sb = new StringBuffer("Annotation: type: "+type+" num elems: "+numElems+" elems: ");
+        StringBuffer sb = new StringBuffer("Annotation: type: "+type+" num elems: "+elems.size()+" elems: ");
         if (elems != null){
             Iterator<AnnotationElem> it = elems.iterator();
             while (it.hasNext()){
@@ -98,8 +115,12 @@ public class AnnotationTag implements Tag
         return type;
     }
     
+    /**
+     * @return the number of elements
+     */
+    @Deprecated
     public int getNumElems(){
-        return numElems;
+        return elems.size();
     }
     
     /** Returns the tag raw data. */
@@ -107,19 +128,37 @@ public class AnnotationTag implements Tag
         throw new RuntimeException( "AnnotationTag has no value for bytecode" );
     }
 
+    /**
+     * Adds one element to the list
+     * @param elem the element
+     */
     public void addElem(AnnotationElem elem){
-        if (elems == null){
-            elems = new ArrayList<AnnotationElem>();
-        }
         elems.add(elem);
     }
     
-    public void setElems(ArrayList<AnnotationElem> list){
+    /**
+     * Overwrites the elements stored previously
+     * @param list the new list of elements
+     */
+    public void setElems(List<AnnotationElem> list){
         this.elems = list;
     }
 
+    /**
+     * Gets the ith element
+     * @param i the element to retrieve
+     * @return whichever element is at this index
+     */
+    @Deprecated
     public AnnotationElem getElemAt(int i){
         return elems.get(i);
+    }
+    
+    /**
+     * @return an immutable collection of the elements
+     */
+    public Collection<AnnotationElem> getElems(){
+      return Collections.unmodifiableCollection(elems);
     }
 }
 


### PR DESCRIPTION
Minor updating of AnnotationTag and its uses.
- Deprecates getting the number of tags and getting a specific element
- Added a return for the collection of elements
- Added constructors
- Updated client code to use the collection of elements and the new constructors

Ran the soot tests, but most of them were failing before and after - so that doesn't help knowing if anything got broken.
