### PR TITLE
fixing bug in coffi.ClassFile with DataInputStream.read

### DIFF
--- a/src/soot/coffi/ClassFile.java
+++ b/src/soot/coffi/ClassFile.java
@@ -560,6 +560,16 @@ public class ClassFile {
       return true;
    }
 
+   private void readAllBytes(byte[] dest, DataInputStream d) throws IOException {
+     int total_len = dest.length;
+     int read_len = 0;
+     while(read_len < total_len){
+       int to_read = total_len - read_len;
+       int curr_read = d.read(dest, read_len, to_read);
+       read_len += curr_read;
+     }
+   }
+
    /** Reads in the given number of attributes from the given stream.
     * @param d Stream forming the <tt>.class</tt> file.
     * @param attributes_count number of attributes to read in.
@@ -597,7 +607,7 @@ public class ClassFile {
             ca.max_locals = d.readUnsignedShort();
             ca.code_length = d.readInt() & 0xFFFFFFFFL;
             ca.code = new byte[(int) ca.code_length];
-            d.read(ca.code);
+            readAllBytes(ca.code, d);
             ca.exception_table_length = d.readUnsignedShort();
             ca.exception_table = new exception_table_entry[ca.exception_table_length];
             int k;
@@ -812,7 +822,7 @@ public class ClassFile {
             Generic_attribute ga = new Generic_attribute();
             if (len>0) {
                ga.info = new byte[(int) len];
-               d.read(ga.info);
+               readAllBytes(ga.info, d);
             }
             a = (attribute_info)ga;
          }


### PR DESCRIPTION
On a mac DataInputStream.read is only reading part
of the array. The code is expecting the whole array
to be read so that the cursor is positioned properly
for the next read.

This is triggered when using -include-all on mac
with classes.jar and ui.jar and doing a body
transformer on:
  apple.awt.CDragSourceContextPeer
  com.apple.java.BackwardsCompatibilityTest
