### PR TITLE
Tamiflex also supports "Array.newInstance"...

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1800,6 +1800,10 @@ public class Scene {
             classNames.add(signatureToClass(target));
           } else if (kind.equals("Field.set*") || kind.equals("Field.get*")) {
             classNames.add(signatureToClass(target));
+          } else if (kind.equals("Array.newInstance")) {
+            // do nothing
+          } else if (kind.equals("Method.getModifiers") || kind.equals("Method.getName")) {
+            classNames.add(signatureToClass(target));
           } else {
             throw new RuntimeException("Unknown entry kind: " + kind);
           }


### PR DESCRIPTION
Tamiflex also supports "Array.newInstance", "Method.getModifiers" and "Method.getName".  To avoid a crash bug when load reflection logs generated by Tamiflex, we need to append these lines.