### PR TITLE
Fix for dandling classes incorrectly considered as non-interfaces.

### DIFF
--- a/src/soot/SootClass.java
+++ b/src/soot/SootClass.java
@@ -126,18 +126,35 @@ public class SootClass extends AbstractHost implements Numberable
             default: throw new RuntimeException("unknown resolving level");
         }
     }
+
+  /**
+   * Checks if the class has at lease the resolving level specified.
+   * This check does nothing is the class resolution process is not completed.
+   * @param level the resolution level, one of DANGLING, HIERARCHY, SIGNATURES, and BODIES
+   * @throws java.lang.RuntimeException if the resolution is at an insufficient level
+   */
     public void checkLevel( int level ) {
         if( !Scene.v().doneResolving() ) return;
-        if( resolvingLevel < level ) {
-        	String hint = "\nIf you are extending Soot, try to add the following call before calling soot.Main.main(..):\n" +
-        			      "Scene.v().addBasicClass("+getName()+","+levelToString(level)+");\n" +
-        			      "Otherwise, try whole-program mode (-w).";
-            throw new RuntimeException(
-                "This operation requires resolving level "+
-                levelToString(level)+" but "+name+
-                " is at resolving level "+levelToString(resolvingLevel) + hint);
-        }
+      checkLevelIgnoreResolving(level);
     }
+
+  /**
+   * Checks if the class has at lease the resolving level specified.
+   * This check ignores the resolution completeness.
+   * @param level the resolution level, one of DANGLING, HIERARCHY, SIGNATURES, and BODIES
+   * @throws java.lang.RuntimeException if the resolution is at an insufficient level
+   */
+  public void checkLevelIgnoreResolving( int level ) {
+    if( resolvingLevel < level ) {
+      String hint = "\nIf you are extending Soot, try to add the following call before calling soot.Main.main(..):\n" +
+              "Scene.v().addBasicClass("+getName()+","+levelToString(level)+");\n" +
+              "Otherwise, try whole-program mode (-w).";
+      throw new RuntimeException(
+              "This operation requires resolving level "+
+                      levelToString(level)+" but "+name+
+                      " is at resolving level "+levelToString(resolvingLevel) + hint);
+    }
+  }
 
     public int resolvingLevel() { return resolvingLevel; }
     public void setResolvingLevel( int newLevel ) {

--- a/src/soot/jimple/internal/JInterfaceInvokeExpr.java
+++ b/src/soot/jimple/internal/JInterfaceInvokeExpr.java
@@ -42,6 +42,10 @@ public class JInterfaceInvokeExpr extends AbstractInterfaceInvokeExpr
     {
         super(Jimple.v().newLocalBox(base), methodRef, new ValueBox[args.size()]);
 
+        //Check that the method's class is resolved enough
+        //CheckLevel returns without doing anything because we can be not 'done' resolving
+        methodRef.declaringClass().checkLevelIgnoreResolving(SootClass.HIERARCHY);
+        //now check if the class is valid
         if(!methodRef.declaringClass().isInterface() && !methodRef.declaringClass().isPhantom()) {
         	throw new RuntimeException("Trying to create interface invoke expression for non-interface type: " +
         			methodRef.declaringClass() +

--- a/src/soot/jimple/internal/JVirtualInvokeExpr.java
+++ b/src/soot/jimple/internal/JVirtualInvokeExpr.java
@@ -39,6 +39,9 @@ public class JVirtualInvokeExpr extends AbstractVirtualInvokeExpr
     {
         super(Jimple.v().newLocalBox(base), methodRef, new ValueBox[args.size()]);
 
+        //Check that the method's class is resolved enough
+        methodRef.declaringClass().checkLevelIgnoreResolving(SootClass.HIERARCHY);
+        //now check if the class is valid
         if(methodRef.declaringClass().isInterface()) {
             SootClass sc = methodRef.declaringClass();
             String path = sc.hasTag("SourceFileTag")? ((SourceFileTag)sc.getTag("SourceFileTag")).getAbsolutePath() : "uknown";


### PR DESCRIPTION
Now it gives an exception telling the user what is the root cause of the problem. The user can then ensure its loading.
