### PR TITLE
DexPrinter: improved handling of errors while writing a method

### DIFF
--- a/src/main/java/soot/Body.java
+++ b/src/main/java/soot/Body.java
@@ -71,17 +71,18 @@ import soot.validation.ValueBoxesValidator;
 @SuppressWarnings("serial")
 public abstract class Body extends AbstractHost implements Serializable {
   private static final Logger logger = LoggerFactory.getLogger(Body.class);
+
   /** The method associated with this Body. */
   protected transient SootMethod method = null;
 
   /** The chain of locals for this Body. */
-  protected Chain<Local> localChain = new HashChain<Local>();
+  protected Chain<Local> localChain = new HashChain<>();
 
   /** The chain of traps for this Body. */
-  protected Chain<Trap> trapChain = new HashChain<Trap>();
+  protected Chain<Trap> trapChain = new HashChain<>();
 
   /** The chain of units for this Body. */
-  protected UnitPatchingChain unitChain = new UnitPatchingChain(new HashChain<Unit>());
+  protected UnitPatchingChain unitChain = new UnitPatchingChain(new HashChain<>());
 
   private static BodyValidator[] validators;
 
@@ -146,7 +147,7 @@ public abstract class Body extends AbstractHost implements Serializable {
 
   /** Copies the contents of the given Body into this one. */
   public Map<Object, Object> importBodyContentsFrom(Body b) {
-    HashMap<Object, Object> bindings = new HashMap<Object, Object>();
+    HashMap<Object, Object> bindings = new HashMap<>();
 
     {
       // Clone units in body's statement list
@@ -222,7 +223,7 @@ public abstract class Body extends AbstractHost implements Serializable {
   }
 
   protected void runValidation(BodyValidator validator) {
-    final List<ValidationException> exceptionList = new ArrayList<ValidationException>();
+    final List<ValidationException> exceptionList = new ArrayList<>();
     validator.validate(this, exceptionList);
     if (!exceptionList.isEmpty()) {
       throw exceptionList.get(0);
@@ -231,7 +232,7 @@ public abstract class Body extends AbstractHost implements Serializable {
 
   /** Verifies a few sanity conditions on the contents on this body. */
   public void validate() {
-    List<ValidationException> exceptionList = new ArrayList<ValidationException>();
+    List<ValidationException> exceptionList = new ArrayList<>();
     validate(exceptionList);
     if (!exceptionList.isEmpty()) {
       throw exceptionList.get(0);
@@ -330,7 +331,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    */
   public List<Local> getParameterLocals() {
     final int numParams = getMethod().getParameterCount();
-    final List<Local> retVal = new ArrayList<Local>(numParams);
+    final List<Local> retVal = new ArrayList<>(numParams);
 
     // Parameters are zero-indexed, so the keeping of the index is safe
     for (Unit u : getUnits()) {
@@ -396,7 +397,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see soot.shimple.PhiExpr#getUnitBoxes()
    **/
   public List<UnitBox> getAllUnitBoxes() {
-    ArrayList<UnitBox> unitBoxList = new ArrayList<UnitBox>();
+    ArrayList<UnitBox> unitBoxList = new ArrayList<>();
     {
       Iterator<Unit> it = unitChain.iterator();
       while (it.hasNext()) {
@@ -443,7 +444,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see soot.shimple.PhiExpr#getUnitBoxes()
    **/
   public List<UnitBox> getUnitBoxes(boolean branchTarget) {
-    ArrayList<UnitBox> unitBoxList = new ArrayList<UnitBox>();
+    ArrayList<UnitBox> unitBoxList = new ArrayList<>();
     {
       Iterator<Unit> it = unitChain.iterator();
       while (it.hasNext()) {
@@ -494,7 +495,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    *
    */
   public List<ValueBox> getUseBoxes() {
-    ArrayList<ValueBox> useBoxList = new ArrayList<ValueBox>();
+    ArrayList<ValueBox> useBoxList = new ArrayList<>();
 
     Iterator<Unit> it = unitChain.iterator();
     while (it.hasNext()) {
@@ -537,7 +538,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see Value
    */
   public List<ValueBox> getUseAndDefBoxes() {
-    ArrayList<ValueBox> useAndDefBoxList = new ArrayList<ValueBox>();
+    ArrayList<ValueBox> useAndDefBoxList = new ArrayList<>();
 
     Iterator<Unit> it = unitChain.iterator();
     while (it.hasNext()) {
@@ -558,14 +559,12 @@ public abstract class Body extends AbstractHost implements Serializable {
   @Override
   public String toString() {
     ByteArrayOutputStream streamOut = new ByteArrayOutputStream();
-    PrintWriter writerOut = new PrintWriter(new EscapedWriter(new OutputStreamWriter(streamOut)));
-    try {
+    try (PrintWriter writerOut = new PrintWriter(new EscapedWriter(new OutputStreamWriter(streamOut)))) {
       Printer.v().printTo(this, writerOut);
+      writerOut.flush();
     } catch (RuntimeException e) {
       logger.error(e.getMessage(), e);
     }
-    writerOut.flush();
-    writerOut.close();
     return streamOut.toString();
   }
 

--- a/src/main/java/soot/toDex/LabelAssigner.java
+++ b/src/main/java/soot/toDex/LabelAssigner.java
@@ -39,11 +39,11 @@ public class LabelAssigner {
 
   private int lastLabelId = 0;
 
-  private Map<Stmt, Label> stmtToLabel = new HashMap<Stmt, Label>();
-  private Map<Stmt, String> stmtToLabelName = new HashMap<Stmt, String>();
+  private Map<Stmt, Label> stmtToLabel = new HashMap<>();
+  private Map<Stmt, String> stmtToLabelName = new HashMap<>();
 
-  private Map<AbstractPayload, Label> payloadToLabel = new HashMap<AbstractPayload, Label>();
-  private Map<AbstractPayload, String> payloadToLabelName = new HashMap<AbstractPayload, String>();
+  private Map<AbstractPayload, Label> payloadToLabel = new HashMap<>();
+  private Map<AbstractPayload, String> payloadToLabelName = new HashMap<>();
 
   public LabelAssigner(MethodImplementationBuilder builder) {
     this.builder = builder;

--- a/src/main/java/soot/toDex/StmtVisitor.java
+++ b/src/main/java/soot/toDex/StmtVisitor.java
@@ -132,17 +132,14 @@ public class StmtVisitor implements StmtSwitch {
   private List<AbstractPayload> payloads;
 
   // maps used to map Jimple statements to dalvik instructions
-  private Map<Insn, Stmt> insnStmtMap = new HashMap<Insn, Stmt>();
-  private Map<Instruction, LocalRegisterAssignmentInformation> instructionRegisterMap
-      = new IdentityHashMap<Instruction, LocalRegisterAssignmentInformation>();
-  private Map<Instruction, Insn> instructionInsnMap = new IdentityHashMap<Instruction, Insn>();
-  private Map<Insn, LocalRegisterAssignmentInformation> insnRegisterMap
-      = new IdentityHashMap<Insn, LocalRegisterAssignmentInformation>();
-  private Map<Instruction, AbstractPayload> instructionPayloadMap = new IdentityHashMap<Instruction, AbstractPayload>();
-  private List<LocalRegisterAssignmentInformation> parameterInstructionsList
-      = new ArrayList<LocalRegisterAssignmentInformation>();
+  private Map<Insn, Stmt> insnStmtMap = new HashMap<>();
+  private Map<Instruction, LocalRegisterAssignmentInformation> instructionRegisterMap = new IdentityHashMap<>();
+  private Map<Instruction, Insn> instructionInsnMap = new IdentityHashMap<>();
+  private Map<Insn, LocalRegisterAssignmentInformation> insnRegisterMap = new IdentityHashMap<>();
+  private Map<Instruction, AbstractPayload> instructionPayloadMap = new IdentityHashMap<>();
+  private List<LocalRegisterAssignmentInformation> parameterInstructionsList = new ArrayList<>();
 
-  private Map<Constant, Register> monitorRegs = new HashMap<Constant, Register>();
+  private Map<Constant, Register> monitorRegs = new HashMap<>();
 
   private static final Opcode[] OPCODES = Opcode.values();
 
@@ -168,8 +165,8 @@ public class StmtVisitor implements StmtSwitch {
     constantV = new ConstantVisitor(this);
     regAlloc = new RegisterAllocator();
     exprV = new ExprVisitor(this, constantV, regAlloc);
-    insns = new ArrayList<Insn>();
-    payloads = new ArrayList<AbstractPayload>();
+    insns = new ArrayList<>();
+    payloads = new ArrayList<>();
   }
 
   protected void setLastReturnTypeDescriptor(String typeDescriptor) {
@@ -337,7 +334,7 @@ public class StmtVisitor implements StmtSwitch {
   }
 
   public List<BuilderInstruction> getRealInsns(LabelAssigner labelAssigner) {
-    List<BuilderInstruction> finalInsns = new ArrayList<BuilderInstruction>();
+    List<BuilderInstruction> finalInsns = new ArrayList<>();
     for (Insn i : insns) {
       if (i instanceof AddressInsn) {
         continue; // skip non-insns


### PR DESCRIPTION
Without this PR it was always necessary to use the debugger to identify the method which caused the problem.  
Therefore I added another RuntimeException which explicitly states which method was processed by DexPrinter when the error occurred.

+ other minor improvements