### PR TITLE
Test struct. equivalence in equivTo of JimpleLocal

### DIFF
--- a/src/main/java/soot/jimple/internal/JimpleLocal.java
+++ b/src/main/java/soot/jimple/internal/JimpleLocal.java
@@ -56,7 +56,9 @@ public class JimpleLocal implements Local, ConvertToBaf {
   /** Returns true if the given object is structurally equal to this one. */
   @Override
   public boolean equivTo(Object o) {
-    if (!(o instanceof JimpleLocal)) return false;
+    if (!(o instanceof JimpleLocal)) {
+      return false;
+    }
 
     JimpleLocal that = (JimpleLocal) o;
     return Objects.equals(this.type, that.type);

--- a/src/main/java/soot/jimple/internal/JimpleLocal.java
+++ b/src/main/java/soot/jimple/internal/JimpleLocal.java
@@ -24,6 +24,7 @@ package soot.jimple.internal;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import soot.Local;
 import soot.Scene;
@@ -55,7 +56,10 @@ public class JimpleLocal implements Local, ConvertToBaf {
   /** Returns true if the given object is structurally equal to this one. */
   @Override
   public boolean equivTo(Object o) {
-    return this.equals(o);
+    if (!(o instanceof JimpleLocal)) return false;
+
+    JimpleLocal that = (JimpleLocal) o;
+    return Objects.equals(this.type, that.type);
   }
 
   /**
@@ -64,10 +68,7 @@ public class JimpleLocal implements Local, ConvertToBaf {
   @Override
   public int equivHashCode() {
     final int prime = 31;
-    int result = 1;
-    result = prime * result + ((name == null) ? 0 : name.hashCode());
-    result = prime * result + ((type == null) ? 0 : type.hashCode());
-    return result;
+    return prime + ((type == null) ? 0 : type.hashCode());
   }
 
   /** Returns a clone of the current JimpleLocal. */


### PR DESCRIPTION
The JimpleLocal class has an `equivTo` and an `equivHashCode` method. Both claim to test for structural equality (as described in their Javadocs). However, as mentioned in #953, this is not actually the case. This change replaces the referential equality check with a type equality check.

Closes #953.