### PR TITLE
Update BlockGraphConverter.java

### DIFF
--- a/src/soot/toolkits/graph/BlockGraphConverter.java
+++ b/src/soot/toolkits/graph/BlockGraphConverter.java
@@ -194,6 +194,6 @@ class DummyBlock extends Block
 
     public Iterator<Unit> iterator()
     {
-        return Collections.emptyListIterator();
+        return (Collections.<Unit>emptyList()).iterator();
     }
 }


### PR DESCRIPTION
The old line 197:
return Collections.emptyListIterator();
returns a syntax error on my machine. Changed it to:
return (Collections.<Unit>emptyList()).iterator();
