### PR TITLE
fix bug in analyzing source code, fixes #1377

### DIFF
--- a/src/main/generated/jastadd/soot/JastAddJ/BytecodeParser.java
+++ b/src/main/generated/jastadd/soot/JastAddJ/BytecodeParser.java
@@ -641,6 +641,15 @@ public class BytecodeParser extends java.lang.Object implements Flags, BytecodeR
     private static final int CONSTANT_Utf8 = 1;
 
 
+    private static final int CONSTANT_MethodHandle= 15;
+
+
+    private static final int CONSTANT_MethodType = 16;
+
+
+    private static final int CONSTANT_InvokeDynamic = 18;
+
+
 
     public void parseEntry(int i) {
       int tag = u1();
@@ -677,6 +686,15 @@ public class BytecodeParser extends java.lang.Object implements Flags, BytecodeR
           break;
         case CONSTANT_Utf8:
           constantPool[i] = new CONSTANT_Utf8_Info(this);
+          break;
+        case CONSTANT_MethodHandle:
+          constantPool[i] = new CONSTANT_MethodHandle_Info(this);
+          break;
+        case CONSTANT_MethodType:
+          constantPool[i] = new CONSTANT_MethodType_Info(this);
+          break;
+        case CONSTANT_InvokeDynamic:
+          constantPool[i] = new CONSTANT_InvokeDynamic_Info(this);
           break;
         default:
           println("Unknown entry: " + tag);

--- a/src/main/generated/jastadd/soot/JastAddJ/CONSTANT_InvokeDynamic_Info.java
+++ b/src/main/generated/jastadd/soot/JastAddJ/CONSTANT_InvokeDynamic_Info.java
@@ -1,0 +1,26 @@
+package soot.JastAddJ;
+
+/**
+ * @ast class
+ */
+public class CONSTANT_InvokeDynamic_Info extends CONSTANT_Info {
+
+    public int method_attr_index;
+
+
+    public int name_and_type_index;
+
+
+    public CONSTANT_InvokeDynamic_Info(BytecodeParser parser) {
+      super(parser);
+      method_attr_index = p.u2();
+      name_and_type_index = p.u2();
+    }
+
+
+    public String toString() {
+        return "InvokeDynamicInfo: " + method_attr_index + " " + name_and_type_index;
+    }
+
+
+}

--- a/src/main/generated/jastadd/soot/JastAddJ/CONSTANT_MethodHandle_Info.java
+++ b/src/main/generated/jastadd/soot/JastAddJ/CONSTANT_MethodHandle_Info.java
@@ -1,0 +1,26 @@
+package soot.JastAddJ;
+
+/**
+ * @ast class
+ */
+public class CONSTANT_MethodHandle_Info extends CONSTANT_Info {
+
+    public int reference_kind;
+
+
+    public int reference_index;
+
+
+    public CONSTANT_MethodHandle_Info(BytecodeParser parser) {
+      super(parser);
+      reference_kind = p.u1();
+      reference_index = p.u2();
+    }
+
+
+    public String toString() {
+        return "MethodHandleInfo: " + reference_kind + " " + reference_index;
+    }
+
+
+}

--- a/src/main/generated/jastadd/soot/JastAddJ/CONSTANT_MethodType_Info.java
+++ b/src/main/generated/jastadd/soot/JastAddJ/CONSTANT_MethodType_Info.java
@@ -1,0 +1,22 @@
+package soot.JastAddJ;
+
+/**
+ * @ast class
+ */
+public class CONSTANT_MethodType_Info extends CONSTANT_Info {
+
+    public int descriptor_index;
+
+
+    public CONSTANT_MethodType_Info(BytecodeParser parser) {
+      super(parser);
+      descriptor_index = p.u2();
+    }
+
+
+    public String toString() {
+        return "MethodTypeInfo: " + descriptor_index ;
+    }
+
+
+}


### PR DESCRIPTION
The issue #1377 will occur, because the  analysis the source-code frontend using the constant pool in bytecode with java6. Howerer, three more constant categories have been added to the constant pool in bytecode after java7.  Parseing java.lang.CharSequence failed，becase original code unknown the tag 15/16/18  in the constant pool.