### PR TITLE
fix bug in isAccessLegal(..)

### DIFF
--- a/src/main/java/soot/jimple/toolkits/invoke/InlinerSafetyManager.java
+++ b/src/main/java/soot/jimple/toolkits/invoke/InlinerSafetyManager.java
@@ -37,7 +37,9 @@ import soot.jimple.InvokeExpr;
 import soot.jimple.SpecialInvokeExpr;
 import soot.jimple.Stmt;
 
-/** Methods for checking safety requirements for inlining. */
+/**
+ * Methods for checking safety requirements for inlining.
+ */
 public class InlinerSafetyManager {
 
   private static final boolean PRINT_FAILURE_REASONS = true;
@@ -258,5 +260,8 @@ public class InlinerSafetyManager {
     // ACC_SUPER must always be set, eh?
     Hierarchy h = Scene.v().getActiveHierarchy();
     return h.isClassSuperclassOf(m.getDeclaringClass(), containerClass);
+  }
+
+  private InlinerSafetyManager() {
   }
 }


### PR DESCRIPTION
Protected methods were not allowed to reference other classes in the same package as specified by the definition of the protected keyword.
Additionally, some refactoring and formatting.