### PR TITLE
EquivalentValue: Remove getDeepestValue().

### DIFF
--- a/src/soot/EquivalentValue.java
+++ b/src/soot/EquivalentValue.java
@@ -62,6 +62,14 @@ public class EquivalentValue implements Value {
     public boolean equalsToValue(Value v) {
       return e.equals(v);
     }
+    
+    /**
+     * @deprecated
+     * @see #getValue()
+     **/
+    public Value getDeepestValue() {
+    	return getValue();
+    }
 
     public int hashCode() { return e.equivHashCode(); }
     public String toString() { return e.toString(); }


### PR DESCRIPTION
Add check at constructor so that we never get EquivalentValue inside.
This renders (original buggy) getDeepestValue() obsolete. Since there's no code referencing getDeepestValue() inside soot, I just removed the method.
