### PR TITLE
Cleanup classes in soot.tagkit package

### DIFF
--- a/src/main/java/soot/tagkit/AnnotationAnnotationElem.java
+++ b/src/main/java/soot/tagkit/AnnotationAnnotationElem.java
@@ -25,18 +25,18 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the base class of annotation elements each annotation can have several elements for Java 1.5.
+ * Represents the Annotation annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationAnnotationElem extends AnnotationElem {
 
-  AnnotationTag value;
+  private final AnnotationTag value;
 
   public AnnotationAnnotationElem(AnnotationTag t, char kind, String name) {
     super(kind, name);
     this.value = t;
   }
 
+  @Override
   public String toString() {
     return super.toString() + "value: " + value.toString();
   }
@@ -66,18 +66,17 @@ public class AnnotationAnnotationElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationAnnotationElem other = (AnnotationAnnotationElem) obj;
-    if (value == null) {
+    if (this.value == null) {
       if (other.value != null) {
         return false;
       }
-    } else if (!value.equals(other.value)) {
+    } else if (!this.value.equals(other.value)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationArrayElem.java
+++ b/src/main/java/soot/tagkit/AnnotationArrayElem.java
@@ -27,18 +27,18 @@ import java.util.ArrayList;
 import soot.util.Switch;
 
 /**
- * Represents the base class of annotation elements each annotation can have several elements for Java 1.5.
+ * Represents the Array annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationArrayElem extends AnnotationElem {
 
-  ArrayList<AnnotationElem> values;
+  private final ArrayList<AnnotationElem> values;
 
   public AnnotationArrayElem(ArrayList<AnnotationElem> t, char kind, String name) {
     super(kind, name);
     this.values = t;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " values: " + values.toString();
   }
@@ -80,18 +80,17 @@ public class AnnotationArrayElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationArrayElem other = (AnnotationArrayElem) obj;
-    if (values == null) {
+    if (this.values == null) {
       if (other.values != null) {
         return false;
       }
-    } else if (!values.equals(other.values)) {
+    } else if (!this.values.equals(other.values)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationBooleanElem.java
+++ b/src/main/java/soot/tagkit/AnnotationBooleanElem.java
@@ -24,14 +24,19 @@ package soot.tagkit;
 
 import soot.util.Switch;
 
+/**
+ * Represents the boolean annotation element each annotation can have several elements for Java 1.5.
+ */
 public class AnnotationBooleanElem extends AnnotationElem {
-  boolean value;
+
+  private final boolean value;
 
   public AnnotationBooleanElem(boolean v, char kind, String name) {
     super(kind, name);
     this.value = v;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " value: " + value;
   }
@@ -61,14 +66,10 @@ public class AnnotationBooleanElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationBooleanElem other = (AnnotationBooleanElem) obj;
-    if (value != other.value) {
-      return false;
-    }
-    return true;
+    return this.value == other.value;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationClassElem.java
+++ b/src/main/java/soot/tagkit/AnnotationClassElem.java
@@ -25,18 +25,18 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the base class of annotation elements each annotation can have several elements for Java 1.5.
+ * Represents the Class annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationClassElem extends AnnotationElem {
 
-  String desc;
+  private final String desc;
 
   public AnnotationClassElem(String s, char kind, String name) {
     super(kind, name);
     this.desc = s;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " decription: " + desc;
   }
@@ -66,18 +66,17 @@ public class AnnotationClassElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationClassElem other = (AnnotationClassElem) obj;
-    if (desc == null) {
+    if (this.desc == null) {
       if (other.desc != null) {
         return false;
       }
-    } else if (!desc.equals(other.desc)) {
+    } else if (!this.desc.equals(other.desc)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationDefaultTag.java
+++ b/src/main/java/soot/tagkit/AnnotationDefaultTag.java
@@ -23,23 +23,23 @@ package soot.tagkit;
  */
 
 /**
- * Represents the annotation default attribute attatched method - could have at most one annotation default each for Java
- * 1.5.
+ * Represents the annotation default attribute attached method - could have at most one annotation default each for Java 1.5.
  */
-
 public class AnnotationDefaultTag implements Tag {
-  private AnnotationElem defaultVal;
+
+  private final AnnotationElem defaultVal;
 
   public AnnotationDefaultTag(AnnotationElem def) {
     this.defaultVal = def;
   }
 
-  // should also print here number of annotations and perhaps the annotations themselves
+  @Override
   public String toString() {
     return "Annotation Default: " + defaultVal;
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "AnnotationDefaultTag";
   }
@@ -53,8 +53,8 @@ public class AnnotationDefaultTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("AnnotationDefaultTag has no value for bytecode");
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationDoubleElem.java
+++ b/src/main/java/soot/tagkit/AnnotationDoubleElem.java
@@ -25,18 +25,18 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the int annotation element each annotation can have several elements for Java 1.5.
+ * Represents the double annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationDoubleElem extends AnnotationElem {
 
-  double value;
+  private final double value;
 
   public AnnotationDoubleElem(double v, char kind, String name) {
     super(kind, name);
     this.value = v;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " value: " + value;
   }
@@ -54,8 +54,7 @@ public class AnnotationDoubleElem extends AnnotationElem {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    long temp;
-    temp = Double.doubleToLongBits(value);
+    long temp = Double.doubleToLongBits(value);
     result = prime * result + (int) (temp ^ (temp >>> 32));
     return result;
   }
@@ -68,14 +67,10 @@ public class AnnotationDoubleElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationDoubleElem other = (AnnotationDoubleElem) obj;
-    if (Double.doubleToLongBits(value) != Double.doubleToLongBits(other.value)) {
-      return false;
-    }
-    return true;
+    return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationElem.java
+++ b/src/main/java/soot/tagkit/AnnotationElem.java
@@ -27,17 +27,17 @@ import soot.util.Switchable;
 /**
  * Represents the base class of annotation elements each annotation can have several elements for Java 1.5.
  */
-
 public abstract class AnnotationElem implements Switchable {
 
-  char kind;
-  String name;
+  private final char kind;
+  private String name;
 
   public AnnotationElem(char k, String name) {
     this.kind = k;
     this.name = name;
   }
 
+  @Override
   public String toString() {
     return "Annotation Element: kind: " + kind + " name: " + name;
   }
@@ -68,24 +68,20 @@ public abstract class AnnotationElem implements Switchable {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (obj == null || this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationElem other = (AnnotationElem) obj;
-    if (kind != other.kind) {
+    if (this.kind != other.kind) {
       return false;
     }
-    if (name == null) {
+    if (this.name == null) {
       if (other.name != null) {
         return false;
       }
-    } else if (!name.equals(other.name)) {
+    } else if (!this.name.equals(other.name)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationEnumElem.java
+++ b/src/main/java/soot/tagkit/AnnotationEnumElem.java
@@ -25,13 +25,12 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the base class of annotation elements each annotation can have several elements for Java 1.5.
+ * Represents the Enum annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationEnumElem extends AnnotationElem {
 
-  String typeName;
-  String constantName;
+  private String typeName;
+  private String constantName;
 
   public AnnotationEnumElem(String t, String c, char kind, String name) {
     super(kind, name);
@@ -82,25 +81,24 @@ public class AnnotationEnumElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationEnumElem other = (AnnotationEnumElem) obj;
-    if (constantName == null) {
+    if (this.constantName == null) {
       if (other.constantName != null) {
         return false;
       }
-    } else if (!constantName.equals(other.constantName)) {
+    } else if (!this.constantName.equals(other.constantName)) {
       return false;
     }
-    if (typeName == null) {
+    if (this.typeName == null) {
       if (other.typeName != null) {
         return false;
       }
-    } else if (!typeName.equals(other.typeName)) {
+    } else if (!this.typeName.equals(other.typeName)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationFloatElem.java
+++ b/src/main/java/soot/tagkit/AnnotationFloatElem.java
@@ -25,18 +25,18 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the int annotation element each annotation can have several elements for Java 1.5.
+ * Represents the float annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationFloatElem extends AnnotationElem {
 
-  float value;
+  private final float value;
 
   public AnnotationFloatElem(float v, char kind, String name) {
     super(kind, name);
     this.value = v;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " value: " + value;
   }
@@ -66,14 +66,10 @@ public class AnnotationFloatElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationFloatElem other = (AnnotationFloatElem) obj;
-    if (Float.floatToIntBits(value) != Float.floatToIntBits(other.value)) {
-      return false;
-    }
-    return true;
+    return Float.floatToIntBits(this.value) == Float.floatToIntBits(other.value);
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationIntElem.java
+++ b/src/main/java/soot/tagkit/AnnotationIntElem.java
@@ -27,16 +27,16 @@ import soot.util.Switch;
 /**
  * Represents the int annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationIntElem extends AnnotationElem {
 
-  int value;
+  private final int value;
 
   public AnnotationIntElem(int v, char kind, String name) {
     super(kind, name);
     this.value = v;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " value: " + value;
   }
@@ -66,14 +66,10 @@ public class AnnotationIntElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationIntElem other = (AnnotationIntElem) obj;
-    if (value != other.value) {
-      return false;
-    }
-    return true;
+    return this.value == other.value;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationLongElem.java
+++ b/src/main/java/soot/tagkit/AnnotationLongElem.java
@@ -25,18 +25,18 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the int annotation element each annotation can have several elements for Java 1.5.
+ * Represents the long annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationLongElem extends AnnotationElem {
 
-  long value;
+  private final long value;
 
   public AnnotationLongElem(long v, char kind, String name) {
     super(kind, name);
     this.value = v;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " value: " + value;
   }
@@ -66,14 +66,10 @@ public class AnnotationLongElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationLongElem other = (AnnotationLongElem) obj;
-    if (value != other.value) {
-      return false;
-    }
-    return true;
+    return this.value == other.value;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationStringElem.java
+++ b/src/main/java/soot/tagkit/AnnotationStringElem.java
@@ -25,18 +25,18 @@ package soot.tagkit;
 import soot.util.Switch;
 
 /**
- * Represents the base class of annotation elements each annotation can have several elements for Java 1.5.
+ * Represents the String annotation element each annotation can have several elements for Java 1.5.
  */
-
 public class AnnotationStringElem extends AnnotationElem {
 
-  String value;
+  private final String value;
 
   public AnnotationStringElem(String s, char kind, String name) {
     super(kind, name);
     this.value = s;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " value: " + value;
   }
@@ -66,18 +66,17 @@ public class AnnotationStringElem extends AnnotationElem {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationStringElem other = (AnnotationStringElem) obj;
-    if (value == null) {
+    if (this.value == null) {
       if (other.value != null) {
         return false;
       }
-    } else if (!value.equals(other.value)) {
+    } else if (!this.value.equals(other.value)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/AnnotationTag.java
+++ b/src/main/java/soot/tagkit/AnnotationTag.java
@@ -26,14 +26,12 @@ package soot.tagkit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /**
  * Represents the annotation attribute attached to a class, method, field, method param - they could have many annotations
  * each for Java 1.5.
  */
-
 public class AnnotationTag implements Tag {
 
   // type - the question here is the class of the type is potentially
@@ -61,7 +59,7 @@ public class AnnotationTag implements Tag {
   /**
    * The type
    */
-  private String type;
+  private final String type;
 
   /**
    * The annotations
@@ -92,15 +90,15 @@ public class AnnotationTag implements Tag {
   }
 
   // should also print here number of annotations and perhaps the annotations themselves
+  @Override
   public String toString() {
     if (elems != null) {
-      StringBuffer sb = new StringBuffer("Annotation: type: " + type + " num elems: " + elems.size() + " elems: ");
-      Iterator<AnnotationElem> it = elems.iterator();
-      while (it.hasNext()) {
-        sb.append("\n");
-        sb.append(it.next());
+      StringBuilder sb = new StringBuilder("Annotation: type: ");
+      sb.append(type).append(" num elems: ").append(elems.size()).append(" elems: ");
+      for (AnnotationElem next : elems) {
+        sb.append('\n').append(next);
       }
-      sb.append("\n");
+      sb.append('\n');
       return sb.toString();
     } else {
       return "Annotation type: " + type + " without elements";
@@ -108,6 +106,7 @@ public class AnnotationTag implements Tag {
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "AnnotationTag";
   }
@@ -121,6 +120,7 @@ public class AnnotationTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("AnnotationTag has no value for bytecode");
   }
@@ -169,28 +169,24 @@ public class AnnotationTag implements Tag {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (obj == null || this.getClass() != obj.getClass()) {
       return false;
     }
     AnnotationTag other = (AnnotationTag) obj;
-    if (elems == null) {
+    if (this.elems == null) {
       if (other.elems != null) {
         return false;
       }
-    } else if (!elems.equals(other.elems)) {
+    } else if (!this.elems.equals(other.elems)) {
       return false;
     }
-    if (type == null) {
+    if (this.type == null) {
       if (other.type != null) {
         return false;
       }
-    } else if (!type.equals(other.type)) {
+    } else if (!this.type.equals(other.type)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/Attribute.java
+++ b/src/main/java/soot/tagkit/Attribute.java
@@ -25,10 +25,8 @@ package soot.tagkit;
 /**
  * Tags that are attached to the class file, field, method, or method body should implement this interface.
  */
-
 public interface Attribute extends Tag {
 
   /** Sets the value of the attribute from a byte[]. */
   public void setValue(byte[] v);
-
 }

--- a/src/main/java/soot/tagkit/Base64.java
+++ b/src/main/java/soot/tagkit/Base64.java
@@ -26,6 +26,8 @@
 
 package soot.tagkit;
 
+import java.util.Arrays;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -59,6 +61,33 @@ package soot.tagkit;
  */
 public class Base64 {
 
+  //
+  // code characters for values 0..63
+  //
+  private static final char[] alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".toCharArray();
+
+  //
+  // lookup table for converting base64 characters to value in range 0..63
+  //
+  private static final byte[] codes = new byte[256];
+
+  static {
+    for (int i = 0; i < 256; i++) {
+      codes[i] = -1;
+    }
+    for (int i = 'A'; i <= 'Z'; i++) {
+      codes[i] = (byte) (i - 'A');
+    }
+    for (int i = 'a'; i <= 'z'; i++) {
+      codes[i] = (byte) (26 + i - 'a');
+    }
+    for (int i = '0'; i <= '9'; i++) {
+      codes[i] = (byte) (52 + i - '0');
+    }
+    codes['+'] = 62;
+    codes['/'] = 63;
+  }
+
   /**
    * returns an array of base64-encoded characters to represent the passed data array.
    *
@@ -66,7 +95,7 @@ public class Base64 {
    *          the array of bytes to encode
    * @return base64-coded character array.
    */
-  static public char[] encode(byte[] data) {
+  public static char[] encode(byte[] data) {
     char[] out = new char[((data.length + 2) / 3) * 4];
 
     //
@@ -106,7 +135,7 @@ public class Base64 {
    * As of version 1.2 this method will properly handle input containing junk characters (newlines and the like) rather than
    * throwing an error. It does this by pre-parsing the input and generating from that a count of VALID input characters.
    **/
-  static public byte[] decode(char[] data) {
+  public static byte[] decode(char[] data) {
     // as our input could contain non-BASE64 data (newlines,
     // whitespace of any sort, whatever) we must first adjust
     // our count of USABLE data so that...
@@ -169,31 +198,4 @@ public class Base64 {
 
     return out;
   }
-
-  //
-  // code characters for values 0..63
-  //
-  private static final char[] alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".toCharArray();
-
-  //
-  // lookup table for converting base64 characters to value in range 0..63
-  //
-  private static final byte[] codes = new byte[256];
-  static {
-    for (int i = 0; i < 256; i++) {
-      codes[i] = -1;
-    }
-    for (int i = 'A'; i <= 'Z'; i++) {
-      codes[i] = (byte) (i - 'A');
-    }
-    for (int i = 'a'; i <= 'z'; i++) {
-      codes[i] = (byte) (26 + i - 'a');
-    }
-    for (int i = '0'; i <= '9'; i++) {
-      codes[i] = (byte) (52 + i - '0');
-    }
-    codes['+'] = 62;
-    codes['/'] = 63;
-  }
-
 }

--- a/src/main/java/soot/tagkit/BytecodeOffsetTag.java
+++ b/src/main/java/soot/tagkit/BytecodeOffsetTag.java
@@ -28,12 +28,11 @@ package soot.tagkit;
  * @author Roman Manevich.
  * @since October 3 2002 Initial creation.
  */
-
 public class BytecodeOffsetTag implements Tag {
   /**
    * The index of the last byte-code instruction.
    */
-  protected int offset;
+  protected final int offset;
 
   /**
    * Constructs a tag from the index offset.
@@ -45,6 +44,7 @@ public class BytecodeOffsetTag implements Tag {
   /**
    * Returns the name of this tag.
    */
+  @Override
   public String getName() {
     return "BytecodeOffsetTag";
   }
@@ -52,14 +52,12 @@ public class BytecodeOffsetTag implements Tag {
   /**
    * Returns the offset in a four byte array.
    */
+  @Override
   public byte[] getValue() {
     byte[] v = new byte[4];
     v[0] = (byte) ((offset >> 24) % 256);
-    ;
     v[1] = (byte) ((offset >> 16) % 256);
-    ;
     v[2] = (byte) ((offset >> 8) % 256);
-    ;
     v[3] = (byte) (offset % 256);
     return v;
   }
@@ -74,7 +72,8 @@ public class BytecodeOffsetTag implements Tag {
   /**
    * Returns the offset in a string.
    */
+  @Override
   public String toString() {
-    return "" + offset;
+    return Integer.toString(offset);
   }
 }

--- a/src/main/java/soot/tagkit/ColorTag.java
+++ b/src/main/java/soot/tagkit/ColorTag.java
@@ -27,17 +27,6 @@ import org.slf4j.LoggerFactory;
 
 public class ColorTag implements Tag {
   private static final Logger logger = LoggerFactory.getLogger(ColorTag.class);
-  /* it is a value representing red. */
-  private int red;
-  /* it is a value representing green. */
-  private int green;
-  /* it is a value representing blue. */
-  private int blue;
-  /*
-   * for highlighting foreground of text default is to higlight background
-   */
-  private boolean foreground = false;
-  private String analysisType = "Unknown";
 
   public static final int RED = 0;
   public static final int GREEN = 1;
@@ -46,86 +35,98 @@ public class ColorTag implements Tag {
   public static final int ORANGE = 4;
   public static final int PURPLE = 5;
 
-  public ColorTag(int r, int g, int b, boolean fg) {
-    red = r;
-    green = g;
-    blue = b;
-    foreground = fg;
-  }
+  private static final boolean DEFAULT_FOREGROUND = false;
+  private static final String DEFAULT_ANALYSIS_TYPE = "Unknown";
+
+  /* it is a value representing red. */
+  private final int red;
+  /* it is a value representing green. */
+  private final int green;
+  /* it is a value representing blue. */
+  private final int blue;
+  /* for highlighting foreground of text default is to higlight background */
+  private final boolean foreground;
+  private final String analysisType;
 
   public ColorTag(int r, int g, int b) {
-    this(r, g, b, false);
+    this(r, g, b, DEFAULT_FOREGROUND, DEFAULT_ANALYSIS_TYPE);
+  }
+
+  public ColorTag(int r, int g, int b, boolean fg) {
+    this(r, g, b, fg, DEFAULT_ANALYSIS_TYPE);
   }
 
   public ColorTag(int r, int g, int b, String type) {
-    this(r, g, b, false, type);
+    this(r, g, b, DEFAULT_FOREGROUND, type);
   }
 
   public ColorTag(int r, int g, int b, boolean fg, String type) {
-    this(r, g, b, false);
-    analysisType = type;
-  }
-
-  public ColorTag(int color, String type) {
-    this(color, false, type);
-  }
-
-  public ColorTag(int color, boolean fg, String type) {
-    this(color, fg);
-    analysisType = type;
+    this.red = r;
+    this.green = g;
+    this.blue = b;
+    this.foreground = fg;
+    this.analysisType = type;
   }
 
   public ColorTag(int color) {
-    this(color, false);
+    this(color, DEFAULT_FOREGROUND, DEFAULT_ANALYSIS_TYPE);
+  }
+
+  public ColorTag(int color, String type) {
+    this(color, DEFAULT_FOREGROUND, type);
   }
 
   public ColorTag(int color, boolean fg) {
-    // logger.debug("color: "+color);
+    this(color, fg, DEFAULT_ANALYSIS_TYPE);
+  }
+
+  public ColorTag(int color, boolean fg, String type) {
     switch (color) {
       case RED: {
-        red = 255;
-        green = 0;
-        blue = 0;
+        this.red = 255;
+        this.green = 0;
+        this.blue = 0;
         break;
       }
       case GREEN: {
-        red = 45;
-        green = 255;
-        blue = 84;
+        this.red = 45;
+        this.green = 255;
+        this.blue = 84;
         break;
       }
       case YELLOW: {
-        red = 255;
-        green = 248;
-        blue = 35;
+        this.red = 255;
+        this.green = 248;
+        this.blue = 35;
         break;
       }
       case BLUE: {
-        red = 174;
-        green = 210;
-        blue = 255;
+        this.red = 174;
+        this.green = 210;
+        this.blue = 255;
         break;
       }
       case ORANGE: {
-        red = 255;
-        green = 163;
-        blue = 0;
+        this.red = 255;
+        this.green = 163;
+        this.blue = 0;
         break;
       }
       case PURPLE: {
-        red = 159;
-        green = 34;
-        blue = 193;
+        this.red = 159;
+        this.green = 34;
+        this.blue = 193;
         break;
       }
       default: {
-        red = 220;
-        green = 220;
-        blue = 220;
+        this.red = 220;
+        this.green = 220;
+        this.blue = 220;
         break;
       }
     }
-    foreground = fg;
+    this.foreground = fg;
+    this.analysisType = type;
   }
 
   public String getAnalysisType() {
@@ -148,17 +149,18 @@ public class ColorTag implements Tag {
     return foreground;
   }
 
+  @Override
   public String getName() {
     return "ColorTag";
   }
 
+  @Override
   public byte[] getValue() {
-    byte[] v = new byte[2];
-    return v;
+    return new byte[2];
   }
 
+  @Override
   public String toString() {
     return "" + red + " " + green + " " + blue;
   }
-
 }

--- a/src/main/java/soot/tagkit/ConstantValueTag.java
+++ b/src/main/java/soot/tagkit/ConstantValueTag.java
@@ -27,22 +27,27 @@ import java.util.Arrays;
 import soot.jimple.Constant;
 
 public abstract class ConstantValueTag implements Tag {
-  protected byte[] bytes; // encoded constant
 
-  protected ConstantValueTag() {
+  protected final byte[] bytes; // encoded constant
+
+  protected ConstantValueTag(byte[] bytes) {
+    this.bytes = bytes;
   }
 
+  @Override
   public String getName() {
     String className = getClass().getName();
     return className.substring(className.lastIndexOf('.') + 1);
   }
 
+  @Override
   public byte[] getValue() {
     return bytes;
   }
 
   public abstract Constant getConstant();
 
+  @Override
   public abstract String toString();
 
   @Override
@@ -58,17 +63,10 @@ public abstract class ConstantValueTag implements Tag {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (obj == null || this.getClass() != obj.getClass()) {
       return false;
     }
     ConstantValueTag other = (ConstantValueTag) obj;
-    if (!Arrays.equals(bytes, other.bytes)) {
-      return false;
-    }
-    return true;
+    return Arrays.equals(bytes, other.bytes);
   }
-
 }

--- a/src/main/java/soot/tagkit/DebugTypeTag.java
+++ b/src/main/java/soot/tagkit/DebugTypeTag.java
@@ -25,27 +25,30 @@ package soot.tagkit;
 /**
  * Represents the signature attribute used by fields, methods and classes for dealing with generics in Java 1.5.
  */
-
 public class DebugTypeTag extends SignatureTag {
 
   public DebugTypeTag(String signature) {
     super(signature);
   }
 
+  @Override
   public String toString() {
     return "DebugType: " + getSignature();
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "DebugTypeTag";
   }
 
+  @Override
   public String getInfo() {
     return "DebugType";
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("DebugTypeTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/DeprecatedTag.java
+++ b/src/main/java/soot/tagkit/DeprecatedTag.java
@@ -25,17 +25,18 @@ package soot.tagkit;
 /**
  * Represents the deprecated attribute used by fields, methods and classes
  */
-
 public class DeprecatedTag implements Tag {
 
   public DeprecatedTag() {
   }
 
+  @Override
   public String toString() {
     return "Deprecated";
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "DeprecatedTag";
   }
@@ -45,6 +46,7 @@ public class DeprecatedTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("DeprecatedTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/DoubleConstantValueTag.java
+++ b/src/main/java/soot/tagkit/DoubleConstantValueTag.java
@@ -25,6 +25,7 @@ package soot.tagkit;
 import soot.jimple.DoubleConstant;
 
 public class DoubleConstantValueTag extends ConstantValueTag {
+
   private final double value;
 
   public double getDoubleValue() {
@@ -32,9 +33,11 @@ public class DoubleConstantValueTag extends ConstantValueTag {
   }
 
   public DoubleConstantValueTag(double val) {
+    super(null);
     this.value = val;
   }
 
+  @Override
   public String toString() {
     return "ConstantValue: " + Double.toString(value);
   }
@@ -48,8 +51,7 @@ public class DoubleConstantValueTag extends ConstantValueTag {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    long temp;
-    temp = Double.doubleToLongBits(value);
+    long temp = Double.doubleToLongBits(value);
     result = prime * result + (int) (temp ^ (temp >>> 32));
     return result;
   }
@@ -62,14 +64,10 @@ public class DoubleConstantValueTag extends ConstantValueTag {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     DoubleConstantValueTag other = (DoubleConstantValueTag) obj;
-    if (Double.doubleToLongBits(value) != Double.doubleToLongBits(other.value)) {
-      return false;
-    }
-    return true;
+    return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
   }
-
 }

--- a/src/main/java/soot/tagkit/EnclosingMethodTag.java
+++ b/src/main/java/soot/tagkit/EnclosingMethodTag.java
@@ -23,15 +23,14 @@ package soot.tagkit;
  */
 
 /**
- * Represents the enclosing method attribute attatched to anon and inner classes to indicate the class and method it is
+ * Represents the enclosing method attribute attached to anon and inner classes to indicate the class and method it is
  * declared in for Java 1.5.
  */
-
 public class EnclosingMethodTag implements Tag {
 
-  private String enclosingClass;
-  private String enclosingMethod;
-  private String enclosingMethodSig;
+  private final String enclosingClass;
+  private final String enclosingMethod;
+  private final String enclosingMethodSig;
 
   public EnclosingMethodTag(String c, String m, String s) {
     this.enclosingClass = c;
@@ -39,11 +38,13 @@ public class EnclosingMethodTag implements Tag {
     this.enclosingMethodSig = s;
   }
 
+  @Override
   public String toString() {
     return "Enclosing Class: " + enclosingClass + " Enclosing Method: " + enclosingMethod + " Sig: " + enclosingMethodSig;
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "EnclosingMethodTag";
   }
@@ -65,6 +66,7 @@ public class EnclosingMethodTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("EnclosingMethodTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/EnclosingTag.java
+++ b/src/main/java/soot/tagkit/EnclosingTag.java
@@ -25,12 +25,11 @@ package soot.tagkit;
 /**
  * Represents the synthetic attribute.
  */
-
 public class EnclosingTag extends SyntheticParamTag {
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "EnclosingTag";
   }
-
 }

--- a/src/main/java/soot/tagkit/FirstTagAggregator.java
+++ b/src/main/java/soot/tagkit/FirstTagAggregator.java
@@ -30,19 +30,13 @@ import soot.Unit;
  * A tag aggregator that associates a tag with the <b>first</b> instruction that is tagged with it.
  */
 public abstract class FirstTagAggregator extends TagAggregator {
-  /** Decide whether this tag should be aggregated by this aggregator. */
-  public abstract boolean wantTag(Tag t);
-
-  /** Return name of the resulting aggregated tag. */
-  public abstract String aggregatedName();
 
   /** Decide whether this tag should be aggregated by this aggregator. */
   @Override
   public void considerTag(Tag t, Unit u, LinkedList<Tag> tags, LinkedList<Unit> units) {
-    if (units.size() > 0 && units.getLast() == u) {
-      return;
+    if (units.size() <= 0 || units.getLast() != u) {
+      units.add(u);
+      tags.add(t);
     }
-    units.add(u);
-    tags.add(t);
   }
 }

--- a/src/main/java/soot/tagkit/FloatConstantValueTag.java
+++ b/src/main/java/soot/tagkit/FloatConstantValueTag.java
@@ -25,9 +25,11 @@ package soot.tagkit;
 import soot.jimple.FloatConstant;
 
 public class FloatConstantValueTag extends ConstantValueTag {
+
   private final float value;
 
   public FloatConstantValueTag(float value) {
+    super(null);
     this.value = value;
   }
 
@@ -35,6 +37,7 @@ public class FloatConstantValueTag extends ConstantValueTag {
     return value;
   }
 
+  @Override
   public String toString() {
     return "ConstantValue: " + Float.toString(value);
   }
@@ -60,14 +63,10 @@ public class FloatConstantValueTag extends ConstantValueTag {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     FloatConstantValueTag other = (FloatConstantValueTag) obj;
-    if (Float.floatToIntBits(value) != Float.floatToIntBits(other.value)) {
-      return false;
-    }
-    return true;
+    return Float.floatToIntBits(this.value) == Float.floatToIntBits(other.value);
   }
-
 }

--- a/src/main/java/soot/tagkit/GenericAttribute.java
+++ b/src/main/java/soot/tagkit/GenericAttribute.java
@@ -22,6 +22,7 @@ package soot.tagkit;
  * #L%
  */
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,29 +35,31 @@ import soot.UnitBox;
  * @see CodeAttribute
  */
 public class GenericAttribute implements Attribute {
+
   private final String mName;
   private byte[] mValue;
 
   public GenericAttribute(String name, byte[] value) {
-    if (value == null) {
-      value = new byte[0];
-    }
-    mName = name;
-    mValue = value;
+    this.mName = name;
+    this.mValue = value != null ? value : new byte[0];
   }
 
+  @Override
   public String getName() {
     return mName;
   }
 
+  @Override
   public byte[] getValue() {
     return mValue;
   }
 
+  @Override
   public String toString() {
-    return mName + " " + Base64.encode(mValue).toString();
+    return mName + ' ' + Arrays.toString(Base64.encode(mValue));
   }
 
+  @Override
   public void setValue(byte[] value) {
     mValue = value;
   }

--- a/src/main/java/soot/tagkit/ImportantTagAggregator.java
+++ b/src/main/java/soot/tagkit/ImportantTagAggregator.java
@@ -32,20 +32,14 @@ import soot.baf.Inst;
  * is important if it contains a field or array reference, a method invocation, or an object allocation.
  */
 public abstract class ImportantTagAggregator extends TagAggregator {
-  /** Decide whether this tag should be aggregated by this aggregator. */
-  public abstract boolean wantTag(Tag t);
-
-  /** Return name of the resulting aggregated tag. */
-  public abstract String aggregatedName();
 
   /** Decide whether this tag should be aggregated by this aggregator. */
   @Override
   public void considerTag(Tag t, Unit u, LinkedList<Tag> tags, LinkedList<Unit> units) {
     Inst i = (Inst) u;
-    if (!(i.containsInvokeExpr() || i.containsFieldRef() || i.containsArrayRef() || i.containsNewExpr())) {
-      return;
+    if (i.containsInvokeExpr() || i.containsFieldRef() || i.containsArrayRef() || i.containsNewExpr()) {
+      units.add(u);
+      tags.add(t);
     }
-    units.add(u);
-    tags.add(t);
   }
 }

--- a/src/main/java/soot/tagkit/InnerClassAttribute.java
+++ b/src/main/java/soot/tagkit/InnerClassAttribute.java
@@ -28,13 +28,14 @@ import java.util.List;
 
 /**
  * Represents an inner class attribute which can be attached to implementations of Host. It can be directly used to add
- * attributes to class files
- *
+ * attributes to class files.
  */
 public class InnerClassAttribute implements Tag {
-  private ArrayList<InnerClassTag> list = null;
+
+  private ArrayList<InnerClassTag> list;
 
   public InnerClassAttribute() {
+    this.list = null;
   }
 
   public InnerClassAttribute(ArrayList<InnerClassTag> list) {
@@ -44,28 +45,30 @@ public class InnerClassAttribute implements Tag {
   public String getClassSpecs() {
     if (list == null) {
       return "";
+    } else {
+      StringBuilder sb = new StringBuilder();
+      for (InnerClassTag ict : list) {
+        sb.append(".inner_class_spec_attr ");
+        sb.append(ict.getInnerClass());
+        sb.append(' ');
+        sb.append(ict.getOuterClass());
+        sb.append(' ');
+        sb.append(ict.getShortName());
+        sb.append(' ');
+        sb.append(ict.getAccessFlags());
+        sb.append(' ');
+        sb.append(".end .inner_class_spec_attr ");
+      }
+      return sb.toString();
     }
-
-    StringBuffer sb = new StringBuffer();
-    for (InnerClassTag ict : list) {
-      sb.append(".inner_class_spec_attr ");
-      sb.append(ict.getInnerClass());
-      sb.append(" ");
-      sb.append(ict.getOuterClass());
-      sb.append(" ");
-      sb.append(ict.getShortName());
-      sb.append(" ");
-      sb.append(ict.getAccessFlags());
-      sb.append(" ");
-      sb.append(".end .inner_class_spec_attr ");
-    }
-    return sb.toString();
   }
 
+  @Override
   public String getName() {
     return "InnerClassAttribute";
   }
 
+  @Override
   public byte[] getValue() throws AttributeValueException {
     return new byte[1];
   }
@@ -75,30 +78,30 @@ public class InnerClassAttribute implements Tag {
   }
 
   public void add(InnerClassTag newt) {
-    if (list != null) {
-      String new_inner = newt.getInnerClass();
-      for (InnerClassTag ict : this.list) {
-        String inner = ict.getInnerClass();
-        if (new_inner.equals(inner)) {
-          if (ict.accessFlags != 0 && newt.accessFlags > 0 && ict.accessFlags != newt.accessFlags) {
+    ArrayList<InnerClassTag> this_list = this.list;
+    if (this_list == null) {
+      this.list = this_list = new ArrayList<InnerClassTag>();
+    } else {
+      String newt_inner = newt.getInnerClass();
+      int newt_accessFlags = newt.getAccessFlags();
+      for (InnerClassTag ict : this_list) {
+        if (newt_inner.equals(ict.getInnerClass())) {
+          int ict_accessFlags = ict.getAccessFlags();
+          if (ict_accessFlags != 0 && newt_accessFlags > 0 && ict_accessFlags != newt_accessFlags) {
             throw new RuntimeException("Error: trying to add an InnerClassTag twice with different access flags! ("
-                + ict.accessFlags + " and " + newt.accessFlags + ")");
+                + ict_accessFlags + " and " + newt_accessFlags + ")");
           }
-          if (ict.accessFlags == 0 && newt.accessFlags != 0) {
+          if (ict_accessFlags == 0 && newt_accessFlags != 0) {
             // The Dalvik parser may find an InnerClass annotation without accessFlags in the outer class
             // and then an annotation with the accessFlags in the inner class.
             // When we have more information about the accessFlags we update the InnerClassTag.
-            list.remove(ict);
-            list.add(newt);
+            this_list.remove(ict);
+            this_list.add(newt);
           }
           return;
         }
       }
     }
-
-    if (list == null) {
-      list = new ArrayList<InnerClassTag>();
-    }
-    list.add(newt);
+    this_list.add(newt);
   }
 }

--- a/src/main/java/soot/tagkit/InnerClassTag.java
+++ b/src/main/java/soot/tagkit/InnerClassTag.java
@@ -25,10 +25,11 @@ package soot.tagkit;
 import java.io.UnsupportedEncodingException;
 
 public class InnerClassTag implements Tag {
-  String innerClass;
-  String outerClass;
-  String name;
-  int accessFlags;
+
+  private final String innerClass;
+  private final String outerClass;
+  private final String name;
+  private final int accessFlags;
 
   public InnerClassTag(String innerClass, String outerClass, String name, int accessFlags) {
     this.innerClass = innerClass;
@@ -37,11 +38,11 @@ public class InnerClassTag implements Tag {
     this.accessFlags = accessFlags;
     if (innerClass != null && (innerClass.startsWith("L") && innerClass.endsWith(";"))) {
       throw new RuntimeException(
-          "InnerClass annotation type string must " + "be of the form a/b/ClassName not '" + innerClass + "'");
+          "InnerClass annotation type string must be of the form a/b/ClassName not '" + innerClass + "'");
     }
     if (outerClass != null && (outerClass.startsWith("L") && outerClass.endsWith(";"))) {
       throw new RuntimeException(
-          "OuterType annotation type string must " + "be of the form a/b/ClassName not '" + innerClass + "'");
+          "OuterType annotation type string must be of the form a/b/ClassName not '" + innerClass + "'");
     }
     if (name != null && name.endsWith(";")) {
       throw new RuntimeException("InnerClass name cannot end with ';', got '" + name + "'");
@@ -55,7 +56,7 @@ public class InnerClassTag implements Tag {
 
   /**
    * Returns the inner class name (only) encoded in UTF8. There is no obvious standalone byte[] encoding for this attribute
-   * because it contains embedded constant pool indicies.
+   * because it contains embedded constant pool indices.
    */
   @Override
   public byte[] getValue() {

--- a/src/main/java/soot/tagkit/InnerClassTagAggregator.java
+++ b/src/main/java/soot/tagkit/InnerClassTagAggregator.java
@@ -23,7 +23,6 @@ package soot.tagkit;
  */
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map;
 
 import soot.G;
@@ -46,11 +45,10 @@ public class InnerClassTagAggregator extends SceneTransformer {
     return "InnerClasses";
   }
 
+  @Override
   public void internalTransform(String phaseName, Map<String, String> options) {
-    Iterator<SootClass> it = Scene.v().getApplicationClasses().iterator();
-    while (it.hasNext()) {
+    for (SootClass nextSc : Scene.v().getApplicationClasses()) {
       ArrayList<InnerClassTag> list = new ArrayList<InnerClassTag>();
-      SootClass nextSc = it.next();
       for (Tag t : nextSc.getTags()) {
         if (t instanceof InnerClassTag) {
           list.add((InnerClassTag) t);

--- a/src/main/java/soot/tagkit/IntegerConstantValueTag.java
+++ b/src/main/java/soot/tagkit/IntegerConstantValueTag.java
@@ -25,18 +25,20 @@ package soot.tagkit;
 import soot.jimple.IntConstant;
 
 public class IntegerConstantValueTag extends ConstantValueTag {
+
   private final int value;
 
   public IntegerConstantValueTag(int value) {
+    super(new byte[] { (byte) ((value >> 24) & 0xff), (byte) ((value >> 16) & 0xff), (byte) ((value >> 8) & 0xff),
+        (byte) ((value) & 0xff) });
     this.value = value;
-    this.bytes = new byte[] { (byte) ((value >> 24) & 0xff), (byte) ((value >> 16) & 0xff), (byte) ((value >> 8) & 0xff),
-        (byte) ((value) & 0xff) };
   }
 
   public int getIntValue() {
     return value;
   }
 
+  @Override
   public String toString() {
     return "ConstantValue: " + Integer.toString(value);
   }
@@ -62,14 +64,10 @@ public class IntegerConstantValueTag extends ConstantValueTag {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     IntegerConstantValueTag other = (IntegerConstantValueTag) obj;
-    if (value != other.value) {
-      return false;
-    }
-    return true;
+    return this.value == other.value;
   }
-
 }

--- a/src/main/java/soot/tagkit/JasminAttribute.java
+++ b/src/main/java/soot/tagkit/JasminAttribute.java
@@ -33,7 +33,6 @@ import soot.Unit;
  * stream at the location where the value of their pc is to occur. For example:
  *
  * <pre>
- *
     aload_1
     iload_2
     label2:
@@ -53,9 +52,9 @@ import soot.Unit;
  * </pre>
  *
  */
-
 public abstract class JasminAttribute implements Attribute {
-  abstract public byte[] decode(String attr, Hashtable<String, Integer> labelToPc);
 
-  abstract public String getJasminValue(Map<Unit, String> instToLabel);
+  public abstract byte[] decode(String attr, Hashtable<String, Integer> labelToPc);
+
+  public abstract String getJasminValue(Map<Unit, String> instToLabel);
 }

--- a/src/main/java/soot/tagkit/JimpleLineNumberTag.java
+++ b/src/main/java/soot/tagkit/JimpleLineNumberTag.java
@@ -23,18 +23,19 @@ package soot.tagkit;
  */
 
 public class JimpleLineNumberTag implements Tag {
+
   /* it is a value representing line number. */
   private final int startLineNumber;
   private final int endLineNumber;
 
   public JimpleLineNumberTag(int ln) {
-    startLineNumber = ln;
-    endLineNumber = ln;
+    this.startLineNumber = ln;
+    this.endLineNumber = ln;
   }
 
   public JimpleLineNumberTag(int startLn, int endLn) {
-    startLineNumber = startLn;
-    endLineNumber = endLn;
+    this.startLineNumber = startLn;
+    this.endLineNumber = endLn;
   }
 
   public int getLineNumber() {
@@ -49,17 +50,18 @@ public class JimpleLineNumberTag implements Tag {
     return endLineNumber;
   }
 
+  @Override
   public String getName() {
     return "JimpleLineNumberTag";
   }
 
+  @Override
   public byte[] getValue() {
-    byte[] v = new byte[2];
-    return v;
+    return new byte[2];
   }
 
+  @Override
   public String toString() {
     return "Jimple Line Tag: " + startLineNumber;
   }
-
 }

--- a/src/main/java/soot/tagkit/KeyTag.java
+++ b/src/main/java/soot/tagkit/KeyTag.java
@@ -24,76 +24,71 @@ package soot.tagkit;
 
 public class KeyTag implements Tag {
 
-  private int red;
-  private int green;
-  private int blue;
-  private String key;
-  private String analysisType;
-
-  /*
-   * public KeyTag(int r, int g, int b, String k){ this(r, g, b, k, "Unknown"); }
-   */
+  private final int red;
+  private final int green;
+  private final int blue;
+  private final String key;
+  private final String analysisType;
 
   public KeyTag(int r, int g, int b, String k, String type) {
-    red = r;
-    green = g;
-    blue = b;
-    key = k;
-    analysisType = type;
+    this.red = r;
+    this.green = g;
+    this.blue = b;
+    this.key = k;
+    this.analysisType = type;
   }
 
   public KeyTag(int color, String k, String type) {
-    this(color, k);
-    analysisType = type;
-  }
-
-  public KeyTag(int color, String k) {
     switch (color) {
       case ColorTag.RED: {
-        red = 255;
-        green = 0;
-        blue = 0;
+        this.red = 255;
+        this.green = 0;
+        this.blue = 0;
         break;
       }
       case ColorTag.GREEN: {
-        red = 45;
-        green = 255;
-        blue = 84;
+        this.red = 45;
+        this.green = 255;
+        this.blue = 84;
         break;
       }
       case ColorTag.YELLOW: {
-        red = 255;
-        green = 248;
-        blue = 35;
+        this.red = 255;
+        this.green = 248;
+        this.blue = 35;
         break;
       }
       case ColorTag.BLUE: {
-        red = 174;
-        green = 210;
-        blue = 255;
+        this.red = 174;
+        this.green = 210;
+        this.blue = 255;
         break;
       }
       case ColorTag.ORANGE: {
-        red = 255;
-        green = 163;
-        blue = 0;
+        this.red = 255;
+        this.green = 163;
+        this.blue = 0;
         break;
       }
       case ColorTag.PURPLE: {
-        red = 159;
-        green = 34;
-        blue = 193;
+        this.red = 159;
+        this.green = 34;
+        this.blue = 193;
         break;
       }
       default: {
-        red = 220;
-        green = 220;
-        blue = 220;
+        this.red = 220;
+        this.green = 220;
+        this.blue = 220;
         break;
       }
-
     }
-    key = k;
+    this.key = k;
+    this.analysisType = type;
+  }
+
+  public KeyTag(int color, String k) {
+    this(color, k, null);
   }
 
   public int red() {
@@ -116,13 +111,13 @@ public class KeyTag implements Tag {
     return analysisType;
   }
 
+  @Override
   public String getName() {
     return "KeyTag";
   }
 
+  @Override
   public byte[] getValue() {
-    byte[] v = new byte[4];
-    return v;
+    return new byte[4];
   }
-
 }

--- a/src/main/java/soot/tagkit/LineNumberTag.java
+++ b/src/main/java/soot/tagkit/LineNumberTag.java
@@ -23,18 +23,22 @@ package soot.tagkit;
  */
 
 public class LineNumberTag implements Tag {
+
   public static final String IDENTIFIER = "LineNumberTag";
+
   /* it is a u2 value representing line number. */
   protected int line_number;
 
   public LineNumberTag(int ln) {
-    line_number = ln;
+    this.line_number = ln;
   }
 
+  @Override
   public String getName() {
     return IDENTIFIER;
   }
 
+  @Override
   public byte[] getValue() {
     byte[] v = new byte[2];
     v[0] = (byte) (line_number / 256);
@@ -50,8 +54,8 @@ public class LineNumberTag implements Tag {
     line_number = value;
   }
 
+  @Override
   public String toString() {
     return String.valueOf(line_number);
   }
-
 }

--- a/src/main/java/soot/tagkit/LineNumberTagAggregator.java
+++ b/src/main/java/soot/tagkit/LineNumberTagAggregator.java
@@ -31,6 +31,7 @@ import soot.Unit;
 
 /** The aggregator for LineNumberTable attribute. */
 public class LineNumberTagAggregator extends FirstTagAggregator {
+
   public LineNumberTagAggregator(Singletons.Global g) {
   }
 
@@ -39,10 +40,12 @@ public class LineNumberTagAggregator extends FirstTagAggregator {
   }
 
   /** Decide whether this tag should be aggregated by this aggregator. */
+  @Override
   public boolean wantTag(Tag t) {
     return (t instanceof LineNumberTag) || (t instanceof SourceLnPosTag);
   }
 
+  @Override
   public String aggregatedName() {
     return "LineNumberTable";
   }

--- a/src/main/java/soot/tagkit/LinkTag.java
+++ b/src/main/java/soot/tagkit/LinkTag.java
@@ -25,10 +25,10 @@ package soot.tagkit;
 /**
  * Represents a tag that just has a string to be printed with the code.
  */
-
 public class LinkTag extends StringTag {
-  Host link;
-  String className;
+
+  private final Host link;
+  private final String className;
 
   public LinkTag(String string, Host link, String className, String type) {
     super(string, type);
@@ -42,10 +42,6 @@ public class LinkTag extends StringTag {
     this.className = className;
   }
 
-  public String toString() {
-    return s;
-  }
-
   public String getClassName() {
     return className;
   }
@@ -55,11 +51,13 @@ public class LinkTag extends StringTag {
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "StringTag";
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("StringTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/LongConstantValueTag.java
+++ b/src/main/java/soot/tagkit/LongConstantValueTag.java
@@ -25,19 +25,21 @@ package soot.tagkit;
 import soot.jimple.LongConstant;
 
 public class LongConstantValueTag extends ConstantValueTag {
+
   private final long value;
 
   public LongConstantValueTag(long value) {
-    this.value = value;
-    this.bytes = new byte[] { (byte) ((value >> 56) & 0xff), (byte) ((value >> 48) & 0xff), (byte) ((value >> 40) & 0xff),
+    super(new byte[] { (byte) ((value >> 56) & 0xff), (byte) ((value >> 48) & 0xff), (byte) ((value >> 40) & 0xff),
         (byte) ((value >> 32) & 0xff), (byte) ((value >> 24) & 0xff), (byte) ((value >> 16) & 0xff),
-        (byte) ((value >> 8) & 0xff), (byte) ((value) & 0xff) };
+        (byte) ((value >> 8) & 0xff), (byte) ((value) & 0xff) });
+    this.value = value;
   }
 
   public long getLongValue() {
     return value;
   }
 
+  @Override
   public String toString() {
     return "ConstantValue: " + Long.toString(value);
   }
@@ -63,14 +65,10 @@ public class LongConstantValueTag extends ConstantValueTag {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     LongConstantValueTag other = (LongConstantValueTag) obj;
-    if (value != other.value) {
-      return false;
-    }
-    return true;
+    return this.value == other.value;
   }
-
 }

--- a/src/main/java/soot/tagkit/LoopInvariantTag.java
+++ b/src/main/java/soot/tagkit/LoopInvariantTag.java
@@ -25,7 +25,6 @@ package soot.tagkit;
 /**
  * Represents a tag that just has a string to be printed with the code.
  */
-
 public class LoopInvariantTag extends StringTag {
 
   public LoopInvariantTag(String s) {
@@ -33,6 +32,7 @@ public class LoopInvariantTag extends StringTag {
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "LoopInvariantTag";
   }

--- a/src/main/java/soot/tagkit/OuterClassTag.java
+++ b/src/main/java/soot/tagkit/OuterClassTag.java
@@ -27,9 +27,10 @@ import java.io.UnsupportedEncodingException;
 import soot.SootClass;
 
 public class OuterClassTag implements Tag {
-  SootClass outerClass;
-  String simpleName;
-  boolean anon;
+
+  private final SootClass outerClass;
+  private final String simpleName;
+  private final boolean anon;
 
   public OuterClassTag(SootClass outer, String simpleName, boolean anon) {
     this.outerClass = outer;
@@ -37,12 +38,14 @@ public class OuterClassTag implements Tag {
     this.anon = anon;
   }
 
+  @Override
   public String getName() {
     return "OuterClassTag";
   }
 
   /**
    */
+  @Override
   public byte[] getValue() {
     try {
       return outerClass.getName().getBytes("UTF8");
@@ -63,6 +66,7 @@ public class OuterClassTag implements Tag {
     return anon;
   }
 
+  @Override
   public String toString() {
     return "[outer class=" + outerClass.getName() + "]";
   }

--- a/src/main/java/soot/tagkit/ParamNamesTag.java
+++ b/src/main/java/soot/tagkit/ParamNamesTag.java
@@ -28,9 +28,9 @@ import java.util.List;
 /**
  * Represents a tag that just has a string to be printed with the code.
  */
-
 public class ParamNamesTag implements Tag {
-  String[] names;
+
+  private final String[] names;
 
   /**
    * Backwards compatibility
@@ -42,12 +42,12 @@ public class ParamNamesTag implements Tag {
   }
 
   public ParamNamesTag(String[] parameterNames) {
-    names = parameterNames;
+    this.names = parameterNames;
   }
 
   @Override
   public String toString() {
-    return names.toString();
+    return Arrays.toString(names);
   }
 
   public List<String> getNames() {

--- a/src/main/java/soot/tagkit/PositionTag.java
+++ b/src/main/java/soot/tagkit/PositionTag.java
@@ -23,6 +23,7 @@ package soot.tagkit;
  */
 
 public class PositionTag implements Tag {
+
   /* it is a value representing end offset. */
   private final int endOffset;
 
@@ -30,9 +31,8 @@ public class PositionTag implements Tag {
   private final int startOffset;
 
   public PositionTag(int start, int end) {
-    startOffset = start;
-    endOffset = end;
-
+    this.startOffset = start;
+    this.endOffset = end;
   }
 
   public int getEndOffset() {
@@ -43,17 +43,18 @@ public class PositionTag implements Tag {
     return startOffset;
   }
 
+  @Override
   public String getName() {
     return "PositionTag";
   }
 
+  @Override
   public byte[] getValue() {
-    byte[] v = new byte[2];
-    return v;
+    return new byte[2];
   }
 
+  @Override
   public String toString() {
     return "Jimple pos tag: spos: " + startOffset + " epos: " + endOffset;
   }
-
 }

--- a/src/main/java/soot/tagkit/QualifyingTag.java
+++ b/src/main/java/soot/tagkit/QualifyingTag.java
@@ -25,12 +25,11 @@ package soot.tagkit;
 /**
  * Represents the synthetic attribute.
  */
-
 public class QualifyingTag extends SyntheticParamTag {
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "QualifyingTag";
   }
-
 }

--- a/src/main/java/soot/tagkit/SignatureTag.java
+++ b/src/main/java/soot/tagkit/SignatureTag.java
@@ -29,7 +29,7 @@ public class SignatureTag implements Tag {
 
   public static final String NAME = SignatureTag.class.getSimpleName();
 
-  private String signature;
+  private final String signature;
 
   public SignatureTag(String signature) {
     this.signature = signature;
@@ -59,5 +59,4 @@ public class SignatureTag implements Tag {
   public String toString() {
     return "Signature: " + signature;
   }
-
 }

--- a/src/main/java/soot/tagkit/SourceFileTag.java
+++ b/src/main/java/soot/tagkit/SourceFileTag.java
@@ -73,5 +73,4 @@ public class SourceFileTag implements Tag {
   public String toString() {
     return sourceFile;
   }
-
 }

--- a/src/main/java/soot/tagkit/SourceLineNumberTag.java
+++ b/src/main/java/soot/tagkit/SourceLineNumberTag.java
@@ -23,18 +23,19 @@ package soot.tagkit;
  */
 
 public class SourceLineNumberTag implements Tag {
+
   /* it is a value representing line number. */
   protected int startLineNumber;
   protected int endLineNumber;
 
   public SourceLineNumberTag(int ln) {
-    startLineNumber = ln;
-    endLineNumber = ln;
+    this.startLineNumber = ln;
+    this.endLineNumber = ln;
   }
 
   public SourceLineNumberTag(int startLn, int endLn) {
-    startLineNumber = startLn;
-    endLineNumber = endLn;
+    this.startLineNumber = startLn;
+    this.endLineNumber = endLn;
   }
 
   public int getLineNumber() {
@@ -62,17 +63,19 @@ public class SourceLineNumberTag implements Tag {
     this.endLineNumber = value;
   }
 
+  @Override
   public String getName() {
     return "SourceLineNumberTag";
   }
 
+  @Override
   public byte[] getValue() {
     byte[] v = new byte[2];
     return v;
   }
 
+  @Override
   public String toString() {
     return String.valueOf(startLineNumber);
   }
-
 }

--- a/src/main/java/soot/tagkit/SourceLnNamePosTag.java
+++ b/src/main/java/soot/tagkit/SourceLnNamePosTag.java
@@ -44,12 +44,12 @@ public class SourceLnNamePosTag extends SourceLnPosTag {
   /**
    * {@inheritDoc}
    */
+  @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append(super.toString());
     sb.append(" file: ");
     sb.append(fileName);
     return sb.toString();
   }
-
 }

--- a/src/main/java/soot/tagkit/SourceLnPosTag.java
+++ b/src/main/java/soot/tagkit/SourceLnPosTag.java
@@ -25,16 +25,17 @@ package soot.tagkit;
 public class SourceLnPosTag implements Tag {
 
   public static final String IDENTIFIER = "SourceLnPosTag";
+
   private final int startLn;
   private final int endLn;
   private final int startPos;
   private final int endPos;
 
   public SourceLnPosTag(int sline, int eline, int spos, int epos) {
-    startLn = sline;
-    endLn = eline;
-    startPos = spos;
-    endPos = epos;
+    this.startLn = sline;
+    this.endLn = eline;
+    this.startPos = spos;
+    this.endPos = epos;
   }
 
   public int startLn() {
@@ -53,10 +54,12 @@ public class SourceLnPosTag implements Tag {
     return endPos;
   }
 
+  @Override
   public String getName() {
     return IDENTIFIER;
   }
 
+  @Override
   public byte[] getValue() {
     byte[] v = new byte[2];
     v[0] = (byte) (startLn / 256);
@@ -64,17 +67,14 @@ public class SourceLnPosTag implements Tag {
     return v;
   }
 
+  @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("Source Line Pos Tag: ");
-    sb.append("sline: ");
-    sb.append(startLn);
-    sb.append(" eline: ");
-    sb.append(endLn);
-    sb.append(" spos: ");
-    sb.append(startPos);
-    sb.append(" epos: ");
-    sb.append(endPos);
+    sb.append("sline: ").append(startLn);
+    sb.append(" eline: ").append(endLn);
+    sb.append(" spos: ").append(startPos);
+    sb.append(" epos: ").append(endPos);
     return sb.toString();
   }
 }

--- a/src/main/java/soot/tagkit/SourcePositionTag.java
+++ b/src/main/java/soot/tagkit/SourcePositionTag.java
@@ -23,10 +23,12 @@ package soot.tagkit;
  */
 
 public class SourcePositionTag extends PositionTag {
+
   public SourcePositionTag(int i, int j) {
     super(i, j);
   }
 
+  @Override
   public String getName() {
     return "SourcePositionTag";
   }

--- a/src/main/java/soot/tagkit/StringConstantValueTag.java
+++ b/src/main/java/soot/tagkit/StringConstantValueTag.java
@@ -26,17 +26,19 @@ import soot.coffi.CONSTANT_Utf8_info;
 import soot.jimple.StringConstant;
 
 public class StringConstantValueTag extends ConstantValueTag {
+
   private final String value;
 
   public StringConstantValueTag(String value) {
+    super(CONSTANT_Utf8_info.toUtf8(value));
     this.value = value;
-    this.bytes = CONSTANT_Utf8_info.toUtf8(value);
   }
 
   public String getStringValue() {
     return value;
   }
 
+  @Override
   public String toString() {
     return "ConstantValue: " + value;
   }
@@ -62,18 +64,17 @@ public class StringConstantValueTag extends ConstantValueTag {
     if (!super.equals(obj)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (this.getClass() != obj.getClass()) {
       return false;
     }
     StringConstantValueTag other = (StringConstantValueTag) obj;
-    if (value == null) {
+    if (this.value == null) {
       if (other.value != null) {
         return false;
       }
-    } else if (!value.equals(other.value)) {
+    } else if (!this.value.equals(other.value)) {
       return false;
     }
     return true;
   }
-
 }

--- a/src/main/java/soot/tagkit/StringTag.java
+++ b/src/main/java/soot/tagkit/StringTag.java
@@ -25,20 +25,21 @@ package soot.tagkit;
 /**
  * Represents a tag that just has a string to be printed with the code.
  */
-
 public class StringTag implements Tag {
-  String s;
-  private String analysisType = "Unknown";
+
+  private final String s;
+  private final String analysisType;
 
   public StringTag(String s, String type) {
-    this(s);
-    analysisType = type;
+    this.s = s;
+    this.analysisType = type;
   }
 
   public StringTag(String s) {
-    this.s = s;
+    this(s, "Unknown");
   }
 
+  @Override
   public String toString() {
     return s;
   }
@@ -48,6 +49,7 @@ public class StringTag implements Tag {
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "StringTag";
   }
@@ -57,6 +59,7 @@ public class StringTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("StringTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/SyntheticParamTag.java
+++ b/src/main/java/soot/tagkit/SyntheticParamTag.java
@@ -25,17 +25,18 @@ package soot.tagkit;
 /**
  * Represents the synthetic attribute.
  */
-
 public class SyntheticParamTag implements Tag {
 
   public SyntheticParamTag() {
   }
 
+  @Override
   public String toString() {
     return "SyntheticParamTag";
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "SyntheticParamTag";
   }
@@ -45,6 +46,7 @@ public class SyntheticParamTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("SyntheticParamTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/SyntheticTag.java
+++ b/src/main/java/soot/tagkit/SyntheticTag.java
@@ -25,17 +25,18 @@ package soot.tagkit;
 /**
  * Represents the synthetic attribute.
  */
-
 public class SyntheticTag implements Tag {
 
   public SyntheticTag() {
   }
 
+  @Override
   public String toString() {
     return "Synthetic";
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "SyntheticTag";
   }
@@ -45,6 +46,7 @@ public class SyntheticTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("SyntheticTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/TagAggregator.java
+++ b/src/main/java/soot/tagkit/TagAggregator.java
@@ -22,7 +22,6 @@ package soot.tagkit;
  * #L%
  */
 
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -32,8 +31,8 @@ import soot.Unit;
 import soot.baf.BafBody;
 
 /** Interface to aggregate tags of units. */
-
 public abstract class TagAggregator extends BodyTransformer {
+
   /** Decide whether this tag should be aggregated by this aggregator. */
   public abstract boolean wantTag(Tag t);
 
@@ -43,6 +42,7 @@ public abstract class TagAggregator extends BodyTransformer {
   /** Return name of the resulting aggregated tag. */
   public abstract String aggregatedName();
 
+  @Override
   protected void internalTransform(Body b, String phaseName, Map<String, String> options) {
     BafBody body = (BafBody) b;
 
@@ -50,10 +50,8 @@ public abstract class TagAggregator extends BodyTransformer {
     LinkedList<Unit> units = new LinkedList<Unit>();
 
     /* aggregate all tags */
-    for (Iterator<Unit> unitIt = body.getUnits().iterator(); unitIt.hasNext();) {
-      final Unit unit = unitIt.next();
-      for (Iterator<Tag> tagIt = unit.getTags().iterator(); tagIt.hasNext();) {
-        final Tag tag = tagIt.next();
+    for (Unit unit : body.getUnits()) {
+      for (Tag tag : unit.getTags()) {
         if (wantTag(tag)) {
           considerTag(tag, unit, tags, units);
         }
@@ -69,5 +67,4 @@ public abstract class TagAggregator extends BodyTransformer {
   /** Called after all tags for a method have been aggregated. */
   public void fini() {
   }
-
 }

--- a/src/main/java/soot/tagkit/ThrowCreatedByCompilerTag.java
+++ b/src/main/java/soot/tagkit/ThrowCreatedByCompilerTag.java
@@ -25,18 +25,19 @@ package soot.tagkit;
 /**
  * Represents a tag that just has a string to be printed with the code.
  */
-
 public class ThrowCreatedByCompilerTag implements Tag {
 
   public ThrowCreatedByCompilerTag() {
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "ThrowCreatedByCompilerTag";
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("ThrowCreatedByCompilerTag has no value for bytecode");
   }

--- a/src/main/java/soot/tagkit/TryCatchTag.java
+++ b/src/main/java/soot/tagkit/TryCatchTag.java
@@ -25,26 +25,29 @@ package soot.tagkit;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TryCatchTag implements soot.tagkit.Tag {
+import soot.Unit;
+
+public class TryCatchTag implements Tag {
 
   public static final String NAME = "TryCatchTag";
 
-  protected Map<soot.Unit, soot.Unit> handlerUnitToFallThroughUnit = new HashMap<soot.Unit, soot.Unit>();
+  protected Map<Unit, Unit> handlerUnitToFallThroughUnit = new HashMap<Unit, Unit>();
 
-  public void register(soot.Unit handler, soot.Unit fallThrough) {
+  public void register(Unit handler, Unit fallThrough) {
     handlerUnitToFallThroughUnit.put(handler, fallThrough);
   }
 
-  public soot.Unit getFallThroughUnitOf(soot.Unit handlerUnit) {
+  public Unit getFallThroughUnitOf(Unit handlerUnit) {
     return handlerUnitToFallThroughUnit.get(handlerUnit);
   }
 
+  @Override
   public String getName() {
     return NAME;
   }
 
+  @Override
   public byte[] getValue() throws AttributeValueException {
     throw new UnsupportedOperationException();
   }
-
 }

--- a/src/main/java/soot/tagkit/VisibilityAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityAnnotationTag.java
@@ -25,22 +25,26 @@ package soot.tagkit;
 import java.util.ArrayList;
 
 /**
- * Represents the visibility of an annotation attribute attatched to a class, field, method or method param (only one of
- * these each) has one or more annotations for Java 1.5.
+ * Represents the visibility of an annotation attribute attached to a class, field, method or method param (only one of these
+ * each) has one or more annotations for Java 1.5.
  */
-
 public class VisibilityAnnotationTag implements Tag {
 
-  private int visibility;
-  private ArrayList<AnnotationTag> annotations = null;
+  private final int visibility;
+  private ArrayList<AnnotationTag> annotations;
 
+  /**
+   * @param vis
+   *          one of {@link soot.tagkit.AnnotationConstants}
+   */
   public VisibilityAnnotationTag(int vis) {
     this.visibility = vis;
   }
 
-  // should also print here number of annotations and perhaps the annotations themselves
+  @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer("Visibility Annotation: level: ");
+    // should also print here number of annotations and perhaps the annotations themselves
+    StringBuilder sb = new StringBuilder("Visibility Annotation: level: ");
     switch (visibility) {
       case AnnotationConstants.RUNTIME_INVISIBLE:
         sb.append("CLASS (runtime-invisible)");
@@ -55,15 +59,16 @@ public class VisibilityAnnotationTag implements Tag {
     sb.append("\n Annotations:");
     if (annotations != null) {
       for (AnnotationTag tag : annotations) {
-        sb.append("\n");
+        sb.append('\n');
         sb.append(tag.toString());
       }
     }
-    sb.append("\n");
+    sb.append('\n');
     return sb.toString();
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "VisibilityAnnotationTag";
   }
@@ -77,6 +82,7 @@ public class VisibilityAnnotationTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("VisibilityAnnotationTag has no value for bytecode");
   }
@@ -93,6 +99,6 @@ public class VisibilityAnnotationTag implements Tag {
   }
 
   public boolean hasAnnotations() {
-    return annotations == null ? false : true;
+    return annotations != null && !annotations.isEmpty();
   }
 }

--- a/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
@@ -21,34 +21,40 @@ package soot.tagkit;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
+
 /**
  * Represents the visibility of an annotation attribute attached to method local variable. Only mark the local variable tag
  * different with{@link soot.tagkit.VisibilityParameterAnnotationTag}
  * 
  * @author raintung.li
- *
  */
-
 public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnnotationTag {
 
+  /**
+   * @param num
+   *          number of local variable annotations
+   * @param kind
+   *          one of {@link soot.tagkit.AnnotationConstants}
+   */
   public VisibilityLocalVariableAnnotationTag(int num, int kind) {
     super(num, kind);
   }
 
-  // should also print here number of annotations and perhaps the annotations themselves
+  @Override
   public String toString() {
+    // should also print here number of annotations and perhaps the annotations themselves
     int num_var = getVisibilityAnnotations() != null ? getVisibilityAnnotations().size() : 0;
-    StringBuffer sb
-        = new StringBuffer("Visibility LocalVariable Annotation: num Annotation: " + num_var + " kind: " + getKind());
+    StringBuilder sb = new StringBuilder("Visibility LocalVariable Annotation: num Annotation: ");
+    sb.append(num_var).append(" kind: ").append(getKind());
     if (num_var > 0) {
       for (VisibilityAnnotationTag tag : getVisibilityAnnotations()) {
-        sb.append("\n");
+        sb.append('\n');
         if (tag != null) {
           sb.append(tag.toString());
         }
       }
     }
-    sb.append("\n");
+    sb.append('\n');
     return sb.toString();
   }
 
@@ -57,6 +63,7 @@ public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnn
    * 
    * @return string
    */
+  @Override
   public String getName() {
     return "VisibilityLocalVariableAnnotationTag";
   }
@@ -66,6 +73,7 @@ public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnn
    * 
    * @return string
    */
+  @Override
   public String getInfo() {
     return "VisibilityLocalVariableAnnotation";
   }
@@ -75,8 +83,8 @@ public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnn
    * 
    * @return
    */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("VisibilityLocalVariableAnnotationTag has no value for bytecode");
   }
-
 }

--- a/src/main/java/soot/tagkit/VisibilityParameterAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityParameterAnnotationTag.java
@@ -25,37 +25,47 @@ package soot.tagkit;
 import java.util.ArrayList;
 
 /**
- * Represents the visibility of an annotation attribute attatched to a class, field, method or method param (only one of
- * these each) has one or more annotations for Java 1.5.
+ * Represents the visibility of an annotation attribute attached to a class, field, method or method param (only one of these
+ * each) has one or more annotations for Java 1.5.
  */
-
 public class VisibilityParameterAnnotationTag implements Tag {
 
-  private int num_params;
-  private int kind;
+  private final int num_params;
+  private final int kind;
   private ArrayList<VisibilityAnnotationTag> visibilityAnnotations;
 
+  /**
+   * NOTE: any parameter without annotations has a {@code null} entry in the list
+   * 
+   * @param num
+   *          total number of parameters
+   * @param kind
+   *          one of {@link soot.tagkit.AnnotationConstants}
+   */
   public VisibilityParameterAnnotationTag(int num, int kind) {
     this.num_params = num;
     this.kind = kind;
   }
 
-  // should also print here number of annotations and perhaps the annotations themselves
+  @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer("Visibility Param Annotation: num params: " + num_params + " kind: " + kind);
+    // should also print here number of annotations and perhaps the annotations themselves
+    StringBuilder sb = new StringBuilder("Visibility Param Annotation: num params: ");
+    sb.append(num_params).append(" kind: ").append(kind);
     if (visibilityAnnotations != null) {
       for (VisibilityAnnotationTag tag : visibilityAnnotations) {
-        sb.append("\n");
+        sb.append('\n');
         if (tag != null) {
           sb.append(tag.toString());
         }
       }
     }
-    sb.append("\n");
+    sb.append('\n');
     return sb.toString();
   }
 
   /** Returns the tag name. */
+  @Override
   public String getName() {
     return "VisibilityParameterAnnotationTag";
   }
@@ -65,6 +75,7 @@ public class VisibilityParameterAnnotationTag implements Tag {
   }
 
   /** Returns the tag raw data. */
+  @Override
   public byte[] getValue() {
     throw new RuntimeException("VisibilityParameterAnnotationTag has no value for bytecode");
   }


### PR DESCRIPTION
Remove StringBuffer, add override annotations, etc. Also added more restrictive access modifiers to some fields and reworked a few constructor patterns to make that work.