### PR TITLE
Improvements to OnFlyCallgraphBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,15 +570,7 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.4.0-b180830.0438</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/javax.xml.parsers/jaxp-api -->
-		<dependency>
-		    <groupId>javax.xml.parsers</groupId>
-		    <artifactId>jaxp-api</artifactId>
-		    <version>1.4.5</version>
-		</dependency>
-
-        
+        </dependency>  
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -571,6 +571,14 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.4.0-b180830.0438</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.xml.parsers/jaxp-api -->
+		<dependency>
+		    <groupId>javax.xml.parsers</groupId>
+		    <artifactId>jaxp-api</artifactId>
+		    <version>1.4.5</version>
+		</dependency>
+
+        
     </dependencies>
 
     <repositories>

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -96,6 +96,11 @@ import soot.jimple.spark.pag.AllocDotField;
 import soot.jimple.spark.pag.PAG;
 import soot.jimple.toolkits.annotation.nullcheck.NullnessAnalysis;
 import soot.jimple.toolkits.callgraph.ConstantArrayAnalysis.ArrayTypes;
+import soot.jimple.toolkits.callgraph.VirtualEdgesSummaries.DirectTarget;
+import soot.jimple.toolkits.callgraph.VirtualEdgesSummaries.RegisteredHandlerTarget;
+import soot.jimple.toolkits.callgraph.VirtualEdgesSummaries.VirtualEdge;
+import soot.jimple.toolkits.callgraph.VirtualEdgesSummaries.VirtualEdgeTarget;
+import soot.jimple.toolkits.callgraph.VirtualEdgesSummaries.WrapperTarget;
 import soot.jimple.toolkits.reflection.ReflectionTraceInfo;
 import soot.options.CGOptions;
 import soot.options.Options;
@@ -223,6 +228,7 @@ public class OnFlyCallGraphBuilder {
   protected VirtualCalls virtualCalls = VirtualCalls.v();
 
   public OnFlyCallGraphBuilder(ContextManager cm, ReachableMethods rm) {
+    VirtualEdgesSummaries.parseSummaries();
     this.cm = cm;
     this.rm = rm;
     worklist = rm.listener();
@@ -825,25 +831,50 @@ public class OnFlyCallGraphBuilder {
           Local receiver = (Local) iie.getBase();
           NumberedString subSig = iie.getMethodRef().getSubSignature();
           addVirtualCallSite(s, m, receiver, iie, subSig, Edge.ieToKind(iie));
-          if (subSig == sigStart) {
-            addVirtualCallSite(s, m, receiver, iie, sigRun, Kind.THREAD);
-          } else if (subSig == sigExecutorExecute || subSig == sigHandlerPost || subSig == sigHandlerPostAtFrontOfQueue
-              || subSig == sigHandlerPostAtTime || subSig == sigHandlerPostAtTimeWithToken || subSig == sigHandlerPostDelayed
-              || subSig == sigRunOnUiThread) {
-            if (iie.getArgCount() > 0) {
-              Value runnable = iie.getArg(0);
-              if (runnable instanceof Local) {
-                addVirtualCallSite(s, m, (Local) runnable, iie, sigRun, Kind.EXECUTOR);
+          VirtualEdge virtualEdge = VirtualEdgesSummaries.getVirtualEdgesMatchingSubSig(subSig);
+          if (virtualEdge != null) {
+            for (VirtualEdgeTarget t : virtualEdge.targets) {
+              if (t instanceof DirectTarget) {
+                DirectTarget directTarget = (DirectTarget) t;
+                if (t.isBase) {
+                  addVirtualCallSite(s, m, receiver, iie, directTarget.targetMethod, virtualEdge.edgeType);
+                } else {
+                  Value runnable = iie.getArg(t.argIndex);
+                  if (runnable instanceof Local) {
+                    addVirtualCallSite(s, m, (Local) runnable, iie, directTarget.targetMethod, virtualEdge.edgeType);
+                  }
+                }
+              } else if (t instanceof WrapperTarget) {
+                WrapperTarget w = (WrapperTarget) t;
+                Local wrapperObject = null;
+                if (t.isBase) {
+                  wrapperObject = receiver;
+                } else {
+                  Value runnable = iie.getArg(t.argIndex);
+                  if (runnable instanceof Local) {
+                    wrapperObject = (Local) runnable;
+                  }
+                }
+
+                if (wrapperObject != null && receiverToSites.get(wrapperObject) != null) {
+                  for (Iterator<VirtualCallSite> siteIt = receiverToSites.get(wrapperObject).iterator(); siteIt.hasNext();) {
+                    final VirtualCallSite site = siteIt.next();
+                    if (w.registrationSignature == site.subSig()) {
+                      for (RegisteredHandlerTarget target : w.targets) {
+                        Value runnable = iie.getArg(t.argIndex);
+                        if (runnable instanceof Local) {
+                          addVirtualCallSite(s, m, (Local) runnable, iie, target.targetMethod, virtualEdge.edgeType);
+                        }
+
+                      }
+                    }
+                  }
+                }
+
               }
             }
-          } else if (subSig == sigHandlerSendEmptyMessage || subSig == sigHandlerSendEmptyMessageAtTime
-              || subSig == sigHandlerSendEmptyMessageDelayed || subSig == sigHandlerSendMessage
-              || subSig == sigHandlerSendMessageAtFrontOfQueue || subSig == sigHandlerSendMessageAtTime
-              || subSig == sigHandlerSendMessageDelayed) {
-            addVirtualCallSite(s, m, receiver, iie, sigHandlerHandleMessage, Kind.HANDLER);
-          } else if (subSig == sigExecute) {
-            addVirtualCallSite(s, m, receiver, iie, sigDoInBackground, Kind.ASYNCTASK);
           }
+
         } else if (ie instanceof DynamicInvokeExpr) {
           if (options.verbose()) {
             logger.debug("" + "WARNING: InvokeDynamic to " + ie + " not resolved during call-graph construction.");
@@ -853,18 +884,34 @@ public class OnFlyCallGraphBuilder {
           if (tgt != null) {
             addEdge(m, s, tgt);
             String signature = tgt.getSignature();
-            if (signature
-                .equals("<java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction)>")
-                || signature.equals("<java.security.AccessController: java.lang.Object doPrivileged"
-                    + "(java.security.PrivilegedExceptionAction)>")
-                || signature.equals("<java.security.AccessController: java.lang.Object doPrivileged"
-                    + "(java.security.PrivilegedAction,java.security.AccessControlContext)>")
-                || signature.equals("<java.security.AccessController: java.lang.Object doPrivileged"
-                    + "(java.security.PrivilegedExceptionAction,java.security.AccessControlContext)>")) {
-
-              Local receiver = (Local) ie.getArg(0);
-              addVirtualCallSite(s, m, receiver, null, sigObjRun, Kind.PRIVILEGED);
-            }
+            VirtualEdge virtualEdge = VirtualEdgesSummaries.getVirtualEdgesMatchingFunction(signature);
+            if (virtualEdge != null) {
+              for (VirtualEdgeTarget t : virtualEdge.targets) {
+                if (t instanceof DirectTarget) {
+                  DirectTarget directTarget = (DirectTarget) t;
+                  if (t.isBase) {
+                    // this should not happen
+                  } else {
+                    Value runnable = ie.getArg(t.argIndex);
+                    if (runnable instanceof Local) {
+                      addVirtualCallSite(s, m, (Local) runnable, null, directTarget.targetMethod, Kind.EXECUTOR);
+                    }
+                  }
+                }
+              }
+            } /*
+               * if (signature
+               * .equals("<java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction)>")
+               * || signature.equals("<java.security.AccessController: java.lang.Object doPrivileged" +
+               * "(java.security.PrivilegedExceptionAction)>") ||
+               * signature.equals("<java.security.AccessController: java.lang.Object doPrivileged" +
+               * "(java.security.PrivilegedAction,java.security.AccessControlContext)>") ||
+               * signature.equals("<java.security.AccessController: java.lang.Object doPrivileged" +
+               * "(java.security.PrivilegedExceptionAction,java.security.AccessControlContext)>")) {
+               * 
+               * Local receiver = (Local) ie.getArg(0); addVirtualCallSite(s, m, receiver, null, sigObjRun, Kind.PRIVILEGED);
+               * }
+               */
           } else {
             if (!Options.v().ignore_resolution_errors()) {
               throw new InternalError(

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
@@ -1,0 +1,166 @@
+package soot.jimple.toolkits.callgraph;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import soot.Kind;
+import soot.ModuleUtil;
+import soot.Scene;
+import soot.util.NumberedString;
+
+/**
+ * 
+ * Utility class used by {@link OnFlyCallGraphBuilder} for finding functions at which to place virtual callgraph edges.
+ * Function signatures are configurable in virtualedges.xml.
+ * 
+ * @author Julius Naeumann
+ *
+ */
+public class VirtualEdgesSummaries {
+  private static final String SUMMARIESFILE = "virtualedges.xml";
+  private static HashMap<NumberedString, VirtualEdge> virtualinvokeEdges;
+  private static HashMap<NumberedString, VirtualEdge> staticinvokeEdges;
+
+  private void parseSummaries() {
+    virtualinvokeEdges = new HashMap<>();
+    staticinvokeEdges = new HashMap<>();
+    InputStream in = null;
+    Path summariesFile = Paths.get(SUMMARIESFILE);
+    try {
+      if (!Files.exists(summariesFile)) {
+        // else take the one package
+
+        in = ModuleUtil.class.getResourceAsStream("/" + SUMMARIESFILE);
+      } else {
+
+        in = Files.newInputStream(summariesFile);
+
+      }
+      DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+      DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+      Document doc = dBuilder.parse(in);
+      doc.getDocumentElement().normalize();
+
+      NodeList edges = doc.getElementsByTagName("edge");
+      for (int i = 0; i < edges.getLength(); i++) {
+        if (edges.item(i).getNodeType() == Node.ELEMENT_NODE) {
+          Element edge = (Element) edges.item(i);
+          if ("instance".equals(edge.getAttribute("invoketype"))) {
+
+          }
+        }
+      }
+
+    } catch (IOException | ParserConfigurationException | SAXException e1) {
+      e1.printStackTrace();
+    }
+  }
+
+  private static VirtualEdgeSource parseEdgeSource(Element source) {
+    String type = source.getAttribute("invoketype");
+    if ("instance".equals(type))
+        return new InstanceinvokeSource(source.getAttribute("subsignature"));
+    if ("static".equals(type))
+        return new StaticinvokeSource(source.getAttribute("signature"));
+    return null;
+  }
+
+  private static ArrayList<VirtualEdgeTarget> parseEdgeTargets(Element targetsElement) {
+    ArrayList<VirtualEdgeTarget> targets = new ArrayList<>();
+    NodeList children = targetsElement.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        Element target = (Element) children.item(i);
+        if ("method".equals(target.getNodeName())) {
+          DirectTarget t = new DirectTarget();
+          t.targetMethod = Scene.v().getSubSigNumberer().findOrAdd(target.getAttribute("subsignature"));
+          if (target.getAttribute("target").equals("argument")) {
+            t.isBase = false;
+            t.argIndex = Integer.valueOf(target.getAttribute("index"));
+          } else {
+            t.isBase = true;
+            t.argIndex = -1;
+          }
+          targets.add(t);
+        } else if ("wrapper".equals(target.getNodeName())) {
+          IndirectTarget t = new IndirectTarget();
+          t.registrationSignature = Scene.v().getSubSigNumberer().findOrAdd(s)
+        }
+      }
+    }
+    return targets;
+  }
+
+  public static abstract class VirtualEdgeSource {
+
+  }
+
+  public static class StaticinvokeSource extends VirtualEdgeSource {
+    public StaticinvokeSource(String signature) {
+      this.signature = (signature);
+    }
+    /**
+     * The method signature at which to insert this edge.
+     */
+    String signature;
+  }
+
+  public static class InstanceinvokeSource extends VirtualEdgeSource {
+    public InstanceinvokeSource(String subSignature) {
+      this.subSignature = Scene.v().getSubSigNumberer().findOrAdd(subSignature);
+    }
+    /**
+     * The method subsignature at which to insert this edge.
+     */
+    NumberedString subSignature;
+  }
+
+  public static abstract class VirtualEdgeTarget {
+
+  }
+
+  public static class DirectTarget extends VirtualEdgeTarget {
+    NumberedString targetMethod;
+
+    boolean isBase;
+
+    int argIndex;
+  }
+
+  public static class IndirectTarget extends VirtualEdgeTarget {
+    NumberedString registrationSignature;
+
+    boolean isBase;
+
+    int argIndex;
+    ArrayList<DirectTarget> targets;
+  }
+
+
+  public static class VirtualEdge {
+    /**
+     * The kind of edge to insert
+     */
+    Kind edgeType;
+    VirtualEdgeSource source;
+    ArrayList<VirtualEdgeTarget> targets;
+
+
+  }
+
+}

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
@@ -1,5 +1,27 @@
 package soot.jimple.toolkits.callgraph;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -28,17 +50,36 @@ import soot.util.NumberedString;
  * Utility class used by {@link OnFlyCallGraphBuilder} for finding functions at which to place virtual callgraph edges.
  * Function signatures are configurable in virtualedges.xml.
  * 
+ * 
  * @author Julius Naeumann
  *
  */
 public class VirtualEdgesSummaries {
   private static final String SUMMARIESFILE = "virtualedges.xml";
-  private static HashMap<NumberedString, VirtualEdge> virtualinvokeEdges;
-  private static HashMap<NumberedString, VirtualEdge> staticinvokeEdges;
+  private static HashMap<NumberedString, VirtualEdge> instanceinvokeEdges;
+  private static HashMap<String, VirtualEdge> staticinvokeEdges;
+  private static HashMap<NumberedString, VirtualEdge> registerfunctionsToEdges;
 
-  private void parseSummaries() {
-    virtualinvokeEdges = new HashMap<>();
+  public static VirtualEdge getVirtualEdgesMatchingSubSig(NumberedString subsig) {
+    return instanceinvokeEdges.get(subsig);
+  }
+
+  public static VirtualEdge getVirtualEdgesMatchingFunction(String signature) {
+    return staticinvokeEdges.get(signature);
+  }
+
+  public static VirtualEdge getVirtualEdgesForPotentialRegisterFunction(NumberedString subsig) {
+    return registerfunctionsToEdges.get(subsig);
+  }
+
+  public static void parseSummaries() {
+    if (instanceinvokeEdges != null) {
+      // only parse once.
+      return;
+    }
+    instanceinvokeEdges = new HashMap<>();
     staticinvokeEdges = new HashMap<>();
+    registerfunctionsToEdges = new HashMap<>();
     InputStream in = null;
     Path summariesFile = Paths.get(SUMMARIESFILE);
     try {
@@ -60,15 +101,60 @@ public class VirtualEdgesSummaries {
       for (int i = 0; i < edges.getLength(); i++) {
         if (edges.item(i).getNodeType() == Node.ELEMENT_NODE) {
           Element edge = (Element) edges.item(i);
-          if ("instance".equals(edge.getAttribute("invoketype"))) {
-
+          VirtualEdge e = new VirtualEdge();
+          switch (edge.getAttribute("type")) {
+            case "THREAD":
+              e.edgeType = Kind.THREAD;
+              break;
+            case "EXECUTOR":
+              e.edgeType = Kind.EXECUTOR;
+              break;
+            case "HANDLER":
+              e.edgeType = Kind.HANDLER;
+              break;
+            case "ASYNCTASK":
+              e.edgeType = Kind.ASYNCTASK;
+              break;
+            case "PRIVILEDGED":
+              e.edgeType = Kind.PRIVILEGED;
+              break;
           }
+          e.source = parseEdgeSource((Element) (edge.getElementsByTagName("source").item(0)));
+          e.targets = new ArrayList<VirtualEdgesSummaries.VirtualEdgeTarget>();
+          Element targetsElement = (Element) edge.getElementsByTagName("targets").item(0);
+          e.targets.addAll(parseDirectEdgeTargets(targetsElement));
+          e.targets.addAll(parseWrapperTargets(targetsElement));
+          if (e.source instanceof InstanceinvokeSource) {
+            InstanceinvokeSource inst = (InstanceinvokeSource) e.source;
+
+            // don't overwrite existing definition
+            VirtualEdge existing = instanceinvokeEdges.get(inst.subSignature);
+            if (existing != null) {
+              existing.targets.addAll(e.targets);
+            } else {
+              instanceinvokeEdges.put(inst.subSignature, e);
+            }
+          }
+          if (e.source instanceof StaticinvokeSource) {
+            StaticinvokeSource stat = (StaticinvokeSource) e.source;
+            staticinvokeEdges.put(stat.signature, e);
+          }
+          for (VirtualEdgeTarget t : e.targets) {
+            if (t instanceof WrapperTarget) {
+              WrapperTarget target = (WrapperTarget) t;
+              registerfunctionsToEdges.put(target.registrationSignature, e);
+            }
+          }
+
         }
       }
 
     } catch (IOException | ParserConfigurationException | SAXException e1) {
       e1.printStackTrace();
     }
+    System.out.println(
+        String.format("Found %d instanceinvoke , %d staticinvoke edge descriptions", instanceinvokeEdges.size(),
+            staticinvokeEdges.size()));
   }
 
   private static VirtualEdgeSource parseEdgeSource(Element source) {
@@ -80,27 +166,66 @@ public class VirtualEdgesSummaries {
     return null;
   }
 
-  private static ArrayList<VirtualEdgeTarget> parseEdgeTargets(Element targetsElement) {
-    ArrayList<VirtualEdgeTarget> targets = new ArrayList<>();
-    NodeList children = targetsElement.getChildNodes();
+  private static ArrayList<DirectTarget> parseDirectEdgeTargets(Element targetsElement) {
+    ArrayList<DirectTarget> targets = new ArrayList<>();
+    NodeList children = targetsElement.getElementsByTagName("direct");
     for (int i = 0; i < children.getLength(); i++) {
       if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-        Element target = (Element) children.item(i);
-        if ("method".equals(target.getNodeName())) {
-          DirectTarget t = new DirectTarget();
-          t.targetMethod = Scene.v().getSubSigNumberer().findOrAdd(target.getAttribute("subsignature"));
-          if (target.getAttribute("target").equals("argument")) {
-            t.isBase = false;
-            t.argIndex = Integer.valueOf(target.getAttribute("index"));
-          } else {
-            t.isBase = true;
-            t.argIndex = -1;
-          }
-          targets.add(t);
-        } else if ("wrapper".equals(target.getNodeName())) {
-          IndirectTarget t = new IndirectTarget();
-          t.registrationSignature = Scene.v().getSubSigNumberer().findOrAdd(s)
+        Element targetElement = (Element) children.item(i);
+        DirectTarget target = new DirectTarget();
+
+        target.targetMethod = Scene.v().getSubSigNumberer().findOrAdd(targetElement.getAttribute("subsignature"));
+
+        if (targetElement.getAttribute("target-position").equals("argument")) {
+          target.isBase = false;
+          target.argIndex = Integer.valueOf(targetElement.getAttribute("index"));
+        } else {
+          target.isBase = true;
+          target.argIndex = -1;
         }
+        targets.add(target);
+      }
+    }
+    return targets;
+  }
+
+  private static ArrayList<RegisteredHandlerTarget> parseRegisteredTargets(Element registermethodsElement) {
+    ArrayList<RegisteredHandlerTarget> targets = new ArrayList<>();
+    NodeList children = registermethodsElement.getElementsByTagName("registered-handler");
+    for (int i = 0; i < children.getLength(); i++) {
+      if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        Element targetElement = (Element) children.item(i);
+        RegisteredHandlerTarget target = new RegisteredHandlerTarget();
+        target.targetMethod = Scene.v().getSubSigNumberer().findOrAdd(targetElement.getAttribute("target-subsignature"));
+        target.argIndex = Integer.valueOf(targetElement.getAttribute("target-argument-index"));
+        targets.add(target);
+      }
+    }
+    return targets;
+  }
+
+  private static ArrayList<WrapperTarget> parseWrapperTargets(Element targetsElement) {
+    ArrayList<WrapperTarget> targets = new ArrayList<>();
+    NodeList children = targetsElement.getElementsByTagName("callback-wrapper");
+    for (int i = 0; i < children.getLength(); i++) {
+      if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        Element targetElement = (Element) children.item(i);
+        WrapperTarget target = new WrapperTarget();
+
+        target.registrationSignature
+            = Scene.v().getSubSigNumberer().findOrAdd(targetElement.getAttribute("registration-subsignature"));
+
+        target.targets
+            = parseRegisteredTargets((Element) (targetElement.getElementsByTagName("handlers").item(0)));
+
+        if (targetElement.getAttribute("wrapper-position").equals("argument")) {
+          target.isBase = false;
+          target.argIndex = Integer.valueOf(targetElement.getAttribute("wrapper-argument-index"));
+        } else {
+          target.isBase = true;
+          target.argIndex = -1;
+        }
+        targets.add(target);
       }
     }
     return targets;
@@ -118,6 +243,12 @@ public class VirtualEdgesSummaries {
      * The method signature at which to insert this edge.
      */
     String signature;
+
+    @Override
+    public String toString() {
+      return signature;
+    }
+
   }
 
   public static class InstanceinvokeSource extends VirtualEdgeSource {
@@ -128,27 +259,65 @@ public class VirtualEdgesSummaries {
      * The method subsignature at which to insert this edge.
      */
     NumberedString subSignature;
+
+    @Override
+    public String toString() {
+      return subSignature.toString();
+    }
+
   }
 
   public static abstract class VirtualEdgeTarget {
+
+    boolean isBase;
+
+    int argIndex;
+
+    @Override
+    public String toString() {
+      return isBase ? "base" : String.format("argument %d", argIndex);
+    }
 
   }
 
   public static class DirectTarget extends VirtualEdgeTarget {
     NumberedString targetMethod;
 
-    boolean isBase;
+    @Override
+    public String toString() {
+      return String.format("Direct to %s on %s", targetMethod.toString(), super.toString());
+    }
 
-    int argIndex;
   }
 
-  public static class IndirectTarget extends VirtualEdgeTarget {
+  public static class RegisteredHandlerTarget {
+    int argIndex;
+    NumberedString targetMethod;
+
+    @Override
+    public String toString() {
+      return String.format("Register to %s passed at %d", targetMethod.toString(), argIndex);
+    }
+
+  }
+
+  public static class WrapperTarget extends VirtualEdgeTarget {
     NumberedString registrationSignature;
 
-    boolean isBase;
+    @Override
+    public String toString() {
+      String targetstr = "";
+      for (RegisteredHandlerTarget t : targets) {
+        targetstr += "(" + t.toString() + ") ";
+      }
+      return String.format("(Instances passed to <?: %s> on %s => %s)", registrationSignature.toString(), super.toString(),
+          targetstr);
 
-    int argIndex;
-    ArrayList<DirectTarget> targets;
+    }
+
+    ArrayList<RegisteredHandlerTarget> targets;
+
+
   }
 
 
@@ -159,6 +328,15 @@ public class VirtualEdgesSummaries {
     Kind edgeType;
     VirtualEdgeSource source;
     ArrayList<VirtualEdgeTarget> targets;
+
+    @Override
+    public String toString() {
+      String targetstr = "";
+      for (VirtualEdgeTarget t : targets) {
+        targetstr += t.toString() + " ";
+      }
+      return String.format("%s %s => %s", edgeType, source.toString(), targetstr);
+    }
 
 
   }

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
@@ -159,10 +159,12 @@ public class VirtualEdgesSummaries {
 
   private static VirtualEdgeSource parseEdgeSource(Element source) {
     String type = source.getAttribute("invoketype");
-    if ("instance".equals(type))
-        return new InstanceinvokeSource(source.getAttribute("subsignature"));
-    if ("static".equals(type))
-        return new StaticinvokeSource(source.getAttribute("signature"));
+    if ("instance".equals(type)) {
+      return new InstanceinvokeSource(source.getAttribute("subsignature"));
+    }
+    if ("static".equals(type)) {
+      return new StaticinvokeSource(source.getAttribute("signature"));
+    }
     return null;
   }
 

--- a/src/main/resources/virtualedges.xml
+++ b/src/main/resources/virtualedges.xml
@@ -136,4 +136,19 @@
 	
 	
 	
+	
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="add(com.android.volley.Request)" />
+		<targets>
+			<wrapper target="argument" position="0" >
+				<registration subsignature="init(java.lang.String,com.Android.volley.Response.Listener)">
+					<targets>
+						<method subsignature="void onResponse(java.lang.Bitmap)" target="argument" position="1" />
+					</targets>
+				</registration>
+			</wrapper>
+		</targets>
+		
+	</edge>
+	
 </virtualedges>

--- a/src/main/resources/virtualedges.xml
+++ b/src/main/resources/virtualedges.xml
@@ -5,7 +5,7 @@
 	<edge type="THREAD">
 		<source invoketype="instance" subsignature="void start()" />
 		<targets>
-			<method subsignature="void run()" target="base"/>
+			<direct subsignature="void run()" target="base"/>
 		</targets>
 	</edge>
 	
@@ -13,37 +13,37 @@
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="void execute(java.lang.Runnable)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="boolean post(java.lang.Runnable)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="boolean postAtFrontOfQueue(java.lang.Runnable)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,long)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,java.lang.Object,long)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="boolean postDelayed(java.lang.Runnable,long)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	
@@ -51,7 +51,7 @@
 	<edge type="EXECUTOR">
 		<source invoketype="instance" subsignature="void runOnUiThread(java.lang.Runnable)" />
 		<targets>
-			<method subsignature="void run()" target="argument" position="0"/>
+			<direct subsignature="void run()" target-position="argument" index="0"/>
 		</targets>
 	</edge>
 	
@@ -59,43 +59,43 @@
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean sendEmptyMessage(int)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean sendEmptyMessageAtTime(int,long)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean sendEmptyMessageDelayed(int,long)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,long)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean sendMessageAtFrontOfQueue(android.os.Message)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean sendMessageAtTime(android.os.Message,long)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	<edge type="HANDLER">
 		<source invoketype="instance" subsignature="boolean sendMessageDelayed(android.os.Message,long)" />
 		<targets>
-			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+			<direct subsignature="void handleMessage(android.os.Message)" target="base"/>
 		</targets>
 	</edge>
 	
@@ -104,7 +104,7 @@
 	<edge type="ASYNCTASK">
 		<source invoketype="instance" subsignature="android.os.AsyncTask execute(java.lang.Object[])" />
 		<targets>
-			<method subsignature="java.lang.Object doInBackground(java.lang.Object[])" target="base"/>
+			<direct subsignature="java.lang.Object doInBackground(java.lang.Object[])" target="base"/>
 		</targets>
 	</edge>
 	
@@ -112,43 +112,329 @@
 	<edge type="PRIVILEDGED">
 		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction)&gt;" />
 		<targets>
-			<method subsignature="java.lang.Object run()" target="base"/>
+			<direct subsignature="java.lang.Object run()" target-position="argument" index="0" />
 		</targets>
 	</edge>
 	<edge type="PRIVILEDGED">
 		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedExceptionAction)&gt;" />
 		<targets>
-			<method subsignature="java.lang.Object run()" target="base"/>
+			<direct subsignature="java.lang.Object run()" target-position="argument" index="0" />
 		</targets>
 	</edge>
 	<edge type="PRIVILEDGED">
 		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction,java.security.AccessControlContext)&gt;" />
 		<targets>
-			<method subsignature="java.lang.Object run()" target="base"/>
+			<direct subsignature="java.lang.Object run()" target-position="argument" index="0" />
 		</targets>
 	</edge>
 	<edge type="PRIVILEDGED">
 		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedExceptionAction,java.security.AccessControlContext)&gt;" />
 		<targets>
-			<method subsignature="java.lang.Object run()" target="base"/>
+			<direct subsignature="java.lang.Object run()" target-position="argument" index="0" />
 		</targets>
 	</edge>
 	
-	
-	
+	<!-- An example for a callback called through indirection. onResponse() will not be called if it is only passed to a request constructor, but when the Request is scheduled to a RequestQueue. -->
 	
 	<edge type="HANDLER">
-		<source invoketype="instance" subsignature="add(com.android.volley.Request)" />
+		<source invoketype="instance" subsignature="com.android.volley.Request add(com.android.volley.Request)" />
 		<targets>
-			<wrapper target="argument" position="0" >
-				<registration subsignature="init(java.lang.String,com.Android.volley.Response.Listener)">
-					<targets>
-						<method subsignature="void onResponse(java.lang.Bitmap)" target="argument" position="1" />
-					</targets>
-				</registration>
-			</wrapper>
+			<callback-wrapper wrapper-position="argument" wrapper-argument-index="0" registration-subsignature="void &lt;init&gt;(int,java.lang.String,com.android.volley.Response$Listener,com.android.volley.Response$ErrorListener)">
+				<handlers>
+					<registered-handler target-argument-index="1" target-subsignature="void onResponse(android.graphics.Bitmap)"  />
+				</handlers>
+			</callback-wrapper>
+			<callback-wrapper wrapper-position="argument" wrapper-argument-index="0" registration-subsignature="void &lt;init&gt;(java.lang.String,com.android.volley.Response$Listener,int,int,android.graphics.Bitmap$Config,com.android.volley.Response$ErrorListener)">
+				<handlers>
+					<registered-handler target-argument-index="1" target-subsignature="void onResponse(android.graphics.Bitmap)"  />
+				</handlers>
+			</callback-wrapper>
 		</targets>
 		
 	</edge>
 	
+	<!-- callback summaries automatically detected from real-world applications. previously, soot failed to add any edges into these callback functions. -->
+	
+	<!-- java.io.Files list predicate -->
+	<edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.lang.String[] list(java.io.FilenameFilter)" />
+        <targets>
+            <direct subsignature="boolean accept(java.io.File,java.lang.String)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.io.File[] listFiles(java.io.FilenameFilter)" />
+        <targets>
+            <direct subsignature="boolean accept(java.io.File,java.lang.String)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.io.File[] listFiles(java.io.FileFilter)" />
+        <targets>
+            <direct subsignature="boolean accept(java.io.File)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- Java reflection  -->
+    
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.lang.Object newProxyInstance(java.lang.ClassLoader,java.lang.Class[],java.lang.reflect.InvocationHandler)" />
+        <targets>
+            <direct subsignature="java.lang.Object invoke(java.lang.Object,java.lang.reflect.Method,java.lang.Object[])" target-position="argument" index="2" />
+        </targets>
+    </edge>
+    
+    <!-- java.net.URLStreamHandler -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void setURLStreamHandlerFactory(java.net.URLStreamHandlerFactory)" />
+        <targets>
+            <direct subsignature="java.net.URLStreamHandler createURLStreamHandler(java.lang.String)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- Android Tasks API -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.tasks.Task addOnCompleteListener(com.google.android.gms.tasks.OnCompleteListener)" />
+        <targets>
+            <direct subsignature="void onComplete(com.google.android.gms.tasks.Task)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.tasks.Task addOnCompleteListener(android.app.Activity,com.google.android.gms.tasks.OnCompleteListener)" />
+        <targets>
+            <direct subsignature="void onComplete(com.google.android.gms.tasks.Task)" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.tasks.Task addOnFailureListener(com.google.android.gms.tasks.OnFailureListener)" />
+        <targets>
+            <direct subsignature="void onFailure(java.lang.Exception)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.tasks.Task continueWithTask(java.util.concurrent.Executor,com.google.android.gms.tasks.Continuation)" />
+        <targets>
+            <direct subsignature="java.lang.Object then(com.google.android.gms.tasks.Task)" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.tasks.Task call(java.util.concurrent.Executor,java.util.concurrent.Callable)" />
+        <targets>
+            <direct subsignature="java.lang.Object call()" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.tasks.Task addOnCompleteListener(java.util.concurrent.Executor,com.google.android.gms.tasks.OnCompleteListener)" />
+        <targets>
+            <direct subsignature="void onComplete(com.google.android.gms.tasks.Task)" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void setResultCallback(com.google.android.gms.common.api.ResultCallback,long,java.util.concurrent.TimeUnit)" />
+        <targets>
+            <direct subsignature="void onResult(com.google.android.gms.common.api.Result)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+   
+    <!-- Android Misc. -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void startConnection(com.android.installreferrer.api.InstallReferrerStateListener)" />
+        <targets>
+            <direct subsignature="void onInstallReferrerSetupFinished(int)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- Kotlin Lazy Evaluation -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="kotlin.Lazy lazy(kotlin.jvm.functions.Function0)" />
+        <targets>
+            <direct subsignature="java.lang.Object invoke()" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- Google Ads -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.android.gms.ads.AdLoader$Builder forUnifiedNativeAd(com.google.android.gms.ads.formats.UnifiedNativeAd$OnUnifiedNativeAdLoadedListener)" />
+        <targets>
+            <direct subsignature="void onUnifiedNativeAdLoaded(com.google.android.gms.ads.formats.UnifiedNativeAd)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+	<edge type="HANDLER">
+        <source invoketype="instance" subsignature="void requestConsentInfoUpdate(java.lang.String[],com.google.ads.consent.ConsentInfoUpdateListener)" />
+        <targets>
+            <direct subsignature="void onFailedToUpdateConsentInfo(java.lang.String)" target-position="argument" index="1" />
+            <direct subsignature="void onConsentInfoUpdated(com.google.ads.consent.ConsentStatus)" target-position="argument" index="1" />
+        </targets>
+    </edge>
+     <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void openContainer(com.google.tagmanager.TagManager,java.lang.String,com.google.tagmanager.ContainerOpener$OpenType,java.lang.Long,com.google.tagmanager.ContainerOpener$Notifier)" />
+        <targets>
+            <direct subsignature="void containerAvailable(com.google.tagmanager.Container)" target-position="argument" index="4" />
+        </targets>
+    </edge>
+    
+	<!-- Android IAB -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void startSetup(com.android.vending.billing.util.IabHelper$OnIabSetupFinishedListener)" />
+        <targets>
+            <direct subsignature="void onIabSetupFinished(com.android.vending.billing.util.IabResult)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void startConnection(com.android.billingclient.api.BillingClientStateListener)" />
+        <targets>
+            <direct subsignature="void onBillingSetupFinished(int)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- Dagger -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="dagger.internal.Binding contributeProvidesBinding(java.lang.String,dagger.internal.ProvidesBinding)" />
+        <targets>
+            <direct subsignature="java.lang.Object get()" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    
+     <!-- Apache Http -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.lang.Object execute(org.apache.http.HttpHost,org.apache.http.HttpRequest,org.apache.http.client.ResponseHandler)" />
+        <targets>
+            <direct subsignature="java.lang.Object handleResponse(org.apache.http.HttpResponse)" target-position="argument" index="2" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void addRequestInterceptor(org.apache.http.HttpRequestInterceptor)" />
+        <targets>
+            <direct subsignature="void process(org.apache.http.HttpRequest,org.apache.http.protocol.HttpContext)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void addResponseInterceptor(org.apache.http.HttpResponseInterceptor)" />
+        <targets>
+            <direct subsignature="void process(org.apache.http.HttpResponse,org.apache.http.protocol.HttpContext)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void setEntity(org.apache.http.HttpEntity)" />
+        <targets>
+            <direct subsignature="org.apache.http.Header getContentType()" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.lang.Object execute(org.apache.http.client.methods.HttpUriRequest,org.apache.http.client.ResponseHandler)" />
+        <targets>
+            <direct subsignature="java.lang.Object handleResponse(org.apache.http.HttpResponse)" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void setRedirectHandler(org.apache.http.client.RedirectHandler)" />
+        <targets>
+            <direct subsignature="boolean isRedirectRequested(org.apache.http.HttpResponse,org.apache.http.protocol.HttpContext)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="java.lang.Object execute(org.apache.http.client.methods.HttpUriRequest,org.apache.http.client.ResponseHandler)" />
+        <targets>
+            <direct subsignature="java.lang.Object handleResponse(org.apache.http.HttpResponse)" target-position="argument" index="1" />
+        </targets>
+    </edge>
+    
+    <!-- ReactiveX -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="io.reactivex.Observable filter(io.reactivex.functions.Predicate)" />
+        <targets>
+            <direct subsignature="boolean test(java.lang.Object)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="io.reactivex.disposables.Disposable subscribe(io.reactivex.functions.Consumer)" />
+        <targets>
+            <direct subsignature="void accept(java.lang.Object)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="io.reactivex.Single fromCallable(java.util.concurrent.Callable)" />
+        <targets>
+            <direct subsignature="java.lang.Object call()" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="io.reactivex.Single create(io.reactivex.SingleOnSubscribe)" />
+        <targets>
+            <direct subsignature="void subscribe(io.reactivex.SingleEmitter)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="io.reactivex.Maybe filter(io.reactivex.functions.Predicate)" />
+        <targets>
+            <direct subsignature="boolean test(java.lang.Object)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    <!-- Android volley -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.android.volley.Request add(com.android.volley.Request)" />
+        <targets>
+            <direct subsignature="java.util.Map getParams()" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- OkHttp -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="okhttp3.OkHttpClient$Builder addInterceptor(okhttp3.Interceptor)" />
+        <targets>
+            <direct subsignature="okhttp3.Response intercept(okhttp3.Interceptor$Chain)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- actionbarsherlock -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void setOnQueryTextListener(com.actionbarsherlock.widget.SearchView$OnQueryTextListener)" />
+        <targets>
+            <direct subsignature="boolean onQueryTextChange(java.lang.String)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+
+    <!-- GSON -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.gson.GsonBuilder registerTypeAdapterFactory(com.google.gson.TypeAdapterFactory)" />
+        <targets>
+            <direct subsignature="com.google.gson.TypeAdapter create(com.google.gson.Gson,com.google.gson.reflect.TypeToken)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+	<edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.google.gson.GsonBuilder setFieldNamingStrategy(com.google.gson.FieldNamingStrategy)" />
+        <targets>
+            <direct subsignature="java.lang.String translateName(java.lang.reflect.Field)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+	<!-- React -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void addUIBlock(com.facebook.react.uimanager.UIBlock)" />
+        <targets>
+            <direct subsignature="void execute(com.facebook.react.uimanager.NativeViewHierarchyManager)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+   	<!-- Google Inject -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void register(com.google.inject.spi.InjectionListener)" />
+        <targets>
+            <direct subsignature="void afterInjection(java.lang.Object)" target-position="argument" index="0" />
+        </targets>
+    </edge>
+    
+    <!-- Bumptech Glide UI Framework -->
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="void register(java.lang.Class,java.lang.Class,com.bumptech.glide.load.model.ModelLoaderFactory)" />
+        <targets>
+            <direct subsignature="com.bumptech.glide.load.model.ModelLoader build(android.content.Context,com.bumptech.glide.load.model.GenericLoaderFactory)" target-position="argument" index="2" />
+        </targets>
+    </edge>
+    <edge type="HANDLER">
+        <source invoketype="instance" subsignature="com.bumptech.glide.BitmapRequestBuilder listener(com.bumptech.glide.request.RequestListener)" />
+        <targets>
+            <direct subsignature="boolean onResourceReady(java.lang.Object,java.lang.Object,com.bumptech.glide.request.target.Target,boolean,boolean)" target-position="argument" index="0" />
+        </targets>
+    </edge>
 </virtualedges>

--- a/src/main/resources/virtualedges.xml
+++ b/src/main/resources/virtualedges.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+
+<virtualedges>
+	<!-- Thread.start()  -->
+	<edge type="THREAD">
+		<source invoketype="instance" subsignature="void start()" />
+		<targets>
+			<method subsignature="void run()" target="base"/>
+		</targets>
+	</edge>
+	
+	<!-- execute and post methods -->
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="void execute(java.lang.Runnable)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="boolean post(java.lang.Runnable)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="boolean postAtFrontOfQueue(java.lang.Runnable)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,long)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,java.lang.Object,long)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="boolean postDelayed(java.lang.Runnable,long)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	
+	<!-- Android runOnUIThread -->
+	<edge type="EXECUTOR">
+		<source invoketype="instance" subsignature="void runOnUiThread(java.lang.Runnable)" />
+		<targets>
+			<method subsignature="void run()" target="argument" position="0"/>
+		</targets>
+	</edge>
+	
+	<!-- Handlers -->
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean sendEmptyMessage(int)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean sendEmptyMessageAtTime(int,long)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean sendEmptyMessageDelayed(int,long)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,long)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean sendMessageAtFrontOfQueue(android.os.Message)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean sendMessageAtTime(android.os.Message,long)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	<edge type="HANDLER">
+		<source invoketype="instance" subsignature="boolean sendMessageDelayed(android.os.Message,long)" />
+		<targets>
+			<method subsignature="void handleMessage(android.os.Message)" target="base"/>
+		</targets>
+	</edge>
+	
+	
+	<!-- Android AsyncTask -->
+	<edge type="ASYNCTASK">
+		<source invoketype="instance" subsignature="android.os.AsyncTask execute(java.lang.Object[])" />
+		<targets>
+			<method subsignature="java.lang.Object doInBackground(java.lang.Object[])" target="base"/>
+		</targets>
+	</edge>
+	
+	<!-- doPriviledged -->
+	<edge type="PRIVILEDGED">
+		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction)&gt;" />
+		<targets>
+			<method subsignature="java.lang.Object run()" target="base"/>
+		</targets>
+	</edge>
+	<edge type="PRIVILEDGED">
+		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedExceptionAction)&gt;" />
+		<targets>
+			<method subsignature="java.lang.Object run()" target="base"/>
+		</targets>
+	</edge>
+	<edge type="PRIVILEDGED">
+		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction,java.security.AccessControlContext)&gt;" />
+		<targets>
+			<method subsignature="java.lang.Object run()" target="base"/>
+		</targets>
+	</edge>
+	<edge type="PRIVILEDGED">
+		<source invoketype="static" signature="&lt;java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedExceptionAction,java.security.AccessControlContext)&gt;" />
+		<targets>
+			<method subsignature="java.lang.Object run()" target="base"/>
+		</targets>
+	</edge>
+	
+	
+	
+</virtualedges>

--- a/src/systemTest/java/soot/asm/AsmInnerClassTest.java
+++ b/src/systemTest/java/soot/asm/AsmInnerClassTest.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import soot.Modifier;
 import soot.Scene;
 import soot.SootMethod;
@@ -35,6 +37,7 @@ import soot.tagkit.InnerClassTag;
 import soot.tagkit.Tag;
 import soot.testing.framework.AbstractTestingFramework;
 
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class AsmInnerClassTest extends AbstractTestingFramework {
 
   private static final String TEST_TARGET_CLASS = "soot.asm.ScopeFinderTarget";

--- a/src/systemTest/java/soot/asm/AsmMethodSourceTest.java
+++ b/src/systemTest/java/soot/asm/AsmMethodSourceTest.java
@@ -26,7 +26,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
+
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import soot.Body;
 import soot.SootMethod;
 import soot.Unit;
@@ -34,6 +37,7 @@ import soot.options.Options;
 import soot.testing.framework.AbstractTestingFramework;
 
 /** @author Manuel Benz at 13.02.20 */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class AsmMethodSourceTest extends AbstractTestingFramework {
 
   private static final String TEST_TARGET_CLASS = "soot.asm.LineNumberExtraction";

--- a/src/systemTest/java/soot/asm/ResolveFieldInitializersTest.java
+++ b/src/systemTest/java/soot/asm/ResolveFieldInitializersTest.java
@@ -25,11 +25,14 @@ package soot.asm;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import soot.Scene;
 import soot.SootClass;
 import soot.testing.framework.AbstractTestingFramework;
 
 /** @author Manuel Benz at 20.02.20 */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class ResolveFieldInitializersTest extends AbstractTestingFramework {
 
   private static final String TEST_TARGET_CLASS = "soot.asm.ResolveFieldInitializers";

--- a/src/systemTest/java/soot/defaultInterfaceMethods/DefaultInterfaceTest.java
+++ b/src/systemTest/java/soot/defaultInterfaceMethods/DefaultInterfaceTest.java
@@ -34,18 +34,19 @@ import com.google.common.collect.Sets;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import soot.Body;
 import soot.FastHierarchy;
 import soot.MethodOrMethodContext;
-import soot.PackManager;
 import soot.PhaseOptions;
 import soot.Scene;
 import soot.SootClass;
@@ -57,10 +58,10 @@ import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.jimple.toolkits.callgraph.Edge;
 import soot.jimple.toolkits.callgraph.ReachableMethods;
 import soot.jimple.toolkits.callgraph.VirtualCalls;
-import soot.options.Options;
 import soot.testing.framework.AbstractTestingFramework;
 
 /** */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class DefaultInterfaceTest extends AbstractTestingFramework {
 	
 	private static String voidType = "void";

--- a/src/systemTest/java/soot/jimple/PropagateLineNumberTagTest.java
+++ b/src/systemTest/java/soot/jimple/PropagateLineNumberTagTest.java
@@ -27,7 +27,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import soot.Body;
 import soot.SootMethod;
 import soot.Unit;
@@ -38,6 +41,7 @@ import soot.tagkit.LineNumberTag;
 import soot.testing.framework.AbstractTestingFramework;
 
 /** @author Manuel Benz at 20.01.20 */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class PropagateLineNumberTagTest extends AbstractTestingFramework {
 
   private static final String TEST_TARGET_CLASS = "soot.jimple.PropagateLineNumberTag";

--- a/src/systemTest/java/soot/jimple/toolkit/callgraph/TypeBasedReflectionModelAnySubTypeTest.java
+++ b/src/systemTest/java/soot/jimple/toolkit/callgraph/TypeBasedReflectionModelAnySubTypeTest.java
@@ -26,12 +26,12 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import soot.Kind;
 import soot.RefType;
@@ -44,6 +44,7 @@ import soot.options.Options;
 import soot.testing.framework.AbstractTestingFramework;
 
 
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class TypeBasedReflectionModelAnySubTypeTest extends AbstractTestingFramework {
   private static final String[] INTERFACE_INVOKEES = new String[] {
       "<soot.jimple.toolkit.callgraph.SubImplementation: void invokeTarget(java.lang.String)>",

--- a/src/systemTest/java/soot/lambdaMetaFactory/Issue1146Test.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/Issue1146Test.java
@@ -23,9 +23,9 @@ package soot.lambdaMetaFactory;
  */
 
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import soot.SootMethod;
-import soot.options.Options;
 import soot.testing.framework.AbstractTestingFramework;
 
 /**
@@ -33,6 +33,7 @@ import soot.testing.framework.AbstractTestingFramework;
  *
  * @author Manuel Benz at 2019-05-14
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class Issue1146Test extends AbstractTestingFramework {
 
   @Test

--- a/src/systemTest/java/soot/lambdaMetaFactory/Issue1292Test.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/Issue1292Test.java
@@ -22,6 +22,8 @@ package soot.lambdaMetaFactory;
  */
 
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import soot.testing.framework.AbstractTestingFramework;
 
 /**
@@ -29,6 +31,7 @@ import soot.testing.framework.AbstractTestingFramework;
  *
  * @author raintung.li
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class Issue1292Test extends AbstractTestingFramework {
 
   @Test

--- a/src/systemTest/java/soot/lambdaMetaFactory/Issue1367Test.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/Issue1367Test.java
@@ -23,6 +23,7 @@ package soot.lambdaMetaFactory;
  */
 
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import soot.SootMethod;
 import soot.testing.framework.AbstractTestingFramework;
@@ -32,6 +33,7 @@ import soot.testing.framework.AbstractTestingFramework;
  *
  * @author David Seekatz
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class Issue1367Test extends AbstractTestingFramework {
 
     @Test

--- a/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryAdaptTest.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryAdaptTest.java
@@ -1,39 +1,15 @@
 package soot.lambdaMetaFactory;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2018 Manuel Benz
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import org.junit.Rule;
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import soot.SootMethod;
 import soot.testing.framework.AbstractTestingFramework;
 
 /**
  * @author Manuel Benz created on 2018-12-18
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class LambdaMetaFactoryAdaptTest extends AbstractTestingFramework {
 
   @Test

--- a/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryAdaptTest.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryAdaptTest.java
@@ -1,5 +1,27 @@
 package soot.lambdaMetaFactory;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2019 Manuel Benz
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 

--- a/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryCHATest.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryCHATest.java
@@ -1,5 +1,7 @@
 package soot.lambdaMetaFactory;
 
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,6 +29,7 @@ import soot.PhaseOptions;
 /**
  * @author Manuel Benz created on 31.10.18
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class LambdaMetaFactoryCHATest extends AbstractLambdaMetaFactoryCGTest {
 
   @Override

--- a/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryRTATest.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryRTATest.java
@@ -1,5 +1,7 @@
 package soot.lambdaMetaFactory;
 
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,6 +29,7 @@ import soot.options.Options;
 /**
  * @author Manuel Benz created on 31.10.18
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class LambdaMetaFactoryRTATest extends AbstractLambdaMetaFactoryCGTest {
 
   @Override

--- a/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactorySPARKTest.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactorySPARKTest.java
@@ -1,5 +1,7 @@
 package soot.lambdaMetaFactory;
 
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,6 +29,7 @@ import soot.PhaseOptions;
 /**
  * @author Manuel Benz created on 31.10.18
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class LambdaMetaFactorySPARKTest extends AbstractLambdaMetaFactoryCGTest {
 
   @Override

--- a/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryVTATest.java
+++ b/src/systemTest/java/soot/lambdaMetaFactory/LambdaMetaFactoryVTATest.java
@@ -1,5 +1,7 @@
 package soot.lambdaMetaFactory;
 
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,6 +29,7 @@ import soot.options.Options;
 /**
  * @author Manuel Benz created on 31.10.18
  */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class LambdaMetaFactoryVTATest extends AbstractLambdaMetaFactoryCGTest {
 
   @Override

--- a/src/systemTest/java/soot/testing/framework/HelloTestingFrameworkTest.java
+++ b/src/systemTest/java/soot/testing/framework/HelloTestingFrameworkTest.java
@@ -24,6 +24,7 @@ package soot.testing.framework;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import soot.SootMethod;
 
@@ -31,7 +32,7 @@ import soot.SootMethod;
  * @author Manuel Benz created on 22.06.18
  */
 
-
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
 public class HelloTestingFrameworkTest extends AbstractTestingFramework {
 
   private static final String TEST_TARGET_CLASS = "soot.testing.framework.HelloTestingFrameworkTarget";


### PR DESCRIPTION
Addressed issue #1064, OnFlyCallgraphBuilder now loads library descriptions from a configuration file in `src/main/resources/virtualedges.xml`. Added missing java stdlib functions to such as java.io.Files.listFiles(). Additionally added callback summaries for several libraries. Additionally, allow specifying "Indirect Callbacks" to describe behavior such as the following:
```
Request r = new Request(" http ://www. example .com");
ResponseHandler handler = new ResponseHandler(){
    @Override
    void onResponse(String[] data, int httpStatus)
    ...
    }
};
r.setResponseHandler(handler);
requestQueue.add(r);
```
