### PR TITLE
Fix data race in Scene.getSootClassUnsafe

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1217,9 +1217,14 @@ public class Scene {
   public SootClass getSootClassUnsafe(String className, boolean phantomNonExist) {
     RefType type = nameToClass.get(className);
     if (type != null) {
-      SootClass tsc = type.getSootClass();
-      if (tsc != null) {
-        return tsc;
+      synchronized (type) {
+        if (type.hasSootClass()
+            || !SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME.equals(className)) {
+          SootClass tsc = type.getSootClass();
+          if (tsc != null) {
+            return tsc;
+          }
+        }
       }
     }
 
@@ -1227,6 +1232,9 @@ public class Scene {
         || className.equals(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME)) {
       type = getOrAddRefType(className);
       synchronized (type) {
+        if (type.hasSootClass()) {
+          return type.getSootClass();
+        }
         SootClass c = new SootClass(className);
         c.isPhantom = true;
         addClassSilent(c);


### PR DESCRIPTION
Without the proper use of synchronization, the following three issues can
occur.

# Issue 1: For a given className, several SootClass instances are created

For this, assume two threads are calling
Scene.getSootClassUnsafe(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME, true)
and there exists no RefType named SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME.
In this case, it is possible that both threads end up executing the following
code

type = getOrAddRefType(className);
synchronized (type) {
  SootClass c = new SootClass(className);
  c.isPhantom = true;
  addClassSilent(c);
  c.setPhantomClass();
  return c;
}

Consequently, two SootClass instances are created where only one of them
will be associated with RefType type afterwards. This could lead to
potential issues.
Note that the second addClassSilent call does not result in a "duplicate
class" RuntimeException because the SootClass(...) constructor (indirectly)
calls RefType.setSootClass(this), which causes Scene.containsClass to
return false (which is called in Scene.addClassSilent).

To avoid the creation of several SootClass instances, check if there is
already a SootClass associated with the RefType (while having the monitor's
lock). If so, return this SootClass instance instead of creating a new
SootClass instance.


# Issue 2: "duplicate class: soot.dummy.InvokeDynamic" RuntimeException

For this, first create "several" class files that contain invokedynamic
instructions.

marcus@linux:~/repro> cat gen_classes.sh 
#!/bin/bash
for i in $(seq 30); do
	cat > "Test$i.java" <<EOF
public class Test$i {
	public String run$i() {
		String x = "foo";
		String y = x + "Test$i";
		System.out.println(y);
		return y;
	}

	public static void main(String[] args) {
		new Test$i().run$i();
	}
}
EOF
	javac11 -d out "Test$i.java"
	rm "Test$i.java"
done
marcus@linux:~/repro> bash gen_classes.sh 
marcus@linux:~/repro>

Next, execute soot (and keep fingers crossed to see some "bad"
interleaving;) )

marcus@linux:~/repro> java11 -cp /path/to/sootclasses-trunk-jar-with-dependencies.jar soot.Main -f J --process-dir out
Soot started on Tue Jun 23 10:53:59 CEST 2020
[Thread-7] ERROR heros.solver.CountingThreadPoolExecutor - Worker thread execution failed: Failed to convert <Test4: java.lang.String run4()>
java.lang.RuntimeException: Failed to convert <Test4: java.lang.String run4()>
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2163)
	at soot.SootMethod.retrieveActiveBody(SootMethod.java:402)
	at soot.PackManager$1.run(PackManager.java:1279)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: duplicate class: soot.dummy.InvokeDynamic
	at soot.Scene.addClassSilent(Scene.java:894)
	at soot.Scene.getSootClassUnsafe(Scene.java:1232)
	at soot.Scene.getSootClassUnsafe(Scene.java:1204)
	at soot.Scene.getSootClass(Scene.java:1243)
	at soot.asm.AsmMethodSource.convertInvokeDynamicInsn(AsmMethodSource.java:1466)
	at soot.asm.AsmMethodSource.convert(AsmMethodSource.java:1909)
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2161)
	... 5 more
java.lang.RuntimeException: Failed to convert <Test4: java.lang.String run4()>
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2163)
	at soot.SootMethod.retrieveActiveBody(SootMethod.java:402)
	at soot.PackManager$1.run(PackManager.java:1279)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: duplicate class: soot.dummy.InvokeDynamic
	at soot.Scene.addClassSilent(Scene.java:894)
	at soot.Scene.getSootClassUnsafe(Scene.java:1232)
	at soot.Scene.getSootClassUnsafe(Scene.java:1204)
	at soot.Scene.getSootClass(Scene.java:1243)
	at soot.asm.AsmMethodSource.convertInvokeDynamicInsn(AsmMethodSource.java:1466)
	at soot.asm.AsmMethodSource.convert(AsmMethodSource.java:1909)
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2161)
	... 5 more
Exception in thread "Thread-7" java.lang.RuntimeException: Failed to convert <Test4: java.lang.String run4()>
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2163)
	at soot.SootMethod.retrieveActiveBody(SootMethod.java:402)
	at soot.PackManager$1.run(PackManager.java:1279)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: duplicate class: soot.dummy.InvokeDynamic
	at soot.Scene.addClassSilent(Scene.java:894)
	at soot.Scene.getSootClassUnsafe(Scene.java:1232)
	at soot.Scene.getSootClassUnsafe(Scene.java:1204)
	at soot.Scene.getSootClass(Scene.java:1243)
	at soot.asm.AsmMethodSource.convertInvokeDynamicInsn(AsmMethodSource.java:1466)
	at soot.asm.AsmMethodSource.convert(AsmMethodSource.java:1909)
	at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2161)
	... 5 more


Ouuups... something went wrong! Sorry about that.
Follow these steps to fix the problem:
1.) Are you sure you used the right command line?
    Click here to double-check:
    https://github.com/soot-oss/soot/wiki/Options-and-JavaDoc

2.) Not sure whether it's a bug? Feel free to discuss
    the issue on the Soot mailing list:
    https://github.com/soot-oss/soot/wiki/Getting-help

3.) Sure it's a bug? Click this link to report it.
    https://github.com/soot-oss/soot/issues/new?title=java.lang.RuntimeException+when+...&body=Steps+to+reproduce%3A%0A1.%29+...%0A%0AFiles+used+to+reproduce%3A+%0A...%0A%0ASoot+version%3A+%3Cpre%3Etrunk%3C%2Fpre%3E%0A%0ACommand+line%3A%0A%3Cpre%3E-f+J+--process-dir+out%3C%2Fpre%3E%0A%0AMax+Memory%3A%0A%3Cpre%3E3916MB%3C%2Fpre%3E%0A%0AStack+trace%3A%0A%3Cpre%3Ejava.lang.RuntimeException%3A+Failed+to+convert+%26%2360%3BTest4%3A+java.lang.String+run4%28%29%26%2362%3B%0A%09at+soot.asm.AsmMethodSource.getBody%28AsmMethodSource.java%3A2163%29%0A%09at+soot.SootMethod.retrieveActiveBody%28SootMethod.java%3A402%29%0A%09at+soot.PackManager%241.run%28PackManager.java%3A1279%29%0A%09at+java.base%2Fjava.util.concurrent.ThreadPoolExecutor.runWorker%28ThreadPoolExecutor.java%3A1128%29%0A%09at+java.base%2Fjava.util.concurrent.ThreadPoolExecutor%24Worker.run%28ThreadPoolExecutor.java%3A628%29%0A%09at+java.base%2Fjava.lang.Thread.run%28Thread.java%3A834%29%0ACaused+by%3A+java.lang.RuntimeException%3A+duplicate+class%3A+soot.dummy.InvokeDynamic%0A%09at+soot.Scene.addClassSilent%28Scene.java%3A894%29%0A%09at+soot.Scene.getSootClassUnsafe%28Scene.java%3A1232%29%0A%09at+soot.Scene.getSootClassUnsafe%28Scene.java%3A1204%29%0A%09at+soot.Scene.getSootClass%28Scene.java%3A1243%29%0A%09at+soot.asm.AsmMethodSource.convertInvokeDynamicInsn%28AsmMethodSource.java%3A1466%29%0A%09at+soot.asm.AsmMethodSource.convert%28AsmMethodSource.java%3A1909%29%0A%09at+soot.asm.AsmMethodSource.getBody%28AsmMethodSource.java%3A2161%29%0A%09...+5+more%0A%3C%2Fpre%3E
    Please be as precise as possible when giving us
    information on how to reproduce the problem. Thanks!
marcus@linux:~/repro> 

For instance, this can occur if two threads (Thread-7 and Thread-1) call
Scene.getSootClassUnsafe(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME, true) and
interleave as follows:

Thread-7                                            Thread-1

...
type = getOrAddRefType(className);
synchronized (type) {
                                                    RefType type = nameToClass.get(className);
                                                    SootClass tsc = type.getSootClass();
                                                    -- SootResolver.v().makeClassRef(...)
  SootClass c = new SootClass(className);
  c.isPhantom = true;
                                                    ---- newClass = new SootClass(className);
                                                    ---- newClass.setResolvingLevel(SootClass.DANGLING);
                                                    ---- Scene.v().addClass(newClass);
                                                    ...
                                                    return tsc;
  addClassSilent(c);


When Thread-7 calls addClassSilent(c), the SootClass instance that was
created by Thread-1 is associated with the RefType type and also part
of the Scene (that is, Scene.containsClass returns true). Hence, the
"duplicate class: soot.dummy.InvokeDynamic" RuntimeException is thrown.

To fix this, it is sufficient to obtain the RefType type monitor's lock
before calling type.getSootClass() (in addition to the fix for "Issue 1").


# Issue 3: DANGLING resolving level during method resolution

For this, reuse the class files from Issue 2 and execute soot (again,
keep fingers crossed to see a "bad" interleaving).

marcus@linux:~/repro> java11 -cp /path/to/sootclasses-trunk-jar-with-dependencies.jar soot.Main --validate -f J --process-dir out
Soot started on Tue Jun 23 13:35:04 CEST 2020
[Thread-10] ERROR heros.solver.CountingThreadPoolExecutor - Worker thread execution failed: This operation requires resolving level SIGNATURES but soot.dummy.InvokeDynamic is at resolving level DANGLING
If you are extending Soot, try to add the following call before calling soot.Main.main(..):
Scene.v().addBasicClass(soot.dummy.InvokeDynamic,SIGNATURES);
Otherwise, try whole-program mode (-w).
java.lang.RuntimeException: This operation requires resolving level SIGNATURES but soot.dummy.InvokeDynamic is at resolving level DANGLING
If you are extending Soot, try to add the following call before calling soot.Main.main(..):
Scene.v().addBasicClass(soot.dummy.InvokeDynamic,SIGNATURES);
Otherwise, try whole-program mode (-w).
	at soot.SootClass.checkLevelIgnoreResolving(SootClass.java:198)
	at soot.SootClass.checkLevel(SootClass.java:180)
	at soot.SootClass.getMethodUnsafe(SootClass.java:561)
	at soot.SootMethodRefImpl.tryResolve(SootMethodRefImpl.java:210)
	at soot.SootMethodRefImpl.resolve(SootMethodRefImpl.java:263)
	at soot.SootMethodRefImpl.resolve(SootMethodRefImpl.java:183)
	at soot.jimple.internal.AbstractInvokeExpr.getMethod(AbstractInvokeExpr.java:56)
	at soot.jimple.validation.InvokeArgumentValidator.validate(InvokeArgumentValidator.java:54)
	at soot.jimple.JimpleBody.validate(JimpleBody.java:118)
	at soot.jimple.JimpleBody.validate(JimpleBody.java:98)
	at soot.PackManager.runBodyPacks(PackManager.java:1007)
	at soot.PackManager.lambda$runBodyPacks$0(PackManager.java:660)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
java.lang.RuntimeException: This operation requires resolving level SIGNATURES but soot.dummy.InvokeDynamic is at resolving level DANGLING
If you are extending Soot, try to add the following call before calling soot.Main.main(..):
Scene.v().addBasicClass(soot.dummy.InvokeDynamic,SIGNATURES);
Otherwise, try whole-program mode (-w).
	at soot.SootClass.checkLevelIgnoreResolving(SootClass.java:198)
	at soot.SootClass.checkLevel(SootClass.java:180)
	at soot.SootClass.getMethodUnsafe(SootClass.java:561)
	at soot.SootMethodRefImpl.tryResolve(SootMethodRefImpl.java:210)
	at soot.SootMethodRefImpl.resolve(SootMethodRefImpl.java:263)
	at soot.SootMethodRefImpl.resolve(SootMethodRefImpl.java:183)
	at soot.jimple.internal.AbstractInvokeExpr.getMethod(AbstractInvokeExpr.java:56)
	at soot.jimple.validation.InvokeArgumentValidator.validate(InvokeArgumentValidator.java:54)
	at soot.jimple.JimpleBody.validate(JimpleBody.java:118)
	at soot.jimple.JimpleBody.validate(JimpleBody.java:98)
	at soot.PackManager.runBodyPacks(PackManager.java:1007)
	at soot.PackManager.lambda$runBodyPacks$0(PackManager.java:660)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Exception in thread "Thread-10" java.lang.RuntimeException: This operation requires resolving level SIGNATURES but soot.dummy.InvokeDynamic is at resolving level DANGLING
If you are extending Soot, try to add the following call before calling soot.Main.main(..):
Scene.v().addBasicClass(soot.dummy.InvokeDynamic,SIGNATURES);
Otherwise, try whole-program mode (-w).
	at soot.SootClass.checkLevelIgnoreResolving(SootClass.java:198)
	at soot.SootClass.checkLevel(SootClass.java:180)
	at soot.SootClass.getMethodUnsafe(SootClass.java:561)
	at soot.SootMethodRefImpl.tryResolve(SootMethodRefImpl.java:210)
	at soot.SootMethodRefImpl.resolve(SootMethodRefImpl.java:263)
	at soot.SootMethodRefImpl.resolve(SootMethodRefImpl.java:183)
	at soot.jimple.internal.AbstractInvokeExpr.getMethod(AbstractInvokeExpr.java:56)
	at soot.jimple.validation.InvokeArgumentValidator.validate(InvokeArgumentValidator.java:54)
	at soot.jimple.JimpleBody.validate(JimpleBody.java:118)
	at soot.jimple.JimpleBody.validate(JimpleBody.java:98)
	at soot.PackManager.runBodyPacks(PackManager.java:1007)
	at soot.PackManager.lambda$runBodyPacks$0(PackManager.java:660)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)


Ouuups... something went wrong! Sorry about that.
Follow these steps to fix the problem:
1.) Are you sure you used the right command line?
    Click here to double-check:
    https://github.com/soot-oss/soot/wiki/Options-and-JavaDoc

2.) Not sure whether it's a bug? Feel free to discuss
    the issue on the Soot mailing list:
    https://github.com/soot-oss/soot/wiki/Getting-help

3.) Sure it's a bug? Click this link to report it.
    https://github.com/soot-oss/soot/issues/new?title=java.lang.RuntimeException+when+...&body=Steps+to+reproduce%3A%0A1.%29+...%0A%0AFiles+used+to+reproduce%3A+%0A...%0A%0ASoot+version%3A+%3Cpre%3Etrunk%3C%2Fpre%3E%0A%0ACommand+line%3A%0A%3Cpre%3E--validate+-f+J+--process-dir+out%3C%2Fpre%3E%0A%0AMax+Memory%3A%0A%3Cpre%3E3916MB%3C%2Fpre%3E%0A%0AStack+trace%3A%0A%3Cpre%3Ejava.lang.RuntimeException%3A+This+operation+requires+resolving+level+SIGNATURES+but+soot.dummy.InvokeDynamic+is+at+resolving+level+DANGLING%0AIf+you+are+extending+Soot%2C+try+to+add+the+following+call+before+calling+soot.Main.main%28..%29%3A%0AScene.v%28%29.addBasicClass%28soot.dummy.InvokeDynamic%2CSIGNATURES%29%3B%0AOtherwise%2C+try+whole-program+mode+%28-w%29.%0A%09at+soot.SootClass.checkLevelIgnoreResolving%28SootClass.java%3A198%29%0A%09at+soot.SootClass.checkLevel%28SootClass.java%3A180%29%0A%09at+soot.SootClass.getMethodUnsafe%28SootClass.java%3A561%29%0A%09at+soot.SootMethodRefImpl.tryResolve%28SootMethodRefImpl.java%3A210%29%0A%09at+soot.SootMethodRefImpl.resolve%28SootMethodRefImpl.java%3A263%29%0A%09at+soot.SootMethodRefImpl.resolve%28SootMethodRefImpl.java%3A183%29%0A%09at+soot.jimple.internal.AbstractInvokeExpr.getMethod%28AbstractInvokeExpr.java%3A56%29%0A%09at+soot.jimple.validation.InvokeArgumentValidator.validate%28InvokeArgumentValidator.java%3A54%29%0A%09at+soot.jimple.JimpleBody.validate%28JimpleBody.java%3A118%29%0A%09at+soot.jimple.JimpleBody.validate%28JimpleBody.java%3A98%29%0A%09at+soot.PackManager.runBodyPacks%28PackManager.java%3A1007%29%0A%09at+soot.PackManager.lambda%24runBodyPacks%240%28PackManager.java%3A660%29%0A%09at+java.base%2Fjava.util.concurrent.ThreadPoolExecutor.runWorker%28ThreadPoolExecutor.java%3A1128%29%0A%09at+java.base%2Fjava.util.concurrent.ThreadPoolExecutor%24Worker.run%28ThreadPoolExecutor.java%3A628%29%0A%09at+java.base%2Fjava.lang.Thread.run%28Thread.java%3A834%29%0A%3C%2Fpre%3E
    Please be as precise as possible when giving us
    information on how to reproduce the problem. Thanks!
marcus@linux:~/repro> 

Note: the --validate option is needed in order to trigger the method
resolution.

As in Issue 2, this is, again, due to some bad interleaving of (at least)
two threads that call
Scene.getSootClassUnsafe(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME, true)
(which is indirectly called from
soot.asm.AsmMethodSource.convertInvokeDynamicInsn, which is indirectly
called from PackManager.retrieveAllBodies).

Thread-7                                            Thread-1

...
type = getOrAddRefType(className);
synchronized (type) {
                                                    RefType type = nameToClass.get(className);
                                                    SootClass tsc = type.getSootClass();
                                                    -- SootResolver.v().makeClassRef(...)
  SootClass c = new SootClass(className);
  c.isPhantom = true;
  addClassSilent(c);
  c.setPhantomClass();
  return c;
}
                                                    ---- newClass = new SootClass(className);
                                                    ---- newClass.setResolvingLevel(SootClass.DANGLING);
                                                    ---- Scene.v().addClass(newClass);
                                                    ...
                                                    return tsc;

That is, in soot.asm.AsmMethodSource.convertInvokeDynamicInsn a new
SootMethodRef(Impl) is constructed where the declaring class has a
DANGLING resolving level. Hence, the RuntimeException is thrown
when resolving this SootMethodRefImpl instance (in Thread-10).

To fix this, only call type.getSootClass() if there is a SootClass
associated with the RefType type or if the className does not equal
SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME (in addition to the fixes
from Issue 1 and Issue 2). That is, always return a phantom SootClass
instance with a non-DANGLING resolving level.
Note: there is a slight chance that this change breaks 3rd party code,
which expects, for instance, a non-phantom class (very unlikely, IMHO).

Fixes: #1373 ("Data Races in Scene.getSootClassUnsafe()")

Signed-off-by: Marcus Hüwe <marcus.huewe@iem.fraunhofer.de>