### PR TITLE
Fix infinite recursion in  DumbPointerAnalysis.reachingObjects(ctx,l)

### DIFF
--- a/src/soot/jimple/toolkits/pointer/DumbPointerAnalysis.java
+++ b/src/soot/jimple/toolkits/pointer/DumbPointerAnalysis.java
@@ -35,7 +35,7 @@ public class DumbPointerAnalysis implements PointsToAnalysis {
 
     /** Returns the set of objects pointed to by variable l in context c. */
     public PointsToSet reachingObjects( Context c, Local l ) {
-        return reachingObjects(null, l);
+        return reachingObjects(l);
     }
 
     /** Returns the set of objects pointed to by static field f. */


### PR DESCRIPTION
Hi Eric, I found a minor bug.
Calling PointsToAnalysis.reachingObject(ctx,lcl) on an object of class DumbPointerAnalysis raises a StackOverflowError because the method recursively calls itself with a null first-argument instead of calling its sibling single-argument version.

Quentin.
