### PR TITLE
Do not overwrite SourceFileTag with class name.

### DIFF
--- a/src/soot/CoffiClassSource.java
+++ b/src/soot/CoffiClassSource.java
@@ -68,8 +68,11 @@ public class CoffiClassSource extends ClassSource
             sc.addTag(tag);
         }
         
-        String name = zipFileName == null ? new File(fileName).getName() : new File(zipFileName).getName();
-        tag.setSourceFile(name); 
+        // Sets sourceFile only when it hasn't been set before
+        if (tag.getSourceFile() == null) {
+            String name = zipFileName == null ? new File(fileName).getName() : new File(zipFileName).getName();
+            tag.setSourceFile(name); 
+        }
     }
 }
 


### PR DESCRIPTION
Fix the problem of SourceFileTag generated from the SourceFile attribute of a class file being overwritten by the class name. Fix for bug #144.
