### PR TITLE
Avoid infinite recursion in FastHierarchy.resolveMethod

### DIFF
--- a/src/main/java/soot/FastHierarchy.java
+++ b/src/main/java/soot/FastHierarchy.java
@@ -696,7 +696,7 @@ public class FastHierarchy {
    * @return The concrete method o.f() to call
    */
   public SootMethod resolveMethod(SootClass baseType, SootMethod m, boolean allowAbstract) {
-    return resolveMethod(baseType, m, allowAbstract);
+    return resolveMethod(baseType, m.makeRef(), allowAbstract);
   }
 
   /**

--- a/src/systemTest/java/soot/defaultInterfaceMethods/DefaultInterfaceTest.java
+++ b/src/systemTest/java/soot/defaultInterfaceMethods/DefaultInterfaceTest.java
@@ -115,6 +115,10 @@ public class DefaultInterfaceTest extends AbstractTestingFramework {
         Scene.v()
             .getFastHierarchy()
             .resolveConcreteDispatch(Scene.v().getSootClass(testClass), defaultMethod);
+    SootMethod concreteImplViaResolveMethod =
+        Scene.v()
+            .getFastHierarchy()
+            .resolveMethod(Scene.v().getSootClass(testClass), defaultMethod, false);
     Set<SootMethod> abstractImpl =
         Scene.v()
             .getFastHierarchy()
@@ -131,6 +135,7 @@ public class DefaultInterfaceTest extends AbstractTestingFramework {
     assertTrue(reachableMethods.contains(defaultMethod));
     assertTrue(edgePresent);
     assertEquals(defaultMethod, concreteImpl);
+    assertEquals(concreteImpl, concreteImplViaResolveMethod);
     assertTrue(
         abstractImpl.contains(
             Scene.v().getMethod("<soot.defaultInterfaceMethods.Default: void target()>")));


### PR DESCRIPTION
The FastHierarchy.resolveMethod(SootClass baseType, SootMethod m,
boolean allowAbstract) method always calls itself, which eventually
results in a java.lang.StackOverflowError. Instead, it should call
the FastHierarchy.resolveMethod(SootClass baseType, SootMethodRef m,
boolean allowAbstract) method (the SootMethodRef is obtained via
m.makeRef()).