### PR TITLE
Add missing singletons to Global Singleton class

### DIFF
--- a/generated/singletons/soot/Singletons.java
+++ b/generated/singletons/soot/Singletons.java
@@ -923,4 +923,28 @@ public class Singletons {
         return instance_soot_toDex_FastDexTrapTightener;
     }
 
+    private soot.jimple.toolkits.typing.fast.Integer127Type instance_soot_jimple_toolkits_typing_fast_Integer127Type;
+    public soot.jimple.toolkits.typing.fast.Integer127Type soot_jimple_toolkits_typing_fast_Integer127Type() {
+        if( instance_soot_jimple_toolkits_typing_fast_Integer127Type == null ) instance_soot_jimple_toolkits_typing_fast_Integer127Type = new soot.jimple.toolkits.typing.fast.Integer127Type( g );
+        return instance_soot_jimple_toolkits_typing_fast_Integer127Type;
+    }
+
+    private soot.jimple.toolkits.typing.fast.Integer1Type instance_soot_jimple_toolkits_typing_fast_Integer1Type;
+    public soot.jimple.toolkits.typing.fast.Integer1Type soot_jimple_toolkits_typing_fast_Integer1Type() {
+        if( instance_soot_jimple_toolkits_typing_fast_Integer1Type == null ) instance_soot_jimple_toolkits_typing_fast_Integer1Type = new soot.jimple.toolkits.typing.fast.Integer1Type( g );
+        return instance_soot_jimple_toolkits_typing_fast_Integer1Type;
+    }
+
+    private soot.jimple.toolkits.typing.fast.Integer32767Type instance_soot_jimple_toolkits_typing_fast_Integer32767Type;
+    public soot.jimple.toolkits.typing.fast.Integer32767Type soot_jimple_toolkits_typing_fast_Integer32767Type() {
+        if( instance_soot_jimple_toolkits_typing_fast_Integer32767Type == null ) instance_soot_jimple_toolkits_typing_fast_Integer32767Type = new soot.jimple.toolkits.typing.fast.Integer32767Type( g );
+        return instance_soot_jimple_toolkits_typing_fast_Integer32767Type;
+    }
+
+    private soot.jimple.toolkits.typing.fast.BottomType instance_soot_jimple_toolkits_typing_fast_BottomType;
+    public soot.jimple.toolkits.typing.fast.BottomType soot_jimple_toolkits_typing_fast_BottomType() {
+        if( instance_soot_jimple_toolkits_typing_fast_BottomType == null ) instance_soot_jimple_toolkits_typing_fast_BottomType = new soot.jimple.toolkits.typing.fast.BottomType( g );
+        return instance_soot_jimple_toolkits_typing_fast_BottomType;
+    }
+
 }

--- a/src/singletons.xml
+++ b/src/singletons.xml
@@ -149,4 +149,8 @@
   <class>soot.toDex.SynchronizedMethodTransformer</class>
   <class>soot.toDex.TrapSplitter</class>
   <class>soot.toDex.FastDexTrapTightener</class>
+  <class>soot.jimple.toolkits.typing.fast.Integer127Type</class>
+  <class>soot.jimple.toolkits.typing.fast.Integer1Type</class>
+  <class>soot.jimple.toolkits.typing.fast.Integer32767Type</class>
+  <class>soot.jimple.toolkits.typing.fast.BottomType</class>
 </singletons>

--- a/src/soot/jimple/toolkits/typing/fast/BottomType.java
+++ b/src/soot/jimple/toolkits/typing/fast/BottomType.java
@@ -20,19 +20,27 @@
  */
 package soot.jimple.toolkits.typing.fast;
 
-import soot.*;
+import soot.G;
+import soot.Singletons;
+import soot.Type;
 
 /**
  * @author Ben Bellamy
  */
-public class BottomType extends Type
-{
-	private final static BottomType instance = new BottomType();
-	
-	public static BottomType v() { return instance; }
-	
-	private BottomType() { }
-	
-	public String toString() { return "bottom_type"; }
-	public boolean equals(Object t) { return this == t; }
+public class BottomType extends Type {
+
+    public static BottomType v() {
+        return G.v().soot_jimple_toolkits_typing_fast_BottomType();
+    }
+
+    public BottomType(Singletons.Global g) {
+    }
+
+    public String toString() {
+        return "bottom_type";
+    }
+
+    public boolean equals(Object t) {
+        return this == t;
+    }
 }

--- a/src/soot/jimple/toolkits/typing/fast/Integer127Type.java
+++ b/src/soot/jimple/toolkits/typing/fast/Integer127Type.java
@@ -25,19 +25,25 @@ import soot.*;
 /**
  * @author Ben Bellamy
  */
-public class Integer127Type extends PrimType implements IntegerType
-{
-	private final static Integer127Type instance = new Integer127Type();
-	
-	public static Integer127Type v() { return instance; }
-	
-	private Integer127Type() { }
-	
-	public String toString() { return "[0..127]"; }
-	public boolean equals(Object t) { return this == t; }
+public class Integer127Type extends PrimType implements IntegerType {
+
+    public static Integer127Type v() {
+        return G.v().soot_jimple_toolkits_typing_fast_Integer127Type();
+    }
+
+    public Integer127Type(Singletons.Global g) {
+    }
+
+    public String toString() {
+        return "[0..127]";
+    }
+
+    public boolean equals(Object t) {
+        return this == t;
+    }
 
     @Override
     public RefType boxedType() {
-    	return RefType.v("java.lang.Integer");
+        return RefType.v("java.lang.Integer");
     }
 }

--- a/src/soot/jimple/toolkits/typing/fast/Integer1Type.java
+++ b/src/soot/jimple/toolkits/typing/fast/Integer1Type.java
@@ -25,19 +25,25 @@ import soot.*;
 /**
  * @author Ben Bellamy
  */
-public class Integer1Type extends PrimType implements IntegerType
-{
-	private final static Integer1Type instance = new Integer1Type();
-	
-	public static Integer1Type v() { return instance; }
-	
-	private Integer1Type() { }
-	
-	public String toString() { return "[0..1]"; }
-	public boolean equals(Object t) { return this == t; }
+public class Integer1Type extends PrimType implements IntegerType {
+
+    public static Integer1Type v() {
+        return G.v().soot_jimple_toolkits_typing_fast_Integer1Type();
+    }
+
+    public Integer1Type(Singletons.Global g) {
+    }
+
+    public String toString() {
+        return "[0..1]";
+    }
+
+    public boolean equals(Object t) {
+        return this == t;
+    }
 
     @Override
     public RefType boxedType() {
-    	return RefType.v("java.lang.Integer");
+        return RefType.v("java.lang.Integer");
     }
 }

--- a/src/soot/jimple/toolkits/typing/fast/Integer32767Type.java
+++ b/src/soot/jimple/toolkits/typing/fast/Integer32767Type.java
@@ -25,19 +25,26 @@ import soot.*;
 /**
  * @author Ben Bellamy
  */
-public class Integer32767Type extends PrimType implements IntegerType
-{
-	private final static Integer32767Type instance = new Integer32767Type();
-	
-	public static Integer32767Type v() { return instance; }
-	
-	private Integer32767Type() { }
-	
-	public String toString() { return "[0..32767]"; }
-	public boolean equals(Object t) { return this == t; }
+public class Integer32767Type extends PrimType implements IntegerType {
+
+
+    public static Integer32767Type v() {
+        return G.v().soot_jimple_toolkits_typing_fast_Integer32767Type();
+    }
+
+    public Integer32767Type(Singletons.Global g) {
+    }
+
+    public String toString() {
+        return "[0..32767]";
+    }
+
+    public boolean equals(Object t) {
+        return this == t;
+    }
 
     @Override
     public RefType boxedType() {
-    	return RefType.v("java.lang.Integer");
+        return RefType.v("java.lang.Integer");
     }
 }


### PR DESCRIPTION
- Add Integer{127,1,32767}Type and Bottom Type from soot.jimple.toolkits.typing.fast to singletons.xml
- Generate new Singletons
- Modify Types accordingly

If soot is run several times in one instance of the JVM, these 4 Types are not added to the Global TypeNumberer after the first call to G.reset().
The general constructor of Type handles this, but since these objects do not need to be recreated that constructor will not be called.
