### PR TITLE
Makes dava to print ClassConst as pkg.ClassName.class

### DIFF
--- a/src/soot/dava/DavaUnitPrinter.java
+++ b/src/soot/dava/DavaUnitPrinter.java
@@ -107,10 +107,15 @@ public class DavaUnitPrinter extends AbstractUnitPrinter {
         throw new RuntimeException( "Dava doesn't have unit references!" );
     }
 
-
-
-
-
+    @Override
+    public void constant( Constant c ) {
+        if (c instanceof ClassConstant) {
+            handleIndent();
+            output.append(((ClassConstant)c).value + ".class");
+        } else {
+          super.constant(c);
+        }
+    }
 
     public void addNot() {
         output.append(" !");


### PR DESCRIPTION
Right now, it uses the same format as in Jimple:
  class "pkg.ClassName"
which makes the generated .java code uncompilable.

Here's a test case.

ClassConst.java:

public class ClassConst {
  public static void main(String[] args) {
    print(ClassConst.class);
  }

  static void print(Class c) {
    System.out.println(c);
  }
}

Run "soot -f d ClassConst" and look at sootOutput/ClassConst.java. The line print(ClassConst.class); will become print(class "ClassConst"); --- not compilable!
