### PR TITLE
Corrected github project references in soot.psf

### DIFF
--- a/soot.psf
+++ b/soot.psf
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <psf version="2.0">
 <provider id="org.eclipse.egit.core.GitProvider">
-<project reference="1.0,https://github.com/Sable/heros,develop,."/>
-<project reference="1.0,https://github.com/Sable/jasmin,develop,."/>
-<project reference="1.0,https://github.com/Sable/soot,develop,."/>
+<project reference="1.0,https://github.com/Sable/heros.git,develop,."/>
+<project reference="1.0,https://github.com/Sable/jasmin.git,develop,."/>
+<project reference="1.0,https://github.com/Sable/soot.git,develop,."/>
 </provider>
 </psf>


### PR DESCRIPTION
The 3 project references each require the .git extension in order to correctly clone in Eclipse.

I realize that this change was proposed in commit bdfe4b821f88573a8a648959dd4b151d3c0586b2#diff-74b85ebf26a995c954fafc9be51c3d21 and reverted in commit dbf186901610d68ea9c84b56dc3180fc529d09a0. However, the comments on the revert refer to test case problems introduced by changes to other files, not this file. These corrections are needed in order to check out soot into Eclipse as referenced in this page: https://github.com/Sable/soot/wiki/Building-Soot-with-Eclipse
