### PR TITLE
added a getPredsOf() to the icfg similarly to the existing getSuccsOf()

### DIFF
--- a/src/soot/jimple/toolkits/ide/icfg/JimpleBasedInterproceduralCFG.java
+++ b/src/soot/jimple/toolkits/ide/icfg/JimpleBasedInterproceduralCFG.java
@@ -167,6 +167,13 @@ public class JimpleBasedInterproceduralCFG implements InterproceduralCFG<Unit,So
 		return unitGraph.getSuccsOf(u);
 	}
 
+	@Override
+	public List<Unit> getPredsOf(Unit u) {
+		Body body = unitToOwner.get(u);
+		DirectedGraph<Unit> unitGraph = getOrCreateUnitGraph(body);
+		return unitGraph.getPredsOf(u);
+	}
+
 	private DirectedGraph<Unit> getOrCreateUnitGraph(Body body) {
 		return bodyToUnitGraph.getUnchecked(body);
 	}


### PR DESCRIPTION
It would be great to be able to traverse the program graph in both directions, so I've added a getPredsOf() similarly to the existing getSuccsOf(). I have also changed Heros to include the new interface method implemented here
