### PR TITLE
Fixes issue #155

### DIFF
--- a/src/soot/baf/internal/BTableSwitchInst.java
+++ b/src/soot/baf/internal/BTableSwitchInst.java
@@ -161,18 +161,17 @@ public class BTableSwitchInst extends AbstractInst implements TableSwitchInst
             
         buffer.append("{" + endOfLine);
         
+        // In this for-loop, we cannot use "<=" since 'i' would wrap around.
+        // The case for "i == highIndex" is handled separately after the loop.
         for(int i = lowIndex; i < highIndex; i++)
         {
-            buffer.append("    case " + i + ": goto " + 
-                getTarget(i - lowIndex) + ";" 
+            buffer.append("    case " + i + ": goto " +
+                getTarget(i - lowIndex) + ";"
                           + endOfLine);
         }
-        // in the for loop above, we cannot use "<=" since 'i' would wrap around
-        if (highIndex == Integer.MAX_VALUE) {
-        	buffer.append("    case " + highIndex + ": goto " + 
-                    getTarget(highIndex - lowIndex) + ";" 
-                              + endOfLine);
-        }
+        buffer.append("    case " + highIndex + ": goto " +
+                  getTarget(highIndex - lowIndex) + ";"
+                            + endOfLine);
 
         buffer.append("    default: goto " + getDefaultTarget() + ";" + endOfLine);
         buffer.append("}");
@@ -186,14 +185,13 @@ public class BTableSwitchInst extends AbstractInst implements TableSwitchInst
         up.literal("{");
         up.newline();
         
-        for(int i = lowIndex; i <= highIndex; i++)
+        // In this for-loop, we cannot use "<=" since 'i' would wrap around.
+        // The case for "i == highIndex" is handled separately after the loop.
+        for(int i = lowIndex; i < highIndex; i++)
         {
             printCaseTarget(up, i);
         }
-        // in the for loop above, we cannot use "<=" since 'i' would wrap around
-        if (highIndex == Integer.MAX_VALUE) {
-        	printCaseTarget(up, highIndex);
-        }
+        printCaseTarget(up, highIndex);
 
         up.literal("    default: goto ");
         defaultTargetBox.toString(up);

--- a/src/soot/jimple/internal/JTableSwitchStmt.java
+++ b/src/soot/jimple/internal/JTableSwitchStmt.java
@@ -128,18 +128,17 @@ public class JTableSwitchStmt extends AbstractStmt
             
         buffer.append("{" + endOfLine);
         
+        // In this for-loop, we cannot use "<=" since 'i' would wrap around.
+        // The case for "i == highIndex" is handled separately after the loop.
         for(int i = lowIndex; i < highIndex; i++)
         {
             buffer.append(
-                          "    " + Jimple.CASE + " " + i + ": " + Jimple.GOTO + 
+                          "    " + Jimple.CASE + " " + i + ": " + Jimple.GOTO +
                           " " + getTarget(i - lowIndex) + ";" + endOfLine);
         }
-        // in the for loop above, we cannot use "<=" since 'i' would wrap around
-        if (highIndex == Integer.MAX_VALUE) {
-        	buffer.append(
-                    "    " + Jimple.CASE + " " + highIndex + ": " + Jimple.GOTO + 
-                    " " + getTarget(highIndex - lowIndex) + ";" + endOfLine);
-        }
+        buffer.append(
+                  "    " + Jimple.CASE + " " + highIndex + ": " + Jimple.GOTO +
+                  " " + getTarget(highIndex - lowIndex) + ";" + endOfLine);
 
         buffer.append("    " +  Jimple.DEFAULT + 
                       ": " +  Jimple.GOTO + " " 
@@ -159,14 +158,13 @@ public class JTableSwitchStmt extends AbstractStmt
         up.newline();
         up.literal("{");
         up.newline();
+        // In this for-loop, we cannot use "<=" since 'i' would wrap around.
+        // The case for "i == highIndex" is handled separately after the loop.
         for(int i = lowIndex; i < highIndex; i++) {
             printCaseTarget(up, i);
         }
-        // in the for loop above, we cannot use "<=" since 'i' would wrap around
-        if (highIndex == Integer.MAX_VALUE) {
-        	printCaseTarget(up, highIndex);
-        }
-        
+        printCaseTarget(up, highIndex);
+
         up.literal("    ");
         up.literal(Jimple.DEFAULT);
         up.literal(": ");


### PR DESCRIPTION
This is a fix for issue #155.

Due to this bug, the generated Baf and Jimple code would miss the last
non-default case in a tableswitch code structure. It does not affect
generated bytecode, so it is not easily triggered.
