### PR TITLE
New option: mute-some-output

### DIFF
--- a/generated/options/soot/options/Options.java
+++ b/generated/options/soot/options/Options.java
@@ -949,7 +949,12 @@ public class Options extends OptionsBase {
             || option.equals( "subtract-gc" )
             )
                 subtract_gc = true;
-  
+
+            else if( false
+              || option.equals( "mute-some-output" )
+              )
+              mute_some_output = true;
+
             else {
                 G.v().out.println( "Invalid option -"+option );
                 return false;
@@ -1222,7 +1227,11 @@ public class Options extends OptionsBase {
     public boolean subtract_gc() { return subtract_gc; }
     private boolean subtract_gc = false;
     public void set_subtract_gc( boolean setting ) { subtract_gc = setting; }
-  
+
+    public boolean mute_some_output() { return mute_some_output; }
+    private boolean mute_some_output = false;
+    public void set_mute_some_output( boolean setting ) { mute_some_output = setting; }
+
 
     public String getUsage() {
         return ""
@@ -1326,7 +1335,8 @@ public class Options extends OptionsBase {
 +"\nMiscellaneous Options:\n"
       
 +padOpt(" -time", "Report time required for transformations" )
-+padOpt(" -subtract-gc", "Subtract gc from time" );
++padOpt(" -subtract-gc", "Subtract gc from time" )
++padOpt(" -mute-some-output", "Mutes from stdout the \'Warning! <class_name> is a phantom class!' warnings and 'Transforming/Decompiling <soot_class>...' messages." );
     }
 
 

--- a/src/soot/PackManager.java
+++ b/src/soot/PackManager.java
@@ -378,7 +378,7 @@ public class PackManager {
 
 
     public Collection<Pack> allPacks() {
-        return Collections.unmodifiableList( packList );
+        return Collections.unmodifiableList(packList);
     }
 
     public void runPacks() {
@@ -488,11 +488,11 @@ public class PackManager {
     }
 
     private ZipOutputStream jarFile = null;
-    
+
     public ZipOutputStream getJarFile() {
 		return jarFile;
 	}
-    
+
     public void writeOutput() {
         setupJAR();
         if(Options.v().verbose())
@@ -803,14 +803,17 @@ public class PackManager {
     private void runBodyPacks(SootClass c) {
         final int format = Options.v().output_format();
         if (format == Options.output_format_dava) {
+          if (!Options.v().mute_some_output())
             G.v().out.print("Decompiling ");
 
 	     //January 13th, 2006  SootMethodAddedByDava is set to false for SuperFirstStmtHandler
 	    G.v().SootMethodAddedByDava=false;
         } else {
+          if (!Options.v().mute_some_output())
             G.v().out.print("Transforming ");
         }
-        G.v().out.println(c.getName() + "... ");
+        if (!Options.v().mute_some_output())
+          G.v().out.println(c.getName() + "... ");
 
         boolean produceBaf = false, produceGrimp = false, produceDava = false,
             produceJimple = true, produceShimple = false;

--- a/src/soot/SootResolver.java
+++ b/src/soot/SootResolver.java
@@ -216,8 +216,8 @@ public class SootResolver
                 throw new SootClassNotFoundException("couldn't find class: " +
                     className + " (is your soot-class-path set properly?)"+suffix);
             } else {
-                G.v().out.println(
-                        "Warning: " + className + " is a phantom class!");
+              if (!Options.v().mute_some_output())
+                G.v().out.println("Warning: " + className + " is a phantom class!");
                 sc.setPhantomClass();
                 classToTypesSignature.put( sc, new ArrayList() );
                 classToTypesHierarchy.put( sc, new ArrayList() );

--- a/src/soot/coffi/Util.java
+++ b/src/soot/coffi/Util.java
@@ -33,6 +33,8 @@ package soot.coffi;
 import soot.jimple.*;
 import java.util.*;
 import java.io.*;
+
+import soot.options.Options;
 import soot.tagkit.*;
 import soot.*;
 
@@ -88,8 +90,9 @@ public class Util
                 {
                     if(!Scene.v().allowsPhantomRefs())
                         throw new RuntimeException("Could not load classfile: " + bclass.getName());
-                    else {                        
-                        G.v().out.println("Warning: " + className + " is a phantom class!");
+                    else {
+                        if (!Options.v().mute_some_output())
+                          G.v().out.println("Warning: " + className + " is a phantom class!");
                         bclass.setPhantom(true);                                                                
                         return;
                     } 


### PR DESCRIPTION
The fact Soot prints alotsa things to stdout by default is painful for elegant logging. I added some crude switch for muting some of the outputs (with printable usage and all). The switch could then be later become more powerful: the `G.out` `PrintStream` to which soot prints could have some logic filtering outputs depending on the muting. And you know what would be really awesome? using `slf4j` logging interface ;]
