### PR TITLE
fix for #1454 - ModulePathSourceLocator

### DIFF
--- a/src/main/java/soot/ModulePathSourceLocator.java
+++ b/src/main/java/soot/ModulePathSourceLocator.java
@@ -671,7 +671,10 @@ public class ModulePathSourceLocator extends SourceLocator {
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
-          String fileName = aPath.relativize(file).toString().replace(File.separatorChar, '.');
+          // Note that some FileSystem implementations used by Path use even on Windows
+          // "/" as path separator. Therefore we have to use the file-system specific path separator
+          // instead of the system specific one (File.separatorChar).
+          String fileName = aPath.relativize(file).toString().replace(file.getFileSystem().getSeparator(), ".");
 
           if (fileName.endsWith(".class")) {
             int index = fileName.lastIndexOf(".class");


### PR DESCRIPTION
The ModulePathSourceLocator always used the system specific file path separator which is on Windows `\`. But some of the file-systems used by Java (e.g. the JrtFileSystem) always use the char `/` as file path separator - even on Windows.

This ended up in totally defect class and package names generated by the ModulePathSourceLocator.

The modified implementation now uses the file separator as defined by the `FileSystem` of the current `Path`.

This PR fixes issue #1454.