### PR TITLE
Improve javadoc for getSootClassUnsafe/getSootClass

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1117,6 +1117,9 @@ public class Scene {
    * Returns the SootClass with the given className. If no class with the given name exists, null is returned unless phantom
    * refs are allowed. In this case, a new phantom class is created.
    *
+   * The difference with the getSootClass() version is that this version doesn't throw a RuntimeException
+   * if the requested class doesn't exist in the Scene. Instead it returns null.
+   *
    * @param className
    *          The name of the class to get
    * @return The class if it exists, otherwise null
@@ -1129,11 +1132,16 @@ public class Scene {
    * Returns the SootClass with the given className. If no class with the given name exists, null is returned unless
    * phantomNonExist=true and phantom refs are allowed. In this case, a new phantom class is created and returned.
    *
+   * The difference with the getSootClass() version is that this version doesn't throw a RuntimeException
+   * if the requested class doesn't exist in the Scene. Instead it returns null or a phantom class, depending
+   * on the flag.
+   *
    * @param className
    *          The name of the class to get
    * @param phantomNonExist
    *          Indicates that a phantom class should be created if a class with the given name does not exist and phantom refs
    *          are allowed
+   *
    * @return The class if it exists, otherwise null
    */
   public SootClass getSootClassUnsafe(String className, boolean phantomNonExist) {
@@ -1166,7 +1174,9 @@ public class Scene {
     return null;
   }
 
-  /** Returns the SootClass with the given className. */
+  /** Returns the SootClass with the given className.
+   * @param className The name of the class to get; throws RuntimeException if this class does not exist.
+   */
   public SootClass getSootClass(String className) {
     SootClass sc = getSootClassUnsafe(className);
     if (sc != null) {


### PR DESCRIPTION
I probably wouldn't have called the non-exception versions "unsafe" (unless I actually did), but let's improve the documentation to make it clear what the Unsafe version actually does.