### PR TITLE
Fixes a bug regarding commit 2a6ddca3adb80fc1b026ae116e584b2b5fa7a9f1.

### DIFF
--- a/src/soot/toolkits/scalar/ConstantValueToInitializerTransformer.java
+++ b/src/soot/toolkits/scalar/ConstantValueToInitializerTransformer.java
@@ -102,7 +102,7 @@ public class ConstantValueToInitializerTransformer extends SceneTransformer {
 				if (initStmt != null) {
 					if (smInit == null)
 						smInit = getOrCreateInitializer(sc, alreadyInitialized);
-					smInit.getActiveBody().getUnits().add(initStmt);
+					smInit.getActiveBody().getUnits().addFirst(initStmt);
 				}
 			}
 		}


### PR DESCRIPTION
Now, dalvik constants get initializers in clinit. However, soot could
generate code like

public void <clinit>() {
  Initializes some stuff
  return;
  < a.a: int b> = 2;  //This line is created by
ConstantValueToInitializerTransformer
  return;  //This line is created by
ConstantValueToInitializerTransformer
}

After this fix:

public void <clinit>() {
  < a.a: int b> = 2;  //This line is created by
ConstantValueToInitializerTransformer
  Initializes some stuff
  return;
}
