### PR TITLE
Set the Method is Phantom while instructions is null

### DIFF
--- a/src/main/java/soot/asm/MethodBuilder.java
+++ b/src/main/java/soot/asm/MethodBuilder.java
@@ -252,11 +252,14 @@ class MethodBuilder extends JSRInlinerAdapter {
       }
       method.addTag(tag);
     }
-    if (instructions == null || instructions.size() == 0) {
-      method.setPhantom(true);
-    } else if (method.isConcrete()) {
-      method.setSource(
-          new AsmMethodSource(maxLocals, instructions, localVariables, tryCatchBlocks, scb.getKlass().moduleName));
+
+    if (method.isConcrete()) {
+      if (instructions == null || instructions.size() == 0) {
+        method.setPhantom(true);
+      } else {
+        method.setSource(
+            new AsmMethodSource(maxLocals, instructions, localVariables, tryCatchBlocks, scb.getKlass().moduleName));
+      }
     }
   }
 }

--- a/src/main/java/soot/asm/MethodBuilder.java
+++ b/src/main/java/soot/asm/MethodBuilder.java
@@ -43,8 +43,8 @@ import soot.tagkit.AnnotationConstants;
 import soot.tagkit.AnnotationDefaultTag;
 import soot.tagkit.AnnotationTag;
 import soot.tagkit.VisibilityAnnotationTag;
-import soot.tagkit.VisibilityParameterAnnotationTag;
 import soot.tagkit.VisibilityLocalVariableAnnotationTag;
+import soot.tagkit.VisibilityParameterAnnotationTag;
 
 /**
  * Soot method builder.
@@ -96,30 +96,30 @@ class MethodBuilder extends JSRInlinerAdapter {
   }
 
   @Override
-  public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef, final TypePath typePath,
-			final Label[] start, final Label[] end, final int[] index, final String descriptor, final boolean visible) {
-	final VisibilityAnnotationTag vat = new VisibilityAnnotationTag(
-					visible ? AnnotationConstants.RUNTIME_VISIBLE : AnnotationConstants.RUNTIME_INVISIBLE);
-	if (visible) {
-		if (visibleLocalVarAnnotations == null) {
-			visibleLocalVarAnnotations = new ArrayList<VisibilityAnnotationTag>(2);
-		}
-		visibleLocalVarAnnotations.add(vat);
-	} else {
-		if (invisibleLocalVarAnnotations == null) {
-			invisibleLocalVarAnnotations = new ArrayList<VisibilityAnnotationTag>(2);
-		}
-		invisibleLocalVarAnnotations.add(vat);
-	}
-	return new AnnotationElemBuilder() {
-		@Override
-		public void visitEnd() {
-			AnnotationTag annotTag = new AnnotationTag(desc, elems);
-			vat.addAnnotation(annotTag);
-		}
-	};
+  public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef, final TypePath typePath, final Label[] start,
+      final Label[] end, final int[] index, final String descriptor, final boolean visible) {
+    final VisibilityAnnotationTag vat
+        = new VisibilityAnnotationTag(visible ? AnnotationConstants.RUNTIME_VISIBLE : AnnotationConstants.RUNTIME_INVISIBLE);
+    if (visible) {
+      if (visibleLocalVarAnnotations == null) {
+        visibleLocalVarAnnotations = new ArrayList<VisibilityAnnotationTag>(2);
+      }
+      visibleLocalVarAnnotations.add(vat);
+    } else {
+      if (invisibleLocalVarAnnotations == null) {
+        invisibleLocalVarAnnotations = new ArrayList<VisibilityAnnotationTag>(2);
+      }
+      invisibleLocalVarAnnotations.add(vat);
+    }
+    return new AnnotationElemBuilder() {
+      @Override
+      public void visitEnd() {
+        AnnotationTag annotTag = new AnnotationTag(desc, elems);
+        vat.addAnnotation(annotTag);
+      }
+    };
   }
-  
+
   @Override
   public AnnotationVisitor visitParameterAnnotation(int parameter, final String desc, boolean visible) {
     VisibilityAnnotationTag vat;
@@ -236,22 +236,22 @@ class MethodBuilder extends JSRInlinerAdapter {
       }
       method.addTag(tag);
     }
-    if (visibleLocalVarAnnotations != null) { 
-        VisibilityLocalVariableAnnotationTag tag 
-            = new VisibilityLocalVariableAnnotationTag(visibleLocalVarAnnotations.size(), AnnotationConstants.RUNTIME_VISIBLE);
-  	  for (VisibilityAnnotationTag vat : visibleLocalVarAnnotations) {
-  			tag.addVisibilityAnnotation(vat);
-  	  }
-  	  method.addTag(tag);
-  	}
-  	if (invisibleLocalVarAnnotations != null) {
-  	  VisibilityLocalVariableAnnotationTag tag 
-  	      = new VisibilityLocalVariableAnnotationTag(visibleLocalVarAnnotations.size(), AnnotationConstants.RUNTIME_INVISIBLE);
-  	  for (VisibilityAnnotationTag vat : invisibleLocalVarAnnotations) {
-  			tag.addVisibilityAnnotation(vat);
-  	  }
-  	  method.addTag(tag);
-  	}
+    if (visibleLocalVarAnnotations != null) {
+      VisibilityLocalVariableAnnotationTag tag
+          = new VisibilityLocalVariableAnnotationTag(visibleLocalVarAnnotations.size(), AnnotationConstants.RUNTIME_VISIBLE);
+      for (VisibilityAnnotationTag vat : visibleLocalVarAnnotations) {
+        tag.addVisibilityAnnotation(vat);
+      }
+      method.addTag(tag);
+    }
+    if (invisibleLocalVarAnnotations != null) {
+      VisibilityLocalVariableAnnotationTag tag = new VisibilityLocalVariableAnnotationTag(visibleLocalVarAnnotations.size(),
+          AnnotationConstants.RUNTIME_INVISIBLE);
+      for (VisibilityAnnotationTag vat : invisibleLocalVarAnnotations) {
+        tag.addVisibilityAnnotation(vat);
+      }
+      method.addTag(tag);
+    }
     if (method.isConcrete()) {
       method.setSource(
           new AsmMethodSource(maxLocals, instructions, localVariables, tryCatchBlocks, scb.getKlass().moduleName));

--- a/src/main/java/soot/asm/MethodBuilder.java
+++ b/src/main/java/soot/asm/MethodBuilder.java
@@ -252,7 +252,9 @@ class MethodBuilder extends JSRInlinerAdapter {
       }
       method.addTag(tag);
     }
-    if (method.isConcrete()) {
+    if (instructions == null || instructions.size() == 0) {
+      method.setPhantom(true);
+    } else if (method.isConcrete()) {
       method.setSource(
           new AsmMethodSource(maxLocals, instructions, localVariables, tryCatchBlocks, scb.getKlass().moduleName));
     }

--- a/src/main/java/soot/asm/SootClassBuilder.java
+++ b/src/main/java/soot/asm/SootClassBuilder.java
@@ -276,6 +276,7 @@ public class SootClassBuilder extends ClassVisitor {
   @Override
   public void visitEnd() {
     super.visitEnd();
+    // Only one class contain methods and all methods is phantom, set the phantom class.
     boolean isPhantom = false;
     for (SootMethod m : klass.getMethods()) {
       if (!m.isPhantom()) {
@@ -287,7 +288,6 @@ public class SootClassBuilder extends ClassVisitor {
       }
     }
     if (isPhantom) {
-      System.out.println("Set the phantom class"+klass.getName());
       klass.setPhantomClass();
     }
   }

--- a/src/main/java/soot/asm/SootClassBuilder.java
+++ b/src/main/java/soot/asm/SootClassBuilder.java
@@ -273,4 +273,22 @@ public class SootClassBuilder extends ClassVisitor {
     return RefType.v(className);
   }
 
+  @Override
+  public void visitEnd() {
+    super.visitEnd();
+    boolean isPhantom = false;
+    for (SootMethod m : klass.getMethods()) {
+      if (!m.isPhantom()) {
+        isPhantom = false;
+        break;
+      } else {
+        isPhantom = true;
+        continue;
+      }
+    }
+    if (isPhantom) {
+      System.out.println("Set the phantom class"+klass.getName());
+      klass.setPhantomClass();
+    }
+  }
 }

--- a/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
@@ -1,4 +1,5 @@
 package soot.tagkit;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -21,62 +22,61 @@ package soot.tagkit;
  * #L%
  */
 /**
- * Represents the visibility of an annotation attribute attached to method local variable.
- * Only mark the local variable tag different with{@link soot.tagkit.VisibilityParameterAnnotationTag}
+ * Represents the visibility of an annotation attribute attached to method local variable. Only mark the local variable tag
+ * different with{@link soot.tagkit.VisibilityParameterAnnotationTag}
  * 
  * @author raintung.li
  *
  */
 
 public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnnotationTag {
-	
-	public VisibilityLocalVariableAnnotationTag(int num, int kind) {
-		super(num, kind);
-	}
 
-	// should also print here number of annotations and perhaps the annotations themselves
-	public String toString() {
-		int num_var = getVisibilityAnnotations()!=null ? getVisibilityAnnotations().size(): 0;
-		StringBuffer sb = new StringBuffer(
-				"Visibility LocalVariable Annotation: num Annotation: " + num_var + " kind: " + getKind());
-		if (num_var > 0) {
-			for (VisibilityAnnotationTag tag : getVisibilityAnnotations()) {
-				sb.append("\n");
-				if (tag != null) {
-					sb.append(tag.toString());
-				}
-			}
-		}
-		sb.append("\n");
-		return sb.toString();
-	}
-	
+  public VisibilityLocalVariableAnnotationTag(int num, int kind) {
+    super(num, kind);
+  }
 
-	/**
-	 * Returns Local Variable tag name
-	 * 
-	 * @return string
-	 */
-	public String getName() {
-		return "VisibilityLocalVariableAnnotationTag";
-	}
-	
-	/**
-	 * Returns Local Variable tag info
-	 * 
-	 * @return string
-	 */
-	public String getInfo() {
-		return "VisibilityLocalVariableAnnotation";
-	}
-	
-	/**
-	 * VisibilityLocalVariableAnnotationTag not support
-	 * 
-	 * @return 
-	 */
-	public byte[] getValue() {
-		throw new RuntimeException("VisibilityLocalVariableAnnotationTag has no value for bytecode");
-	}
+  // should also print here number of annotations and perhaps the annotations themselves
+  public String toString() {
+    int num_var = getVisibilityAnnotations() != null ? getVisibilityAnnotations().size() : 0;
+    StringBuffer sb
+        = new StringBuffer("Visibility LocalVariable Annotation: num Annotation: " + num_var + " kind: " + getKind());
+    if (num_var > 0) {
+      for (VisibilityAnnotationTag tag : getVisibilityAnnotations()) {
+        sb.append("\n");
+        if (tag != null) {
+          sb.append(tag.toString());
+        }
+      }
+    }
+    sb.append("\n");
+    return sb.toString();
+  }
+
+  /**
+   * Returns Local Variable tag name
+   * 
+   * @return string
+   */
+  public String getName() {
+    return "VisibilityLocalVariableAnnotationTag";
+  }
+
+  /**
+   * Returns Local Variable tag info
+   * 
+   * @return string
+   */
+  public String getInfo() {
+    return "VisibilityLocalVariableAnnotation";
+  }
+
+  /**
+   * VisibilityLocalVariableAnnotationTag not support
+   * 
+   * @return
+   */
+  public byte[] getValue() {
+    throw new RuntimeException("VisibilityLocalVariableAnnotationTag has no value for bytecode");
+  }
 
 }

--- a/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
@@ -1,0 +1,82 @@
+package soot.tagkit;
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2005 Jennifer Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+/**
+ * Represents the visibility of an annotation attribute attached to method local variable.
+ * Only mark the local variable tag different with{@link soot.tagkit.VisibilityParameterAnnotationTag}
+ * 
+ * @author raintung.li
+ *
+ */
+
+public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnnotationTag {
+	
+	public VisibilityLocalVariableAnnotationTag(int num, int kind) {
+		super(num, kind);
+	}
+
+	// should also print here number of annotations and perhaps the annotations themselves
+	public String toString() {
+		int num_var = getVisibilityAnnotations()!=null ? getVisibilityAnnotations().size(): 0;
+		StringBuffer sb = new StringBuffer(
+				"Visibility LocalVariable Annotation: num Annotation: " + num_var + " kind: " + getKind());
+		if (num_var > 0) {
+			for (VisibilityAnnotationTag tag : getVisibilityAnnotations()) {
+				sb.append("\n");
+				if (tag != null) {
+					sb.append(tag.toString());
+				}
+			}
+		}
+		sb.append("\n");
+		return sb.toString();
+	}
+	
+
+	/**
+	 * Returns Local Variable tag name
+	 * 
+	 * @return string
+	 */
+	public String getName() {
+		return "VisibilityLocalVariableAnnotationTag";
+	}
+	
+	/**
+	 * Returns Local Variable tag info
+	 * 
+	 * @return string
+	 */
+	public String getInfo() {
+		return "VisibilityLocalVariableAnnotation";
+	}
+	
+	/**
+	 * VisibilityLocalVariableAnnotationTag not support
+	 * 
+	 * @return 
+	 */
+	public byte[] getValue() {
+		throw new RuntimeException("VisibilityLocalVariableAnnotationTag has no value for bytecode");
+	}
+
+}


### PR DESCRIPTION
Some classes's method instructions is empty, set the method is phantom status. Otherwise call AsmMethodSource convert the method body will throw nullpointexception.