### PR TITLE
Fixed access of SootMethod fields to private

### DIFF
--- a/src/soot/SootClass.java
+++ b/src/soot/SootClass.java
@@ -586,8 +586,8 @@ public class SootClass extends AbstractHost implements Numberable
         }
         subSigToMethods.put(m.getNumberedSubSignature(),m);
         methodList.add(m);
-        m.isDeclared = true;
-        m.declaringClass = this;
+        m.setDeclared(true);
+        m.setDeclaringClass(this);
         
     }
 
@@ -607,7 +607,7 @@ public class SootClass extends AbstractHost implements Numberable
         }
         subSigToMethods.put(m.getNumberedSubSignature(),null);
         methodList.remove(m);
-        m.isDeclared = false;
+        m.setDeclared(false);
     }
 
     /**

--- a/src/soot/SootMethod.java
+++ b/src/soot/SootMethod.java
@@ -51,32 +51,32 @@ public class SootMethod
     public static final String staticInitializerName = "<clinit>";
     public static boolean DEBUG=false;
     /** Name of the current method. */
-    String name;
+    private String name;
 
     /** A list of parameter types taken by this <code>SootMethod</code> object, 
       * in declaration order. */
-    List parameterTypes;
+    private List parameterTypes;
 
     /** The return type of this object. */
-    Type returnType;
+    private Type returnType;
 
     /** True when some <code>SootClass</code> object declares this <code>SootMethod</code> object. */
-    boolean isDeclared;
+    private boolean isDeclared;
 
     /** Holds the class which declares this <code>SootClass</code> method. */
-    SootClass declaringClass;
+    private SootClass declaringClass;
 
     /** Modifiers associated with this SootMethod (e.g. private, protected, etc.) */
-    int modifiers;
+    private int modifiers;
 
     /** Is this method a phantom method? */
-    boolean isPhantom = false;
+    private boolean isPhantom = false;
 
     /** Declared exceptions thrown by this method.  Created upon demand. */
-    List<SootClass> exceptions = null;
+    private List<SootClass> exceptions = null;
 
     /** Active body associated with this method. */
-    Body activeBody;
+    private Body activeBody;
 
     /** Tells this method how to find out where its body lives. */
     protected MethodSource ms;


### PR DESCRIPTION
I stumbled on this bad encapsulation. There is no noticeable impact on performance to have those fields managed in an encapsulated manner rather than directly accessed.
