### PR TITLE
Do not print method bodies for inherited methods in Dex Printer

### DIFF
--- a/src/soot/toDex/DexPrinter.java
+++ b/src/soot/toDex/DexPrinter.java
@@ -741,6 +741,11 @@ public class DexPrinter {
 
         List<BuilderMethod> methods = new ArrayList<BuilderMethod>();
         for (SootMethod sm : clazz.getMethods()) {
+            if (sm.isPhantom()) {
+                // Do not print method bodies for inherited methods
+                continue;
+            }
+
         	MethodImplementation impl = toMethodImplementation(sm);
         	
         	List<String> parameterNames = null;


### PR DESCRIPTION
The Dex printer in soot incorrectly attempts to get and print a phantom method body in certain circumstances, resulting in a RuntimeException. A soot class that inherits from an Android base class can legitimately reference a method implemented in that Android class that is not implemented in the soot class. Soot represents this as a phantom method in the soot class, and this method should not be printed. This change fixes this bug.

For example, in the android.support.v7 library, a AdapterViewICS extends ViewGroup extends View. Later on, there's a call to the method onRestoreInstanceState(), implemented in the View class. The onRestoreInstanceState() method is not part of AdapterViewICS and should not be printed.

https://android.googlesource.com/platform/frameworks/support/+/jb-mr2-release/v7/appcompat/src/android/support/v7/internal/widget/AdapterViewICS.java#810
