### PR TITLE
Fix 1367 constructor references

### DIFF
--- a/src/main/java/soot/jimple/validation/ReturnStatementsValidator.java
+++ b/src/main/java/soot/jimple/validation/ReturnStatementsValidator.java
@@ -79,9 +79,9 @@ public enum ReturnStatementsValidator implements BodyValidator {
     }
 
     exceptions.add(new ValidationException(body.getMethod(), "The method does not contain a return statement," +
-            "or the return statement is not of the appropriate type",
+            " or the return statement is not of the appropriate type",
         "Body of method " + body.getMethod().getSignature() + " does not contain a return statement," +
-                "or the return statement is not of the appropriate type"));
+                " or the return statement is not of the appropriate type"));
   }
 
   @Override

--- a/src/main/java/soot/jimple/validation/ReturnStatementsValidator.java
+++ b/src/main/java/soot/jimple/validation/ReturnStatementsValidator.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import soot.Body;
 import soot.Unit;
+import soot.VoidType;
 import soot.jimple.GotoStmt;
 import soot.jimple.RetStmt;
 import soot.jimple.ReturnStmt;
@@ -52,9 +53,14 @@ public enum ReturnStatementsValidator implements BodyValidator {
    */
   @Override
   public void validate(Body body, List<ValidationException> exceptions) {
-    // Checks that this Jimple body actually contains a return statement
+    // Checks that this Jimple body actually contains a return statement, and that the return statement
+    // is of the appropriate type (i.e. void/non-void)
     for (Unit u : body.getUnits()) {
-      if ((u instanceof ReturnStmt) || (u instanceof ReturnVoidStmt) || (u instanceof RetStmt) || (u instanceof ThrowStmt)) {
+      if ((u instanceof RetStmt) || (u instanceof ThrowStmt)) {
+        return;
+      } else if (u instanceof ReturnStmt && !(body.getMethod().getReturnType() instanceof VoidType)) {
+        return;
+      } else if (u instanceof ReturnVoidStmt && body.getMethod().getReturnType() instanceof VoidType) {
         return;
       }
     }
@@ -72,8 +78,10 @@ public enum ReturnStatementsValidator implements BodyValidator {
       return;
     }
 
-    exceptions.add(new ValidationException(body.getMethod(), "The method does not contain a return statement",
-        "Body of method " + body.getMethod().getSignature() + " does not contain a return statement"));
+    exceptions.add(new ValidationException(body.getMethod(), "The method does not contain a return statement," +
+            "or the return statement is not of the appropriate type",
+        "Body of method " + body.getMethod().getSignature() + " does not contain a return statement," +
+                "or the return statement is not of the appropriate type"));
   }
 
   @Override

--- a/src/systemTest/java/soot/lambdaMetaFactory/Issue1367Test.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/Issue1367Test.java
@@ -1,0 +1,49 @@
+package soot.lambdaMetaFactory;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2019 Manuel Benz
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import org.junit.Test;
+
+import soot.SootMethod;
+import soot.testing.framework.AbstractTestingFramework;
+
+/**
+ * Reproduces issue 1367: https://github.com/Sable/soot/issues/1367
+ *
+ * @author David Seekatz
+ */
+public class Issue1367Test extends AbstractTestingFramework {
+
+    @Test
+    public void constructorReference() {
+        String testClass = "soot.lambdaMetaFactory.Issue1367";
+
+        final SootMethod target = prepareTarget(
+                methodSigFromComponents(testClass, "java.util.function.Supplier", "constructorReference"),
+                testClass,
+                "java.util.function.Function");
+
+        validateAllBodies(target.getDeclaringClass());
+    }
+
+}

--- a/src/systemTest/targets/soot/lambdaMetaFactory/Issue1367.java
+++ b/src/systemTest/targets/soot/lambdaMetaFactory/Issue1367.java
@@ -1,0 +1,36 @@
+package soot.lambdaMetaFactory;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2019 Manuel Benz
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.function.Supplier;
+
+/**
+ * Test case for issue 1367: https://github.com/Sable/soot/issues/1367
+ *
+ * @author David Seekatz
+ */
+public class Issue1367 {
+    public Supplier<Object> constructorReference() {
+        return Object::new;
+    }
+}


### PR DESCRIPTION
Fixes #1367 

- Added simple check to `ReturnStatementsValidator` that requires methods with non-void return type to have a non-void return statement and methods with void return type to have a void return statement
- Properly handle constructor references as a special case in `LambdaMetaFactory`
- Added a new test case