### PR TITLE
Unexpected copypropagation behaviour

### DIFF
--- a/src/soot/jimple/toolkits/scalar/CopyPropagator.java
+++ b/src/soot/jimple/toolkits/scalar/CopyPropagator.java
@@ -150,10 +150,14 @@ public class CopyPropagator extends BodyTransformer
                         {
                             DefinitionStmt def = (DefinitionStmt) defsOfUse.get(0);
 
-                            if (def.getRightOp() instanceof Constant)
-                            	if (useBox.canContainValue(def.getRightOp()))
+                            if (def.getRightOp() instanceof Constant) {
+                            	if (useBox.canContainValue(def.getRightOp())) {
                             		useBox.setValue(def.getRightOp());
-                            else if(def.getRightOp() instanceof Local)
+                            	}
+                            	continue;
+                            }
+                            
+                            if(def.getRightOp() instanceof Local)
                             {
                                 Local m = (Local) def.getRightOp();
 


### PR DESCRIPTION
the cp didn't propagte locals in situations like this:

...
a=b;
a.xyz();
...
