### PR TITLE
Add java.lang.Number as a basic class

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1609,6 +1609,7 @@ public class Scene {
     addBasicClass("java.lang.Long", SootClass.SIGNATURES);
     addBasicClass("java.lang.Float", SootClass.SIGNATURES);
     addBasicClass("java.lang.Double", SootClass.SIGNATURES);
+    addBasicClass("java.lang.Number", SootClass.SIGNATURES);
 
     addBasicClass("java.lang.String");
     addBasicClass("java.lang.StringBuffer", SootClass.SIGNATURES);


### PR DESCRIPTION
When using soot on an Android.jar, java.lang.Float loaded from the classpath due to it being a basic class. In contrast, java.lang.Number is phantom because no_bodies_for_excluded is enabled and java.* is in the excluded packages. 

As Android.jar only contains stubs, the value field is missing in java.lang.Float. Because the superclass is phantom, soot resolves the value field in java.lang.Number which is incorrect. 

To force java.lang.Number to be not phantom, I added it to the basic classes. Locally tested using FlowDroid's and soot's tests. Seems fine.