### PR TITLE
Fix for #120

### DIFF
--- a/src/soot/JavaClassProvider.java
+++ b/src/soot/JavaClassProvider.java
@@ -35,7 +35,7 @@ public class JavaClassProvider implements ClassProvider
 		private static final long serialVersionUID = 1L;
 
 		public JarException(String className) {
-			super("Class "+className+" was found in a .jar, but Polyglot doesn't support reading source files out of a .jar");
+			super("Class "+className+" was found in an archive, but Soot doesn't support reading source files out of an archive");
 		}
 		
 	}

--- a/src/soot/SourceLocator.java
+++ b/src/soot/SourceLocator.java
@@ -181,7 +181,6 @@ public class SourceLocator
 			List inputExtensions = new ArrayList(2);
 			inputExtensions.add(".class");
 			inputExtensions.add(".jimple");
-			inputExtensions.add(".java");
 
 			try {
 				ZipFile archive = new ZipFile(aPath);


### PR DESCRIPTION
Problem:
When a jar file contains both .class and .java files, the .java files
are picked up and given to the class loading algorithm to read. However,
the Java front-end cannot read from an archive and throws an exception.

The exception states that Polyglot isn't able to load the file, but
this can be confusing when the user is running Soot with Polyglot disabled.

Solution:
Ignore .java files in archives

Changes:
- Ignored .java files in archives in SourceLocator
- Improved the exception message in JavaClassProvider
