### PR TITLE
fix for: http://trifort.org/soot_testcases/2013_02_01_pair_hmm.tar.gz

### DIFF
--- a/src/soot/jimple/toolkits/typing/fast/UseChecker.java
+++ b/src/soot/jimple/toolkits/typing/fast/UseChecker.java
@@ -184,8 +184,13 @@ public class UseChecker extends AbstractStmtSwitch
 		else if ( rhs instanceof ArrayRef )
 		{
 			this.handleArrayRef((ArrayRef)rhs, stmt);
-			if (!(tlhs instanceof BottomType || tlhs instanceof BottomType)) {
-				((ArrayRef)rhs).setBase((Local)this.uv.visit(((ArrayRef)rhs).getBase(), tlhs.makeArrayType(), stmt));
+      
+      ArrayRef array_rhs = (ArrayRef) rhs;
+      Value base = array_rhs.getBase();
+      Type trhs = base.getType();
+
+			if (!(tlhs instanceof BottomType || trhs instanceof BottomType)) {
+				array_rhs.setBase((Local)this.uv.visit(array_rhs.getBase(), tlhs.makeArrayType(), stmt));
 			}
 			stmt.setRightOp(this.uv.visit(rhs, tlhs, stmt));
 		}


### PR DESCRIPTION
This fix corrects a problem in the fast typing UseChecker.

You can notice that the below line uses tlhs twice in an or.
if (!(tlhs instanceof BottomType || tlhs instanceof BottomType)) {

This fix is to try to follow the intent of the original patch. It corrects an error in the test case given on the subject line. Without this patch there is an incorrect cast from a byte array to an int array. With this patch there is no such cast.

Question: "What is the difference between a computer scientist and a mathematician?"
Answer: "A computer scientist knows no limits."
