### PR TITLE
Fixed potential NPE in MethodBuilder.java

### DIFF
--- a/src/main/java/soot/asm/MethodBuilder.java
+++ b/src/main/java/soot/asm/MethodBuilder.java
@@ -245,7 +245,8 @@ class MethodBuilder extends JSRInlinerAdapter {
       method.addTag(tag);
     }
     if (invisibleLocalVarAnnotations != null) {
-      VisibilityLocalVariableAnnotationTag tag = new VisibilityLocalVariableAnnotationTag(visibleLocalVarAnnotations.size(),
+      VisibilityLocalVariableAnnotationTag tag
+          = new VisibilityLocalVariableAnnotationTag(invisibleLocalVarAnnotations.size(),
           AnnotationConstants.RUNTIME_INVISIBLE);
       for (VisibilityAnnotationTag vat : invisibleLocalVarAnnotations) {
         tag.addVisibilityAnnotation(vat);


### PR DESCRIPTION
This is a follow-up of #1369 

Seems the creation of `VisibilityLocalVariableAnnotationTag` used the `size()` of a wrong collection, which potentially cause an NPE:

```
java.lang.NullPointerException
        at soot.asm.MethodBuilder.visitEnd(MethodBuilder.java:248)
        at org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1287)
        at org.objectweb.asm.ClassReader.accept(ClassReader.java:688)
        at org.objectweb.asm.ClassReader.accept(ClassReader.java:400)
        at soot.asm.AsmClassSource.resolve(AsmClassSource.java:67)
        at soot.SootResolver.bringToHierarchyUnchecked(SootResolver.java:253)
        at soot.SootResolver.bringToHierarchy(SootResolver.java:221)
        at soot.SootResolver.bringToSignatures(SootResolver.java:292)
        at soot.SootResolver.bringToBodies(SootResolver.java:332)
        at soot.SootResolver.processResolveWorklist(SootResolver.java:171)
        at soot.SootResolver.resolveClass(SootResolver.java:141)
        at soot.Scene.loadClass(Scene.java:1009)
        at soot.Scene.loadClassAndSupport(Scene.java:994)
        at soot.Scene.loadNecessaryClasses(Scene.java:1822)
        at soot.Main.run(Main.java:241)
``` 