### PR TITLE
ClassFile.loadClass is buggy

### DIFF
--- a/src/soot/coffi/ClassFile.java
+++ b/src/soot/coffi/ClassFile.java
@@ -188,8 +188,9 @@ public class ClassFile {
       
       try 
       {
-        data = new byte[classFileStream.available()];
-        classFileStream.read(data);
+      	DataInputStream classDataStream = new DataInputStream(classFileStream);
+        data = new byte[classDataStream.available()];
+        classDataStream.readFully(data);
         f = new ByteArrayInputStream(data);
          
       } catch(IOException e)


### PR DESCRIPTION
InputStream.read() does not guarantee actually, well, reading anything:

http://docs.oracle.com/javase/6/docs/api/java/io/InputStream.html#read(byte[])

The original code failed for me when reading from a `.jar` file, as InputStream.read() would cut out halfway and leave the rest of the `data` array as zeroes. This cause a NPE in `resolveFromClassFile`:

```
Exception in thread "main" java.lang.NullPointerException
    at soot.coffi.method_info.toName(method_info.java:86)
    at soot.coffi.Util.resolveFromClassFile(Util.java:225)
    at soot.CoffiClassSource.resolve(CoffiClassSource.java:39)
    at soot.coffi.Test$.loadClass(Test.scala:22)
    at soot.coffi.Test$.main(Test.scala:27)
    at soot.coffi.Test.main(Test.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:120)
```

This could be fixed with a `while(is.available() > 0)` retry loop to keep reading till it's done. Equivalently, wrapping the it in a `DataInputStream` and using `.readFully()` fixes the problem (observed to go away on my machine).
