### PR TITLE
Fix crashes in AsmMethodSource(#1577,#1580)

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -1902,6 +1902,16 @@ final class AsmMethodSource implements MethodSource {
     edges = null;
   }
 
+  Unit getUnitMaybeInlineExceptionHandler(AbstractInsnNode insn) {
+    Unit ret = getUnit(insn);
+
+    if (ret instanceof NopStmt && inlineExceptionHandlers.containsKey(insn)) {
+      return inlineExceptionHandlers.get(insn);
+    } else {
+      return ret;
+    }
+  }
+
   private void handleInlineExceptionHandler(LabelNode ln, ArrayDeque<Edge> worklist) {
     // Catch the exception
     CaughtExceptionRef ref = Jimple.v().newCaughtExceptionRef();
@@ -2065,7 +2075,7 @@ final class AsmMethodSource implements MethodSource {
 
       // We need to jump to the original implementation
       Unit targetUnit = units.get(ln);
-      GotoStmt gotoImpl = Jimple.v().newGotoStmt(targetUnit);
+      GotoStmt gotoImpl = Jimple.v().newGotoStmt(targetUnit instanceof UnitContainer ? ((UnitContainer) targetUnit).getFirstUnit() : targetUnit);
       body.getUnits().add(gotoImpl);
     }
 

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -2075,7 +2075,8 @@ final class AsmMethodSource implements MethodSource {
 
       // We need to jump to the original implementation
       Unit targetUnit = units.get(ln);
-      GotoStmt gotoImpl = Jimple.v().newGotoStmt(targetUnit instanceof UnitContainer ? ((UnitContainer) targetUnit).getFirstUnit() : targetUnit);
+      GotoStmt gotoImpl = Jimple.v().newGotoStmt(
+              targetUnit instanceof UnitContainer ? ((UnitContainer) targetUnit).getFirstUnit() : targetUnit);
       body.getUnits().add(gotoImpl);
     }
 

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -1785,24 +1785,21 @@ final class AsmMethodSource implements MethodSource {
         conversionWorklist.add(edge);
         continue;
       }
-      if (edge.stack != null) {
-        ArrayList<Operand> stackTemp = edge.stack;
-        if (stackTemp.size() != stackss.length) {
-          throw new AssertionError("Multiple un-equal stacks!");
-        }
-        for (int j = 0; j != stackss.length; j++) {
-          if (!stackTemp.get(j).equivTo(stackss[j])) {
-            throw new AssertionError("Multiple un-equal stacks!");
+      for (ArrayList<Operand> stackTemp : edge.stacks) {
+        if (stackTemp.size() == stackss.length) {
+          int j = 0;
+          for (; j != stackss.length && stackTemp.get(j).equivTo(stackss[j]); j++) {}
+          if (j == stackss.length) {
+            continue tgt_loop;
           }
         }
-        continue;
       }
       for (Operand[] ps : edge.prevStacks) {
         if (Arrays.equals(ps, stackss)) {
           continue tgt_loop;
         }
       }
-      edge.stack = new ArrayList<Operand>(stack);
+      edge.stacks.addLast(new ArrayList<Operand>(stack));
       edge.prevStacks.add(stackss);
       conversionWorklist.add(edge);
     } while (i <= lastIdx && (tgt = tgts.get(i++)) != null);
@@ -1824,13 +1821,12 @@ final class AsmMethodSource implements MethodSource {
     do {
       Edge edge = worklist.pollLast();
       AbstractInsnNode insn = edge.insn;
-      stack = edge.stack;
+      stack = edge.stacks.pollLast();
       // restore line. this is important since we might have traversed the edge that leads to
       // bytecode far away from the branch statement first and are now processing the statement
       // right after the branch which should start with the lastLineNumber as it was for the branch
       // statement
       lastLineNumber = edge.lastLineNumber == -1 ? lastLineNumber : edge.lastLineNumber;
-      edge.stack = null;
       do {
         int type = insn.getType();
         if (type == FIELD_INSN) {
@@ -2172,12 +2168,13 @@ final class AsmMethodSource implements MethodSource {
     final LinkedList<Operand[]> prevStacks;
     private int lastLineNumber = -1;
     /* current stack at edge */
-    ArrayList<Operand> stack;
+    final ArrayDeque<ArrayList<Operand>> stacks;
 
     Edge(AbstractInsnNode insn, ArrayList<Operand> stack) {
       this.insn = insn;
       this.prevStacks = new LinkedList<Operand[]>();
-      this.stack = stack;
+      this.stacks = new ArrayDeque<ArrayList<Operand>>();
+      this.stacks.addLast(stack);
     }
 
     Edge(AbstractInsnNode insn, int lastLineNumber) {

--- a/src/main/java/soot/asm/StackFrame.java
+++ b/src/main/java/soot/asm/StackFrame.java
@@ -194,7 +194,7 @@ final class StackFrame {
             AssignStmt as = Jimple.v().newAssignStmt(stack, newOp.value);
             src.setUnit(newOp.insn, as);
           } else {
-            Unit u = src.getUnit(newOp.insn);
+            Unit u = src.getUnitMaybeInlineExceptionHandler(newOp.insn);
             DefinitionStmt as = (DefinitionStmt) (u instanceof UnitContainer ? ((UnitContainer) u).getFirstUnit() : u);
             ValueBox lvb = as.getLeftOpBox();
             assert lvb.getValue() == newOp.stack : "Invalid stack local!";


### PR DESCRIPTION
Fix: https://github.com/soot-oss/soot/issues/1577

* `mergeIn()` should resolve the right `stack_n := @caughtException` when `nop` for `InlineExceptionHandler` appears.
* `UnitContainer` may appear instead of `nop` for `InlineExceptionHandler`.

Fix: https://github.com/soot-oss/soot/issues/1580

* Replace `Edge.stack` with `Edge.stacks` and keep `stack`s in the same order as `edge`s in `worklist`.