### PR TITLE
Make ArrayBoundsChecker a whole-program analysis to fix a concurrency bug

### DIFF
--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/testing/TestOptionsDialogHandler.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/testing/TestOptionsDialogHandler.java
@@ -1483,7 +1483,103 @@ public class TestOptionsDialogHandler {
 			cmd.append(COLON);
 			cmd.append(path);
 			cmd.append(SPACE);
-		}	
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"disabled";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = true;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"with-all";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"with-fieldref";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"with-arrayref";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"with-cse";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"with-classfield";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"with-rectarray";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
+
+		key = "p"+" "+"wjap.abc"+" "+"profiling";
+		value = settings.getBoolean(key.trim());
+
+		boolDefault = false;
+
+
+		if (value != boolDefault ) {
+			cmd.append(DASH);
+			cmd.append(key.trim());
+			cmd.append(SPACE);
+		}
 		
 		key = "p"+" "+"wjtp2"+" "+"disabled";
 		value = settings.getBoolean(key.trim());
@@ -1836,102 +1932,6 @@ public class TestOptionsDialogHandler {
 		}
 		
 		key = "p"+" "+"jap.npc"+" "+"profiling";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"disabled";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = true;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"with-all";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"with-fieldref";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"with-arrayref";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"with-cse";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"with-classfield";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"with-rectarray";
-		value = settings.getBoolean(key.trim());
-		
-		boolDefault = false;
-		
-		
-		if (value != boolDefault ) {
-			cmd.append(DASH);
-			cmd.append(key.trim());
-			cmd.append(SPACE);
-		}
-		
-		key = "p"+" "+"jap.abc"+" "+"profiling";
 		value = settings.getBoolean(key.trim());
 		
 		boolDefault = false;

--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
@@ -627,6 +627,26 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		getwjapwjap_purityannotate_widget().getButton().addSelectionListener(this);
 		getwjapwjap_purityverbose_widget().getButton().addSelectionListener(this);
 
+		makeNewEnableGroup("wjap", "wjap.abc");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcenabled_widget(), "enabled");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcwith_all_widget(), "with-all");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcwith_cse_widget(), "with-cse");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcwith_arrayref_widget(), "with-arrayref");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcwith_fieldref_widget(), "with-fieldref");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcwith_classfield_widget(), "with-classfield");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcwith_rectarray_widget(), "with-rectarray");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcprofiling_widget(), "profiling");
+		addToEnableGroup("wjap", "wjap.abc", getjapjap_abcadd_color_tags_widget(), "add-color-tags");
+		getjapjap_abcenabled_widget().getButton().addSelectionListener(this);
+		getjapjap_abcwith_all_widget().getButton().addSelectionListener(this);
+		getjapjap_abcwith_cse_widget().getButton().addSelectionListener(this);
+		getjapjap_abcwith_arrayref_widget().getButton().addSelectionListener(this);
+		getjapjap_abcwith_fieldref_widget().getButton().addSelectionListener(this);
+		getjapjap_abcwith_classfield_widget().getButton().addSelectionListener(this);
+		getjapjap_abcwith_rectarray_widget().getButton().addSelectionListener(this);
+		getjapjap_abcprofiling_widget().getButton().addSelectionListener(this);
+		getjapjap_abcadd_color_tags_widget().getButton().addSelectionListener(this);
+
 		makeNewEnableGroup("shimple");
 		addToEnableGroup("shimple", getshimpleenabled_widget(), "enabled");
 		addToEnableGroup("shimple", getshimplenode_elim_opt_widget(), "node-elim-opt");
@@ -749,26 +769,6 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		makeNewEnableGroup("jap", "jap.npcolorer");
 		addToEnableGroup("jap", "jap.npcolorer", getjapjap_npcolorerenabled_widget(), "enabled");
 		getjapjap_npcolorerenabled_widget().getButton().addSelectionListener(this);
-
-		makeNewEnableGroup("jap", "jap.abc");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcenabled_widget(), "enabled");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcwith_all_widget(), "with-all");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcwith_cse_widget(), "with-cse");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcwith_arrayref_widget(), "with-arrayref");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcwith_fieldref_widget(), "with-fieldref");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcwith_classfield_widget(), "with-classfield");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcwith_rectarray_widget(), "with-rectarray");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcprofiling_widget(), "profiling");
-		addToEnableGroup("jap", "jap.abc", getjapjap_abcadd_color_tags_widget(), "add-color-tags");
-		getjapjap_abcenabled_widget().getButton().addSelectionListener(this);
-		getjapjap_abcwith_all_widget().getButton().addSelectionListener(this);
-		getjapjap_abcwith_cse_widget().getButton().addSelectionListener(this);
-		getjapjap_abcwith_arrayref_widget().getButton().addSelectionListener(this);
-		getjapjap_abcwith_fieldref_widget().getButton().addSelectionListener(this);
-		getjapjap_abcwith_classfield_widget().getButton().addSelectionListener(this);
-		getjapjap_abcwith_rectarray_widget().getButton().addSelectionListener(this);
-		getjapjap_abcprofiling_widget().getButton().addSelectionListener(this);
-		getjapjap_abcadd_color_tags_widget().getButton().addSelectionListener(this);
 
 		makeNewEnableGroup("jap", "jap.profiling");
 		addToEnableGroup("jap", "jap.profiling", getjapjap_profilingenabled_widget(), "enabled");
@@ -15163,7 +15163,7 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		
 		
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"enabled";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"enabled";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15172,9 +15172,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcenabled_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("Enabled", "p phase-option", "jap.abc","enabled", "\n", defaultBool)));
+		setjapjap_abcenabled_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("Enabled", "p phase-option", "wjap.abc","enabled", "\n", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"with-all";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"with-all";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15183,9 +15183,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcwith_all_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With All", "p phase-option", "jap.abc","with-all", "\nSetting the With All option to true is equivalent to setting \neach of With CSE, With Array Ref, With Field Ref, With Class \nField, and With Rectangular Array to true.", defaultBool)));
+		setjapjap_abcwith_all_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With All", "p phase-option", "wjap.abc","with-all", "\nSetting the With All option to true is equivalent to setting \neach of With CSE, With Array Ref, With Field Ref, With Class \nField, and With Rectangular Array to true.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"with-cse";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"with-cse";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15194,9 +15194,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcwith_cse_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Common Sub-expressions", "p phase-option", "jap.abc","with-cse", "\nThe analysis will consider common subexpressions. For example, \nconsider the situation where r1 is assigned a*b; later, r2 is \nassigned a*b, where neither a nor b have changed between the two \nstatements. The analysis can conclude that r2 has the same value \nas r1. Experiments show that this option can improve the result \nslightly.", defaultBool)));
+		setjapjap_abcwith_cse_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Common Sub-expressions", "p phase-option", "wjap.abc","with-cse", "\nThe analysis will consider common subexpressions. For example, \nconsider the situation where r1 is assigned a*b; later, r2 is \nassigned a*b, where neither a nor b have changed between the two \nstatements. The analysis can conclude that r2 has the same value \nas r1. Experiments show that this option can improve the result \nslightly.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"with-arrayref";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"with-arrayref";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15205,9 +15205,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcwith_arrayref_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Array References", "p phase-option", "jap.abc","with-arrayref", "\nWith this option enabled, array references can be considered as \ncommon subexpressions; however, we are more conservative when \nwriting into an array, because array objects may be aliased. We \nalso assume that the application is single-threaded or that the \narray references occur in a synchronized block. That is, we \nassume that an array element may not be changed by other threads \nbetween two array references.", defaultBool)));
+		setjapjap_abcwith_arrayref_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Array References", "p phase-option", "wjap.abc","with-arrayref", "\nWith this option enabled, array references can be considered as \ncommon subexpressions; however, we are more conservative when \nwriting into an array, because array objects may be aliased. We \nalso assume that the application is single-threaded or that the \narray references occur in a synchronized block. That is, we \nassume that an array element may not be changed by other threads \nbetween two array references.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"with-fieldref";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"with-fieldref";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15216,9 +15216,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcwith_fieldref_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Field References", "p phase-option", "jap.abc","with-fieldref", "\nThe analysis treats field references (static and instance) as \ncommon subexpressions; however, we are more conservative when \nwriting to a field, because the base of the field reference may \nbe aliased. We also assume that the application is \nsingle-threaded or that the field references occur in a \nsynchronized block. That is, we assume that a field may not be \nchanged by other threads between two field references.", defaultBool)));
+		setjapjap_abcwith_fieldref_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Field References", "p phase-option", "wjap.abc","with-fieldref", "\nThe analysis treats field references (static and instance) as \ncommon subexpressions; however, we are more conservative when \nwriting to a field, because the base of the field reference may \nbe aliased. We also assume that the application is \nsingle-threaded or that the field references occur in a \nsynchronized block. That is, we assume that a field may not be \nchanged by other threads between two field references.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"with-classfield";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"with-classfield";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15227,9 +15227,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcwith_classfield_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Class Field", "p phase-option", "jap.abc","with-classfield", "\nThis option makes the analysis work on the class level. The \nalgorithm analyzes final or private class fields first. It can \nrecognize the fields that hold array objects of constant length. \nIn an application using lots of array fields, this option can \nimprove the analysis results dramatically.", defaultBool)));
+		setjapjap_abcwith_classfield_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Class Field", "p phase-option", "wjap.abc","with-classfield", "\nThis option makes the analysis work on the class level. The \nalgorithm analyzes final or private class fields first. It can \nrecognize the fields that hold array objects of constant length. \nIn an application using lots of array fields, this option can \nimprove the analysis results dramatically.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"with-rectarray";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"with-rectarray";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15238,9 +15238,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcwith_rectarray_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Rectangular Array", "p phase-option", "jap.abc","with-rectarray", "\nThis option is used together with wjap.ra to make Soot run the \nwhole-program analysis for rectangular array objects. This \nanalysis is based on the call graph, and it usually takes a long \ntime. If the application uses rectangular arrays, these options \ncan improve the analysis result.", defaultBool)));
+		setjapjap_abcwith_rectarray_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("With Rectangular Array", "p phase-option", "wjap.abc","with-rectarray", "\nThis option is used together with wjap.ra to make Soot run the \nwhole-program analysis for rectangular array objects. This \nanalysis is based on the call graph, and it usually takes a long \ntime. If the application uses rectangular arrays, these options \ncan improve the analysis result.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"profiling";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"profiling";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15249,9 +15249,9 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcprofiling_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("Profiling", "p phase-option", "jap.abc","profiling", "\nProfile the results of array bounds check analysis. The inserted \nprofiling code assumes the existence of a MultiCounter class \nimplementing the methods invoked. For details, see the \nArrayBoundsChecker source code.", defaultBool)));
+		setjapjap_abcprofiling_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("Profiling", "p phase-option", "wjap.abc","profiling", "\nProfile the results of array bounds check analysis. The inserted \nprofiling code assumes the existence of a MultiCounter class \nimplementing the methods invoked. For details, see the \nArrayBoundsChecker source code.", defaultBool)));
 
-		defKey = "p phase-option"+" "+"jap.abc"+" "+"add-color-tags";
+		defKey = "p phase-option"+" "+"wjap.abc"+" "+"add-color-tags";
 		defKey = defKey.trim();
 
 		if (isInDefList(defKey)) {
@@ -15260,7 +15260,7 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			defaultBool = false;
 		}
 
-		setjapjap_abcadd_color_tags_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("Add Color Tags", "p phase-option", "jap.abc","add-color-tags", "\nAdd color tags to the results of the array bounds check \nanalysis.", defaultBool)));
+		setjapjap_abcadd_color_tags_widget(new BooleanOptionWidget(editGroupjapjap_abc, SWT.NONE, new OptionData("Add Color Tags", "p phase-option", "wjap.abc","add-color-tags", "\nAdd color tags to the results of the array bounds check \nanalysis.", defaultBool)));
 
 
 		return editGroupjapjap_abc;

--- a/src/main/generated/options/soot/AntTask.java
+++ b/src/main/generated/options/soot/AntTask.java
@@ -628,12 +628,12 @@ public class AntTask extends MatchingTask {
             if(arg) addArg("-annot-purity");
         }
   
-        public void setannot_nullpointer(boolean arg) {
-            if(arg) addArg("-annot-nullpointer");
-        }
-  
         public void setannot_arraybounds(boolean arg) {
             if(arg) addArg("-annot-arraybounds");
+        }
+  
+        public void setannot_nullpointer(boolean arg) {
+            if(arg) addArg("-annot-nullpointer");
         }
   
         public void setannot_side_effect(boolean arg) {
@@ -2306,6 +2306,69 @@ public class AntTask extends MatchingTask {
       
         }
     
+        public Object createp_wjap_abc() {
+            Object ret = new PhaseOptwjap_abc();
+            phaseopts.add(ret);
+            return ret;
+        }
+        public class PhaseOptwjap_abc {
+      
+          public void setenabled(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("enabled:"+(arg?"true":"false"));
+          }
+      
+          public void setwith_all(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("with-all:"+(arg?"true":"false"));
+          }
+      
+          public void setwith_cse(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("with-cse:"+(arg?"true":"false"));
+          }
+      
+          public void setwith_arrayref(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("with-arrayref:"+(arg?"true":"false"));
+          }
+      
+          public void setwith_fieldref(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("with-fieldref:"+(arg?"true":"false"));
+          }
+      
+          public void setwith_classfield(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("with-classfield:"+(arg?"true":"false"));
+          }
+      
+          public void setwith_rectarray(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("with-rectarray:"+(arg?"true":"false"));
+          }
+      
+          public void setprofiling(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("profiling:"+(arg?"true":"false"));
+          }
+      
+          public void setadd_color_tags(boolean arg) {
+            addArg("-p");
+            addArg("wjap.abc");
+            addArg("add-color-tags:"+(arg?"true":"false"));
+          }
+      
+        }
+    
         public Object createp_shimple() {
             Object ret = new PhaseOptshimple();
             phaseopts.add(ret);
@@ -2740,69 +2803,6 @@ public class AntTask extends MatchingTask {
             addArg("-p");
             addArg("jap.npcolorer");
             addArg("enabled:"+(arg?"true":"false"));
-          }
-      
-        }
-    
-        public Object createp_jap_abc() {
-            Object ret = new PhaseOptjap_abc();
-            phaseopts.add(ret);
-            return ret;
-        }
-        public class PhaseOptjap_abc {
-      
-          public void setenabled(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("enabled:"+(arg?"true":"false"));
-          }
-      
-          public void setwith_all(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("with-all:"+(arg?"true":"false"));
-          }
-      
-          public void setwith_cse(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("with-cse:"+(arg?"true":"false"));
-          }
-      
-          public void setwith_arrayref(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("with-arrayref:"+(arg?"true":"false"));
-          }
-      
-          public void setwith_fieldref(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("with-fieldref:"+(arg?"true":"false"));
-          }
-      
-          public void setwith_classfield(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("with-classfield:"+(arg?"true":"false"));
-          }
-      
-          public void setwith_rectarray(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("with-rectarray:"+(arg?"true":"false"));
-          }
-      
-          public void setprofiling(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("profiling:"+(arg?"true":"false"));
-          }
-      
-          public void setadd_color_tags(boolean arg) {
-            addArg("-p");
-            addArg("jap.abc");
-            addArg("add-color-tags:"+(arg?"true":"false"));
           }
       
         }

--- a/src/main/generated/options/soot/options/Options.java
+++ b/src/main/generated/options/soot/options/Options.java
@@ -1276,32 +1276,33 @@ public class Options extends OptionsBase {
                 pushOption("enabled:true");
                 pushOption("wjap.purity");
                 pushOption("-p");
+            }
+            else if (false
+                || option.equals("annot-nullpointer")
+            ) {
                 pushOption("enabled:true");
                 pushOption("cg.spark");
                 pushOption("-p");
                 pushOption("-w");
             }
             else if (false
-                || option.equals("annot-nullpointer")
+                || option.equals("annot-arraybounds")
             ) {
+                pushOption("-w");
+                pushOption("enabled:true");
+                pushOption("wjap.ra");
+                pushOption("-p");
+                pushOption("enabled:true");
+                pushOption("wjap.abc");
+                pushOption("-p");
+                pushOption("enabled:true");
+                pushOption("tag.an");
+                pushOption("-p");
                 pushOption("enabled:true");
                 pushOption("tag.an");
                 pushOption("-p");
                 pushOption("enabled:true");
                 pushOption("jap.npc");
-                pushOption("-p");
-            }
-            else if (false
-                || option.equals("annot-arraybounds")
-            ) {
-                pushOption("enabled:true");
-                pushOption("tag.an");
-                pushOption("-p");
-                pushOption("enabled:true");
-                pushOption("jap.abc");
-                pushOption("-p");
-                pushOption("enabled:true");
-                pushOption("wjap.ra");
                 pushOption("-p");
             }
             else if (false
@@ -1845,8 +1846,8 @@ public class Options extends OptionsBase {
                 + padOpt("-write-local-annotations", "Write out debug annotations on local names")
                 + "\nAnnotation Options:\n"
                 + padOpt("-annot-purity", "Emit purity attributes")
-                + padOpt("-annot-nullpointer", "Emit null pointer attributes")
                 + padOpt("-annot-arraybounds", "Emit array bounds check attributes")
+                + padOpt("-annot-nullpointer", "Emit null pointer attributes")
                 + padOpt("-annot-side-effect", "Emit side-effect attributes")
                 + padOpt("-annot-fieldrw", "Emit field read/write attributes")
                 + "\nMiscellaneous Options:\n"
@@ -1910,6 +1911,7 @@ public class Options extends OptionsBase {
                     + padVal("wjap.tqt", "Tags all qualifiers that could be tighter")
                     + padVal("wjap.cgg", "Creates graphical call graph.")
                     + padVal("wjap.purity", "Emit purity attributes")
+                    + padVal("wjap.abc", "Array bound checker")
                 + padOpt("shimple", "Sets parameters for Shimple SSA form")
                 + padOpt("stp", "Shimple transformation pack")
                 + padOpt("sop", "Shimple optimization pack")
@@ -1932,7 +1934,6 @@ public class Options extends OptionsBase {
                 + padOpt("jap", "Jimple annotation pack: adds intraprocedural tags")
                     + padVal("jap.npc", "Null pointer checker")
                     + padVal("jap.npcolorer", "Null pointer colourer: tags references for eclipse")
-                    + padVal("jap.abc", "Array bound checker")
                     + padVal("jap.profiling", "Instruments null pointer and array checks")
                     + padVal("jap.sea", "Side effect tagger")
                     + padVal("jap.fieldrw", "Field read/write tagger")
@@ -2521,6 +2522,20 @@ public class Options extends OptionsBase {
                     + padOpt("annotate (true)", "Marks pure methods with a purity bytecode attribute")
                     + padOpt("verbose (false)", "");
 
+        if (phaseName.equals("wjap.abc"))
+            return "Phase " + phaseName + ":\n"
+                    + "\nThe Array Bound Checker performs a static analysis to determine \nwhich array bounds checks may safely be eliminated and then \nannotates statements with the results of the analysis. If Soot \nis in whole-program mode, the Array Bound Checker can use the \nresults provided by the Rectangular Array Finder."
+                    + "\n\nRecognized options (with default values):\n"
+                    + padOpt("enabled (false)", "")
+                    + padOpt("with-all (false)", "")
+                    + padOpt("with-cse (false)", "")
+                    + padOpt("with-arrayref (false)", "")
+                    + padOpt("with-fieldref (false)", "")
+                    + padOpt("with-classfield (false)", "")
+                    + padOpt("with-rectarray (false)", "")
+                    + padOpt("profiling (false)", "Profile the results of array bounds check analysis.")
+                    + padOpt("add-color-tags (false)", "Add color tags to results of array bound check analysis.");
+
         if (phaseName.equals("shimple"))
             return "Phase " + phaseName + ":\n"
                     + "\nShimple Control sets parameters which apply throughout the \ncreation and manipulation of Shimple bodies. Shimple is Soot's \nSSA representation."
@@ -2673,20 +2688,6 @@ public class Options extends OptionsBase {
                     + "\nProduce colour tags that the Soot plug-in for Eclipse can use to \nhighlight null and non-null references."
                     + "\n\nRecognized options (with default values):\n"
                     + padOpt("enabled (false)", "");
-
-        if (phaseName.equals("jap.abc"))
-            return "Phase " + phaseName + ":\n"
-                    + "\nThe Array Bound Checker performs a static analysis to determine \nwhich array bounds checks may safely be eliminated and then \nannotates statements with the results of the analysis. If Soot \nis in whole-program mode, the Array Bound Checker can use the \nresults provided by the Rectangular Array Finder."
-                    + "\n\nRecognized options (with default values):\n"
-                    + padOpt("enabled (false)", "")
-                    + padOpt("with-all (false)", "")
-                    + padOpt("with-cse (false)", "")
-                    + padOpt("with-arrayref (false)", "")
-                    + padOpt("with-fieldref (false)", "")
-                    + padOpt("with-classfield (false)", "")
-                    + padOpt("with-rectarray (false)", "")
-                    + padOpt("profiling (false)", "Profile the results of array bounds check analysis.")
-                    + padOpt("add-color-tags (false)", "Add color tags to results of array bound check analysis.");
 
         if (phaseName.equals("jap.profiling"))
             return "Phase " + phaseName + ":\n"
@@ -3329,6 +3330,19 @@ public class Options extends OptionsBase {
                     "verbose"
             );
 
+        if (phaseName.equals("wjap.abc"))
+            return String.join(" ", 
+                    "enabled",
+                    "with-all",
+                    "with-cse",
+                    "with-arrayref",
+                    "with-fieldref",
+                    "with-classfield",
+                    "with-rectarray",
+                    "profiling",
+                    "add-color-tags"
+            );
+
         if (phaseName.equals("shimple"))
             return String.join(" ", 
                     "enabled",
@@ -3455,19 +3469,6 @@ public class Options extends OptionsBase {
         if (phaseName.equals("jap.npcolorer"))
             return String.join(" ", 
                     "enabled"
-            );
-
-        if (phaseName.equals("jap.abc"))
-            return String.join(" ", 
-                    "enabled",
-                    "with-all",
-                    "with-cse",
-                    "with-arrayref",
-                    "with-fieldref",
-                    "with-classfield",
-                    "with-rectarray",
-                    "profiling",
-                    "add-color-tags"
             );
 
         if (phaseName.equals("jap.profiling"))
@@ -4021,6 +4022,18 @@ public class Options extends OptionsBase {
                     + "annotate:true "
                     + "verbose:false ";
 
+        if (phaseName.equals("wjap.abc"))
+            return ""
+                    + "enabled:false "
+                    + "with-all:false "
+                    + "with-cse:false "
+                    + "with-arrayref:false "
+                    + "with-fieldref:false "
+                    + "with-classfield:false "
+                    + "with-rectarray:false "
+                    + "profiling:false "
+                    + "add-color-tags:false ";
+
         if (phaseName.equals("shimple"))
             return ""
                     + "enabled:true "
@@ -4126,18 +4139,6 @@ public class Options extends OptionsBase {
         if (phaseName.equals("jap.npcolorer"))
             return ""
                     + "enabled:false ";
-
-        if (phaseName.equals("jap.abc"))
-            return ""
-                    + "enabled:false "
-                    + "with-all:false "
-                    + "with-cse:false "
-                    + "with-arrayref:false "
-                    + "with-fieldref:false "
-                    + "with-classfield:false "
-                    + "with-rectarray:false "
-                    + "profiling:false "
-                    + "add-color-tags:false ";
 
         if (phaseName.equals("jap.profiling"))
             return ""
@@ -4355,6 +4356,7 @@ public class Options extends OptionsBase {
                 || phaseName.equals("wjap.tqt")
                 || phaseName.equals("wjap.cgg")
                 || phaseName.equals("wjap.purity")
+                || phaseName.equals("wjap.abc")
                 || phaseName.equals("shimple")
                 || phaseName.equals("stp")
                 || phaseName.equals("sop")
@@ -4377,7 +4379,6 @@ public class Options extends OptionsBase {
                 || phaseName.equals("jap")
                 || phaseName.equals("jap.npc")
                 || phaseName.equals("jap.npcolorer")
-                || phaseName.equals("jap.abc")
                 || phaseName.equals("jap.profiling")
                 || phaseName.equals("jap.sea")
                 || phaseName.equals("jap.fieldrw")
@@ -4524,6 +4525,8 @@ public class Options extends OptionsBase {
             G.v().out.println("Warning: Options exist for non-existent phase wjap.cgg");
         if (!PackManager.v().hasPhase("wjap.purity"))
             G.v().out.println("Warning: Options exist for non-existent phase wjap.purity");
+        if (!PackManager.v().hasPhase("wjap.abc"))
+            G.v().out.println("Warning: Options exist for non-existent phase wjap.abc");
         if (!PackManager.v().hasPhase("shimple"))
             G.v().out.println("Warning: Options exist for non-existent phase shimple");
         if (!PackManager.v().hasPhase("stp"))
@@ -4568,8 +4571,6 @@ public class Options extends OptionsBase {
             G.v().out.println("Warning: Options exist for non-existent phase jap.npc");
         if (!PackManager.v().hasPhase("jap.npcolorer"))
             G.v().out.println("Warning: Options exist for non-existent phase jap.npcolorer");
-        if (!PackManager.v().hasPhase("jap.abc"))
-            G.v().out.println("Warning: Options exist for non-existent phase jap.abc");
         if (!PackManager.v().hasPhase("jap.profiling"))
             G.v().out.println("Warning: Options exist for non-existent phase jap.profiling");
         if (!PackManager.v().hasPhase("jap.sea"))

--- a/src/main/java/soot/PackManager.java
+++ b/src/main/java/soot/PackManager.java
@@ -259,6 +259,7 @@ public class PackManager {
       p.add(new Transform("wjap.tqt", TightestQualifiersTagger.v()));
       p.add(new Transform("wjap.cgg", CallGraphGrapher.v()));
       p.add(new Transform("wjap.purity", PurityAnalysis.v())); // [AM]
+      p.add(new Transform("wjap.abc", ArrayBoundsChecker.v()));
     }
 
     // Shimple pack
@@ -299,7 +300,6 @@ public class PackManager {
     {
       p.add(new Transform("jap.npc", NullPointerChecker.v()));
       p.add(new Transform("jap.npcolorer", NullPointerColorer.v()));
-      p.add(new Transform("jap.abc", ArrayBoundsChecker.v()));
       p.add(new Transform("jap.profiling", ProfilingGenerator.v()));
       p.add(new Transform("jap.sea", SideEffectTagger.v()));
       p.add(new Transform("jap.fieldrw", FieldTagger.v()));

--- a/src/main/java/soot/jimple/toolkits/annotation/arraycheck/ArrayBoundsChecker.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/arraycheck/ArrayBoundsChecker.java
@@ -29,18 +29,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import soot.ArrayType;
-import soot.Body;
-import soot.BodyTransformer;
-import soot.G;
-import soot.Local;
-import soot.Scene;
-import soot.Singletons;
-import soot.SootClass;
-import soot.SootMethod;
-import soot.Type;
-import soot.Value;
-import soot.ValueBox;
+import soot.*;
 import soot.jimple.ArrayRef;
 import soot.jimple.IntConstant;
 import soot.jimple.Jimple;
@@ -53,10 +42,17 @@ import soot.tagkit.KeyTag;
 import soot.tagkit.Tag;
 import soot.util.Chain;
 
-public class ArrayBoundsChecker extends BodyTransformer {
+public class ArrayBoundsChecker extends SceneTransformer {
   private static final Logger logger = LoggerFactory.getLogger(ArrayBoundsChecker.class);
 
   public ArrayBoundsChecker(Singletons.Global g) {
+  }
+
+  @Override
+  protected void internalTransform(String phaseName, Map<String, String> options) {
+    Scene.v().getReachableMethods().listener().forEachRemaining(method -> {
+      internalTransform(method.method().getActiveBody(), options);
+    });
   }
 
   public static ArrayBoundsChecker v() {
@@ -70,7 +66,7 @@ public class ArrayBoundsChecker extends BodyTransformer {
   protected boolean takeRectArray = false;
   protected boolean addColorTags = false;
 
-  protected void internalTransform(Body body, String phaseName, Map opts) {
+  protected void internalTransform(Body body, Map opts) {
     ABCOptions options = new ABCOptions(opts);
     if (options.with_all()) {
       takeClassField = true;

--- a/src/main/xml/options/soot_options.xml
+++ b/src/main/xml/options/soot_options.xml
@@ -5071,6 +5071,146 @@ This locking scheme aims to achieve simple fine-grained locking.
                         <default>false</default>
                     </boolopt>
                 </sub_phase>
+                <sub_phase>
+                    <name>Array Bound Checker</name>
+                    <class>ABCOptions</class>
+                    <alias>wjap.abc</alias>
+                    <short_desc>Array bound checker</short_desc>
+                    <long_desc>
+                        <p>
+                            The Array Bound Checker performs a static analysis to determine
+                            which array bounds checks may safely be eliminated and then annotates
+                            statements with the results of the analysis.
+                        </p>
+                        <p>
+                            If Soot is in whole-program mode, the Array Bound Checker can
+                            use the results provided by the Rectangular Array Finder.
+                        </p>
+                    </long_desc>
+                    <boolopt>
+                        <name>Enabled</name>
+                        <alias>enabled</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc/>
+                    </boolopt>
+                    <boolopt>
+                        <name>With All</name>
+                        <alias>with-all</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc>
+                            <p>
+                                Setting the With All option to true is equivalent to setting each
+                                of With CSE, With Array Ref, With Field Ref,
+                                With Class Field, and With Rectangular Array to true.
+                            </p>
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>With Common Sub-expressions</name>
+                        <alias>with-cse</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc>
+                            <p>
+                                The analysis will consider common subexpressions. For example,
+                                consider the situation where <tt>r1</tt> is assigned
+                                <tt>a*b</tt>; later, <tt>r2</tt> is assigned <tt>a*b</tt>, where
+                                neither <tt>a</tt> nor <tt>b</tt> have changed between the two
+                                statements. The analysis can conclude that <tt>r2</tt> has the
+                                same value as <tt>r1</tt>. Experiments show that this option can
+                                improve the result slightly.
+                            </p>
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>With Array References</name>
+                        <alias>with-arrayref</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc>
+                            <p>
+                                With this option enabled, array references can be considered as
+                                common subexpressions; however, we are more conservative when
+                                writing into an array, because array objects may be aliased. We
+                                also assume that the application is single-threaded or that the
+                                array references occur in a synchronized block. That is, we
+                                assume that an array element may not be changed by other threads
+                                between two array references.
+                            </p>
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>With Field References</name>
+                        <alias>with-fieldref</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc>
+                            <p>
+                                The analysis treats field references (static and instance) as
+                                common subexpressions; however, we are more conservative when
+                                writing to a field, because the base of the field reference may
+                                be aliased. We also assume that the application is
+                                single-threaded or that the field references occur in a
+                                synchronized block. That is, we assume that a field may
+                                not be changed by other threads between two field references.
+                            </p>
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>With Class Field</name>
+                        <alias>with-classfield</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc>
+                            <p>
+                                This option makes the analysis work on the class level. The
+                                algorithm analyzes <tt>final</tt> or <tt>private</tt> class
+                                fields first. It can recognize the fields that hold array objects
+                                of constant length. In an application using lots of array
+                                fields, this option can improve the analysis results
+                                dramatically.
+                            </p>
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>With Rectangular Array</name>
+                        <alias>with-rectarray</alias>
+                        <default>false</default>
+                        <short_desc/>
+                        <long_desc>
+                            This option is used together with <tt>wjap.ra</tt> to make Soot run the whole-program
+                            analysis for rectangular array objects. This analysis is based on the
+                            call graph, and it usually takes a long time. If the application uses
+                            rectangular arrays, these options can improve the analysis
+                            result.
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>Profiling</name>
+                        <alias>profiling</alias>
+                        <default>false</default>
+                        <short_desc>Profile the results of array bounds check analysis.</short_desc>
+                        <long_desc>
+                            <p>
+                                Profile the results of array bounds check analysis. The inserted
+                                profiling code assumes the existence of a
+                                <tt>MultiCounter</tt>
+                                class implementing the methods invoked. For details, see the
+                                <tt>ArrayBoundsChecker</tt>
+                                source code.
+                            </p>
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
+                        <name>Add Color Tags</name>
+                        <alias>add-color-tags</alias>
+                        <default>false</default>
+                        <short_desc>Add color tags to results of array bound check analysis.</short_desc>
+                        <long_desc>Add color tags to the results of the array bounds check analysis.</long_desc>
+                    </boolopt>
+                </sub_phase>
             </phase>
             <phase>
                 <name>Shimple Control</name>
@@ -5792,146 +5932,6 @@ This locking scheme aims to achieve simple fine-grained locking.
                         <alias>enabled</alias>
                         <default>false</default>
                         <long_desc></long_desc>
-                    </boolopt>
-                </sub_phase>
-                <sub_phase>
-                    <name>Array Bound Checker</name>
-                    <class>ABCOptions</class>
-                    <alias>jap.abc</alias>
-                    <short_desc>Array bound checker</short_desc>
-                    <long_desc>
-                        <p>
-                            The Array Bound Checker performs a static analysis to determine
-                            which array bounds checks may safely be eliminated and then annotates
-                            statements with the results of the analysis.
-                        </p>
-                        <p>
-                            If Soot is in whole-program mode, the Array Bound Checker can
-                            use the results provided by the Rectangular Array Finder.
-                        </p>
-                    </long_desc>
-                    <boolopt>
-                        <name>Enabled</name>
-                        <alias>enabled</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc/>
-                    </boolopt>
-                    <boolopt>
-                        <name>With All</name>
-                        <alias>with-all</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc>
-                            <p>
-                                Setting the With All option to true is equivalent to setting each
-                                of With CSE, With Array Ref, With Field Ref,
-                                With Class Field, and With Rectangular Array to true.
-                            </p>
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>With Common Sub-expressions</name>
-                        <alias>with-cse</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc>
-                            <p>
-                                The analysis will consider common subexpressions. For example,
-                                consider the situation where <tt>r1</tt> is assigned
-                                <tt>a*b</tt>; later, <tt>r2</tt> is assigned <tt>a*b</tt>, where
-                                neither <tt>a</tt> nor <tt>b</tt> have changed between the two
-                                statements. The analysis can conclude that <tt>r2</tt> has the
-                                same value as <tt>r1</tt>. Experiments show that this option can
-                                improve the result slightly.
-                            </p>
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>With Array References</name>
-                        <alias>with-arrayref</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc>
-                            <p>
-                                With this option enabled, array references can be considered as
-                                common subexpressions; however, we are more conservative when
-                                writing into an array, because array objects may be aliased. We
-                                also assume that the application is single-threaded or that the
-                                array references occur in a synchronized block. That is, we
-                                assume that an array element may not be changed by other threads
-                                between two array references.
-                            </p>
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>With Field References</name>
-                        <alias>with-fieldref</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc>
-                            <p>
-                                The analysis treats field references (static and instance) as
-                                common subexpressions; however, we are more conservative when
-                                writing to a field, because the base of the field reference may
-                                be aliased. We also assume that the application is
-                                single-threaded or that the field references occur in a
-                                synchronized block. That is, we assume that a field may
-                                not be changed by other threads between two field references.
-                            </p>
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>With Class Field</name>
-                        <alias>with-classfield</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc>
-                            <p>
-                                This option makes the analysis work on the class level. The
-                                algorithm analyzes <tt>final</tt> or <tt>private</tt> class
-                                fields first. It can recognize the fields that hold array objects
-                                of constant length. In an application using lots of array
-                                fields, this option can improve the analysis results
-                                dramatically.
-                            </p>
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>With Rectangular Array</name>
-                        <alias>with-rectarray</alias>
-                        <default>false</default>
-                        <short_desc/>
-                        <long_desc>
-                            This option is used together with <tt>wjap.ra</tt> to make Soot run the whole-program
-                            analysis for rectangular array objects. This analysis is based on the
-                            call graph, and it usually takes a long time. If the application uses
-                            rectangular arrays, these options can improve the analysis
-                            result.
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>Profiling</name>
-                        <alias>profiling</alias>
-                        <default>false</default>
-                        <short_desc>Profile the results of array bounds check analysis.</short_desc>
-                        <long_desc>
-                            <p>
-                                Profile the results of array bounds check analysis. The inserted
-                                profiling code assumes the existence of a
-                                <tt>MultiCounter</tt>
-                                class implementing the methods invoked. For details, see the
-                                <tt>ArrayBoundsChecker</tt>
-                                source code.
-                            </p>
-                        </long_desc>
-                    </boolopt>
-                    <boolopt>
-                        <name>Add Color Tags</name>
-                        <alias>add-color-tags</alias>
-                        <default>false</default>
-                        <short_desc>Add color tags to results of array bound check analysis.</short_desc>
-                        <long_desc>Add color tags to the results of the array bounds check analysis.</long_desc>
                     </boolopt>
                 </sub_phase>
                 <sub_phase>
@@ -7311,6 +7311,27 @@ This locking scheme aims to achieve simple fine-grained locking.
             </long_desc>
         </macroopt>
         <macroopt>
+            <name>Array Bounds Annotation</name>
+            <alias>annot-arraybounds</alias>
+            <expansion>-p</expansion>
+            <expansion>wjap.ra</expansion>
+            <expansion>enabled:true</expansion>
+            <expansion>-p</expansion>
+            <expansion>wjap.abc</expansion>
+            <expansion>enabled:true</expansion>
+            <expansion>-p</expansion>
+            <expansion>tag.an</expansion>
+            <expansion>enabled:true</expansion>
+            <short_desc>Emit array bounds check attributes</short_desc>
+            <long_desc>
+                Perform a static analysis of which array bounds checks may safely
+                be eliminated and annotate output class files with attributes
+                encoding the results of the analysis. For details, see the
+                documentation for Array Bounds Annotation and for the Array
+                Bounds and Null Pointer Check Tag Aggregator.
+            </long_desc>
+        </macroopt>
+        <macroopt>
             <name>Null Pointer Annotation</name>
             <alias>annot-nullpointer</alias>
             <expansion>-p</expansion>
@@ -7326,27 +7347,6 @@ This locking scheme aims to achieve simple fine-grained locking.
                 encoding the results of the analysis. For details, see the
                 documentation for Null Pointer Annotation and for the
                 Array Bounds and Null Pointer Check Tag Aggregator.
-            </long_desc>
-        </macroopt>
-        <macroopt>
-            <name>Array Bounds Annotation</name>
-            <alias>annot-arraybounds</alias>
-            <expansion>-p</expansion>
-            <expansion>wjap.ra</expansion>
-            <expansion>enabled:true</expansion>
-            <expansion>-p</expansion>
-            <expansion>jap.abc</expansion>
-            <expansion>enabled:true</expansion>
-            <expansion>-p</expansion>
-            <expansion>tag.an</expansion>
-            <expansion>enabled:true</expansion>
-            <short_desc>Emit array bounds check attributes</short_desc>
-            <long_desc>
-                Perform a static analysis of which array bounds checks may safely
-                be eliminated and annotate output class files with attributes
-                encoding the results of the analysis. For details, see the
-                documentation for Array Bounds Annotation and for the Array
-                Bounds and Null Pointer Check Tag Aggregator.
             </long_desc>
         </macroopt>
         <macroopt>

--- a/tutorial/useannotation/useannotation.tex
+++ b/tutorial/useannotation/useannotation.tex
@@ -75,7 +75,7 @@ jap.npc}''. It has one phase option (aside from the default option
 Soot also has phase options for the array bounds check analysis.
 These options affect three levels of analyses: intraprocedural,
 class-level, and whole-program. The array bounds check analysis has
-the phase name ``{\em jap.abc}''.  If the whole-program analysis is
+the phase name ``{\em wjap.abc}''.  If the whole-program analysis is
 required, an extra phase ``{\em wjap.ra}'' for finding rectangular
 arrays is required.  This phase can be also enabled with
 phase options.
@@ -88,7 +88,7 @@ options assume that the application is single-threaded.
   
 \begin{description}
 
-\item[-p jap.abc with-cse]\ \\ 
+\item[-p wjap.abc with-cse]\ \\
 The analysis will consider common subexpressions.  For example,
   consider the situation where {\tt r1} is assigned {\tt a*b}; later,
   {\tt r2} is assigned {\tt a*b}, where both {\tt a} and {\tt b} have
@@ -96,7 +96,7 @@ The analysis will consider common subexpressions.  For example,
   conclude that {\tt r2} has the same value as {\tt r1}. Experiments
   show that this option can improve the result slightly.
 
-\item[-p jap.abc with-arrayref]\ \\ With this option enabled, array
+\item[-p wjap.abc with-arrayref]\ \\ With this option enabled, array
 references can be considered as common subexpressions; however, we are
 more conservative when writing into an array, because array
 objects may be aliased. NOTE: We also assume that the application in a
@@ -105,23 +105,23 @@ array element may not be changed by other threads between two array
 references.
 % see my thesis for an example of what to do when you have contention! -plam
 
-\item[-p jap.abc with-fieldref]\ \\ 
+\item[-p wjap.abc with-fieldref]\ \\
 The analysis treats field references (static and instance) as common
 subexpressions. The restrictions from the `{\tt with-arrayref}' option also
 apply. 
 
-\item[-p jap.abc with-classfield]\ \\ 
+\item[-p wjap.abc with-classfield]\ \\
 This option makes the analysis work on the class level. The algorithm 
 analyzes `final' or `private' class fields first. It can recognize
 the fields that hold array objects with constant length.  In an application 
 using lots of array fields, this option can improve the analysis results 
 dramatically. 
 
-\item[-p jap.abc with-all]\ \\
+\item[-p wjap.abc with-all]\ \\
 A macro.  Instead of typing a long string of phase options, this option 
-will turn on all options of the phase ``{\em jap.abc}''.
+will turn on all options of the phase ``{\em wjap.abc}''.
  
-\item[-p jap.abc with-rectarray, -p wjap.ra with-wholeapp]\ \\ These
+\item[-p wjap.abc with-rectarray, -p wjap.ra with-wholeapp]\ \\ These
 two options are used together to make Soot run the whole-program
 analysis for rectangular array objects. This analysis is based on the
 call graph, and it usually takes a long time. If the application uses
@@ -141,7 +141,7 @@ The options for rectangular array should be used in application
 mode. For example:
 \begin{verbatim}
     java soot.Main --app -annot-arraybounds -annot-arraybounds -p wjap.ra with-wholeapp 
-      -p jap.abc with-all spec.benchmarks._222_mpegaudio.Main
+      -p wjap.abc with-all spec.benchmarks._222_mpegaudio.Main
 \end{verbatim}
 
 The following command only annotates the array reference bytecodes.


### PR DESCRIPTION
This fixes #1354. It's caused by the fact that multiple running ArrayBoundsChecker transformations can run certain analyses (SimpleLocalDefs) on the same method, resulting into data being overwritten (in this case, the local.getNumber field). I suspect this happened, because the transformation was designed before (2000) Soot parallelized BodyTransformation's or even supported SceneTransformation's.

I'm not sure if I modified all the documentation correctly. I added a -w flag to the annot-arraybounds, since now its a whole-program transformation. As for some ui code (PhaseOptionsDialog) I didn't test it.

I've ran some basic tests and it works now in whole-program mode. Hope this is of any use.