### PR TITLE
Code cleanup/improvements in Body and subclasses

### DIFF
--- a/src/main/java/soot/Body.java
+++ b/src/main/java/soot/Body.java
@@ -29,7 +29,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -72,48 +71,59 @@ import soot.validation.ValueBoxesValidator;
 public abstract class Body extends AbstractHost implements Serializable {
   private static final Logger logger = LoggerFactory.getLogger(Body.class);
 
-  /** The method associated with this Body. */
+  /**
+   * The method associated with this Body.
+   */
   protected transient SootMethod method = null;
 
-  /** The chain of locals for this Body. */
+  /**
+   * The chain of locals for this Body.
+   */
   protected Chain<Local> localChain = new HashChain<>();
 
-  /** The chain of traps for this Body. */
+  /**
+   * The chain of traps for this Body.
+   */
   protected Chain<Trap> trapChain = new HashChain<>();
 
-  /** The chain of units for this Body. */
+  /**
+   * The chain of units for this Body.
+   */
   protected UnitPatchingChain unitChain = new UnitPatchingChain(new HashChain<>());
 
-  private static BodyValidator[] validators;
+  /**
+   * Lazy initialized array containing some validators in order to validate the Body.
+   */
+  private static class LazyValidatorsSingleton {
+    static final BodyValidator[] V = new BodyValidator[] { LocalsValidator.v(), TrapsValidator.v(), UnitBoxesValidator.v(),
+        UsesValidator.v(), ValueBoxesValidator.v(), /* CheckInitValidator.v(), */ CheckTypesValidator.v(),
+        CheckVoidLocalesValidator.v(), CheckEscapingValidator.v() };
 
-  /** Creates a deep copy of this Body. */
+    private LazyValidatorsSingleton() {
+    }
+  }
+
+  /**
+   * Creates a deep copy of this Body.
+   *
+   * @return
+   */
   @Override
   abstract public Object clone();
 
   /**
-   * Returns an array containing some validators in order to validate the JimpleBody
-   *
-   * @return the array containing validators
-   */
-  private synchronized static BodyValidator[] getValidators() {
-    if (validators == null) {
-      validators = new BodyValidator[] { LocalsValidator.v(), TrapsValidator.v(), UnitBoxesValidator.v(), UsesValidator.v(),
-          ValueBoxesValidator.v(),
-          // CheckInitValidator.v(),
-          CheckTypesValidator.v(), CheckVoidLocalesValidator.v(), CheckEscapingValidator.v() };
-    }
-    return validators;
-  };
-
-  /**
    * Creates a Body associated to the given method. Used by subclasses during initialization. Creation of a Body is triggered
    * by e.g. Jimple.v().newBody(options).
+   *
+   * @param m
    */
   protected Body(SootMethod m) {
     this.method = m;
   }
 
-  /** Creates an extremely empty Body. The Body is not associated to any method. */
+  /**
+   * Creates an extremely empty Body. The Body is not associated to any method.
+   */
   protected Body() {
   }
 
@@ -130,92 +140,101 @@ public abstract class Body extends AbstractHost implements Serializable {
   }
 
   /**
+   * Returns the method associated with this Body.
+   *
+   * @return the method that owns this body.
+   */
+  public SootMethod getMethodUnsafe() {
+    return method;
+  }
+
+  /**
    * Sets the method associated with this Body.
    *
    * @param method
    *          the method that owns this body.
-   *
    */
   public void setMethod(SootMethod method) {
     this.method = method;
   }
 
-  /** Returns the number of locals declared in this body. */
+  /**
+   * Returns the number of locals declared in this body.
+   *
+   * @return
+   */
   public int getLocalCount() {
     return localChain.size();
   }
 
-  /** Copies the contents of the given Body into this one. */
+  /**
+   * Copies the contents of the given Body into this one.
+   *
+   * @param b
+   *
+   * @return
+   */
   public Map<Object, Object> importBodyContentsFrom(Body b) {
     HashMap<Object, Object> bindings = new HashMap<>();
 
-    {
-      // Clone units in body's statement list
-      for (Unit original : b.getUnits()) {
-        Unit copy = (Unit) original.clone();
+    // Clone units in body's statement list
+    for (Unit original : b.getUnits()) {
+      Unit copy = (Unit) original.clone();
 
-        copy.addAllTagsOf(original);
+      copy.addAllTagsOf(original);
 
-        // Add cloned unit to our unitChain.
-        unitChain.addLast(copy);
+      // Add cloned unit to our unitChain.
+      unitChain.addLast(copy);
 
-        // Build old <-> new map to be able to patch up references to other units
-        // within the cloned units. (these are still refering to the original
-        // unit objects).
-        bindings.put(original, copy);
-      }
+      // Build old <-> new map to be able to patch up references to other units
+      // within the cloned units. (these are still refering to the original
+      // unit objects).
+      bindings.put(original, copy);
     }
 
-    {
-      // Clone trap units.
-      for (Trap original : b.getTraps()) {
-        Trap copy = (Trap) original.clone();
+    // Clone trap units.
+    for (Trap original : b.getTraps()) {
+      Trap copy = (Trap) original.clone();
 
-        // Add cloned unit to our trap list.
-        trapChain.addLast(copy);
+      // Add cloned unit to our trap list.
+      trapChain.addLast(copy);
 
-        // Store old <-> new mapping.
-        bindings.put(original, copy);
-      }
+      // Store old <-> new mapping.
+      bindings.put(original, copy);
     }
 
-    {
-      // Clone local units.
-      for (Local original : b.getLocals()) {
-        Local copy = (Local) original.clone();
+    // Clone local units.
+    for (Local original : b.getLocals()) {
+      Local copy = (Local) original.clone();
 
-        // Add cloned unit to our trap list.
-        localChain.addLast(copy);
+      // Add cloned unit to our trap list.
+      localChain.addLast(copy);
 
-        // Build old <-> new mapping.
-        bindings.put(original, copy);
-      }
+      // Build old <-> new mapping.
+      bindings.put(original, copy);
     }
 
-    {
-      // Patch up references within units using our (old <-> new) map.
-      for (UnitBox box : getAllUnitBoxes()) {
-        Unit newObject, oldObject = box.getUnit();
-
-        // if we have a reference to an old object, replace it
-        // it's clone.
-        if ((newObject = (Unit) bindings.get(oldObject)) != null) {
-          box.setUnit(newObject);
-        }
-
+    // Patch up references within units using our (old <-> new) map.
+    for (UnitBox box : getAllUnitBoxes()) {
+      Unit newObject = (Unit) bindings.get(box.getUnit());
+      // if we have a reference to an old object, replace it with its clone.
+      if (newObject != null) {
+        box.setUnit(newObject);
       }
     }
 
     {
       // backpatching all local variables.
       for (ValueBox vb : getUseBoxes()) {
-        if (vb.getValue() instanceof Local) {
-          vb.setValue((Value) bindings.get(vb.getValue()));
+        Value val = vb.getValue();
+        if (val instanceof Local) {
+          vb.setValue((Value) bindings.get(val));
         }
       }
       for (ValueBox vb : getDefBoxes()) {
-        if (vb.getValue() instanceof Local) {
-          vb.setValue((Value) bindings.get(vb.getValue()));
+        Value val = vb.getValue();
+        if (val instanceof Local) {
+          vb.setValue((Value) bindings.get(val));
         }
       }
     }
@@ -230,7 +249,9 @@ public abstract class Body extends AbstractHost implements Serializable {
     }
   }
 
-  /** Verifies a few sanity conditions on the contents on this body. */
+  /**
+   * Verifies a few sanity conditions on the contents on this body.
+   */
   public void validate() {
     List<ValidationException> exceptionList = new ArrayList<>();
     validate(exceptionList);
@@ -247,7 +268,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    */
   public void validate(List<ValidationException> exceptionList) {
     final boolean runAllValidators = Options.v().debug() || Options.v().validate();
-    for (BodyValidator validator : getValidators()) {
+    for (BodyValidator validator : LazyValidatorsSingleton.V) {
       if (!validator.isBasicValidator() && !runAllValidators) {
         continue;
       }
@@ -255,42 +276,68 @@ public abstract class Body extends AbstractHost implements Serializable {
     }
   }
 
-  /** Verifies that a ValueBox is not used in more than one place. */
+  /**
+   * Verifies that a ValueBox is not used in more than one place.
+   */
   public void validateValueBoxes() {
     runValidation(ValueBoxesValidator.v());
   }
 
-  /** Verifies that each Local of getUseAndDefBoxes() is in this body's locals Chain. */
+  /**
+   * Verifies that each Local of {@link #getUseAndDefBoxes()} is in this body's locals Chain.
+   */
   public void validateLocals() {
     runValidation(LocalsValidator.v());
   }
 
-  /** Verifies that the begin, end and handler units of each trap are in this body. */
+  /**
+   * Verifies that the begin, end and handler units of each trap are in this body.
+   */
   public void validateTraps() {
     runValidation(TrapsValidator.v());
   }
 
-  /** Verifies that the UnitBoxes of this Body all point to a Unit contained within this body. */
+  /**
+   * Verifies that the UnitBoxes of this Body all point to a Unit contained within this body.
+   */
   public void validateUnitBoxes() {
     runValidation(UnitBoxesValidator.v());
   }
 
-  /** Verifies that each use in this Body has a def. */
+  /**
+   * Verifies that each use in this Body has a def.
+   */
   public void validateUses() {
     runValidation(UsesValidator.v());
   }
 
-  /** Returns a backed chain of the locals declared in this Body. */
+  public void checkInit() {
+    runValidation(CheckInitValidator.v());
+  }
+
+  /**
+   * Returns a backed chain of the locals declared in this Body.
+   *
+   * @return
+   */
   public Chain<Local> getLocals() {
     return localChain;
   }
 
-  /** Returns a backed view of the traps found in this Body. */
+  /**
+   * Returns a backed view of the traps found in this Body.
+   *
+   * @return
+   */
   public Chain<Trap> getTraps() {
     return trapChain;
   }
 
-  /** Return unit containing the \@this-assignment **/
+  /**
+   * Return unit containing the \@this-assignment
+   *
+   * @return
+   */
   public Unit getThisUnit() {
     for (Unit u : getUnits()) {
       if (u instanceof IdentityStmt && ((IdentityStmt) u).getRightOp() instanceof ThisRef) {
@@ -301,24 +348,36 @@ public abstract class Body extends AbstractHost implements Serializable {
     throw new RuntimeException("couldn't find this-assignment!" + " in " + getMethod());
   }
 
-  /** Return LHS of the first identity stmt assigning from \@this. **/
+  /**
+   * Return LHS of the first identity stmt assigning from \@this.
+   *
+   * @return
+   */
   public Local getThisLocal() {
     return (Local) (((IdentityStmt) getThisUnit()).getLeftOp());
   }
 
-  /** Return LHS of the first identity stmt assigning from \@parameter i. **/
+  /**
+   * Return LHS of the first identity stmt assigning from \@parameter i.
+   *
+   * @param i
+   *
+   * @return
+   */
   public Local getParameterLocal(int i) {
     for (Unit s : getUnits()) {
-      if (s instanceof IdentityStmt && ((IdentityStmt) s).getRightOp() instanceof ParameterRef) {
+      if (s instanceof IdentityStmt) {
         IdentityStmt is = (IdentityStmt) s;
-        ParameterRef pr = (ParameterRef) is.getRightOp();
-        if (pr.getIndex() == i) {
-          return (Local) is.getLeftOp();
+        Value rightOp = is.getRightOp();
+        if (rightOp instanceof ParameterRef) {
+          ParameterRef pr = (ParameterRef) rightOp;
+          if (pr.getIndex() == i) {
+            return (Local) is.getLeftOp();
+          }
         }
       }
     }
-
-    throw new RuntimeException("couldn't find parameterref" + i + "! in " + getMethod());
+    throw new RuntimeException("couldn't find parameterref" + i + " in " + getMethod());
   }
 
   /**
@@ -326,42 +385,67 @@ public abstract class Body extends AbstractHost implements Serializable {
    *
    * @return a list of size as per <code>getMethod().getParameterCount()</code> with all elements ordered as per the
    *         parameter index.
+   *
    * @throws RuntimeException
    *           if a parameterref is missing
    */
   public List<Local> getParameterLocals() {
     final int numParams = getMethod().getParameterCount();
-    final List<Local> retVal = new ArrayList<>(numParams);
-
-    // Parameters are zero-indexed, so the keeping of the index is safe
+    Local[] res = new Local[numParams];
+    int numFound = 0;
     for (Unit u : getUnits()) {
       if (u instanceof IdentityStmt) {
-        IdentityStmt is = ((IdentityStmt) u);
-        if (is.getRightOp() instanceof ParameterRef) {
-          ParameterRef pr = (ParameterRef) is.getRightOp();
-          retVal.add(pr.getIndex(), (Local) is.getLeftOp());
+        IdentityStmt is = (IdentityStmt) u;
+        Value rightOp = is.getRightOp();
+        if (rightOp instanceof ParameterRef) {
+          int idx = ((ParameterRef) rightOp).getIndex();
+          if (res[idx] != null) {
+            throw new RuntimeException("duplicate parameterref" + idx + " in " + getMethod());
+          }
+          res[idx] = (Local) is.getLeftOp();
+          numFound++;
+          if (numFound >= numParams) {
+            break;
+          }
         }
       }
     }
-    if (retVal.size() != numParams) {
-      throw new RuntimeException("couldn't find parameterref! in " + getMethod());
+    if (numFound != numParams) {
+      for (int i = 0; i < numParams; i++) {
+        if (res[i] == null) {
+          throw new RuntimeException("couldn't find parameterref" + i + " in " + getMethod());
+        }
+      }
+      throw new RuntimeException("couldn't find parameterref? in " + getMethod());
     }
-    return retVal;
+    return Arrays.asList(res);
   }
 
   /**
    * Returns the list of parameter references used in this body. The list is as long as the number of parameters declared in
    * the associated method's signature. The list may have <code>null</code> entries for parameters not referenced in the
    * body. The returned list is of fixed size.
+   *
+   * @return
    */
   public List<Value> getParameterRefs() {
-    Value[] res = new Value[getMethod().getParameterCount()];
-    for (Unit s : getUnits()) {
-      if (s instanceof IdentityStmt) {
-        Value rightOp = ((IdentityStmt) s).getRightOp();
+    final int numParams = getMethod().getParameterCount();
+    Value[] res = new Value[numParams];
+    int numFound = 0;
+    for (Unit u : getUnits()) {
+      if (u instanceof IdentityStmt) {
+        Value rightOp = ((IdentityStmt) u).getRightOp();
         if (rightOp instanceof ParameterRef) {
-          ParameterRef parameterRef = (ParameterRef) rightOp;
-          res[parameterRef.getIndex()] = parameterRef;
+          ParameterRef pr = (ParameterRef) rightOp;
+          int idx = pr.getIndex();
+          if (res[idx] != null) {
+            throw new RuntimeException("duplicate parameterref" + idx + " in " + getMethod());
+          }
+          res[idx] = pr;
+          numFound++;
+          if (numFound >= numParams) {
+            break;
+          }
         }
       }
     }
@@ -391,36 +475,23 @@ public abstract class Body extends AbstractHost implements Serializable {
    * This method is typically used for pointer patching, eg when the unit chain is cloned.
    *
    * @return A list of all the UnitBoxes held by this body's units.
+   *
    * @see UnitBox
    * @see #getUnitBoxes(boolean)
    * @see Unit#getUnitBoxes()
    * @see soot.shimple.PhiExpr#getUnitBoxes()
-   **/
+   */
   public List<UnitBox> getAllUnitBoxes() {
     ArrayList<UnitBox> unitBoxList = new ArrayList<>();
-    {
-      Iterator<Unit> it = unitChain.iterator();
-      while (it.hasNext()) {
-        Unit item = it.next();
-        unitBoxList.addAll(item.getUnitBoxes());
-      }
+    for (Unit item : unitChain) {
+      unitBoxList.addAll(item.getUnitBoxes());
     }
-
-    {
-      Iterator<Trap> it = trapChain.iterator();
-      while (it.hasNext()) {
-        Trap item = it.next();
-        unitBoxList.addAll(item.getUnitBoxes());
-      }
+    for (Trap item : trapChain) {
+      unitBoxList.addAll(item.getUnitBoxes());
     }
-
-    {
-      Iterator<Tag> it = getTags().iterator();
-      while (it.hasNext()) {
-        Tag t = it.next();
-        if (t instanceof CodeAttribute) {
-          unitBoxList.addAll(((CodeAttribute) t).getUnitBoxes());
-        }
+    for (Tag t : getTags()) {
+      if (t instanceof CodeAttribute) {
+        unitBoxList.addAll(((CodeAttribute) t).getUnitBoxes());
       }
     }
 
@@ -436,46 +507,28 @@ public abstract class Body extends AbstractHost implements Serializable {
    * If branchTarget is false, returns the result of iterating through the non-branching Units in this body and querying them
    * for their UnitBoxes. Any such UnitBoxes (typically from PhiExpr) contain a Unit that indicates the end of a CFG block.
    *
+   * @param branchTarget
+   *
    * @return a list of all the UnitBoxes held by this body's branching units.
    *
    * @see UnitBox
    * @see #getAllUnitBoxes()
    * @see Unit#getUnitBoxes()
    * @see soot.shimple.PhiExpr#getUnitBoxes()
-   **/
+   */
   public List<UnitBox> getUnitBoxes(boolean branchTarget) {
     ArrayList<UnitBox> unitBoxList = new ArrayList<>();
-    {
-      Iterator<Unit> it = unitChain.iterator();
-      while (it.hasNext()) {
-        Unit item = it.next();
-        if (branchTarget) {
-          if (item.branches()) {
-            unitBoxList.addAll(item.getUnitBoxes());
-          }
-        } else {
-          if (!item.branches()) {
-            unitBoxList.addAll(item.getUnitBoxes());
-          }
-        }
-      }
-    }
-
-    {
-      Iterator<Trap> it = trapChain.iterator();
-      while (it.hasNext()) {
-        Trap item = it.next();
+    for (Unit item : unitChain) {
+      if (item.branches() == branchTarget) {
         unitBoxList.addAll(item.getUnitBoxes());
       }
     }
-
-    {
-      Iterator<Tag> it = getTags().iterator();
-      while (it.hasNext()) {
-        Tag t = it.next();
-        if (t instanceof CodeAttribute) {
-          unitBoxList.addAll(((CodeAttribute) t).getUnitBoxes());
-        }
+    for (Trap item : trapChain) {
+      unitBoxList.addAll(item.getUnitBoxes());
+    }
+    for (Tag t : getTags()) {
+      if (t instanceof CodeAttribute) {
+        unitBoxList.addAll(((CodeAttribute) t).getUnitBoxes());
       }
     }
 
@@ -492,14 +545,10 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see Unit#getUseBoxes
    * @see ValueBox
    * @see Value
-   *
    */
   public List<ValueBox> getUseBoxes() {
     ArrayList<ValueBox> useBoxList = new ArrayList<>();
-
-    Iterator<Unit> it = unitChain.iterator();
-    while (it.hasNext()) {
-      Unit item = it.next();
+    for (Unit item : unitChain) {
       useBoxList.addAll(item.getUseBoxes());
     }
     return useBoxList;
@@ -517,11 +566,8 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see Value
    */
   public List<ValueBox> getDefBoxes() {
-    ArrayList<ValueBox> defBoxList = new ArrayList<ValueBox>();
-
-    Iterator<Unit> it = unitChain.iterator();
-    while (it.hasNext()) {
-      Unit item = it.next();
+    ArrayList<ValueBox> defBoxList = new ArrayList<>();
+    for (Unit item : unitChain) {
       defBoxList.addAll(item.getDefBoxes());
     }
     return defBoxList;
@@ -539,18 +585,11 @@ public abstract class Body extends AbstractHost implements Serializable {
    */
   public List<ValueBox> getUseAndDefBoxes() {
     ArrayList<ValueBox> useAndDefBoxList = new ArrayList<>();
-
-    Iterator<Unit> it = unitChain.iterator();
-    while (it.hasNext()) {
-      Unit item = it.next();
+    for (Unit item : unitChain) {
       useAndDefBoxList.addAll(item.getUseBoxes());
       useAndDefBoxList.addAll(item.getDefBoxes());
     }
     return useAndDefBoxList;
-  }
-
-  public void checkInit() {
-    runValidation(CheckInitValidator.v());
   }
 
   /**
@@ -571,5 +610,4 @@ public abstract class Body extends AbstractHost implements Serializable {
   public long getModificationCount() {
     return localChain.getModificationCount() + unitChain.getModificationCount() + trapChain.getModificationCount();
   }
-
 }

--- a/src/main/java/soot/dava/DavaBody.java
+++ b/src/main/java/soot/dava/DavaBody.java
@@ -173,7 +173,6 @@ import soot.util.Switchable;
  *			Nomair: March 29th, 2006: dealing with trying to remove fully qualified names
  *
  */
-
 /*
  * TODO:   Nomair- February 7th. Refactor the call
  *  	    AST.perform_Analysis( UselessTryRemover.v());
@@ -184,13 +183,13 @@ import soot.util.Switchable;
  *          Specially the deobfuscate option with the boolean constant propagation analysis
  *
  */
-
 public class DavaBody extends Body {
 
   public boolean DEBUG = false;
-  private Map<Integer, Value> pMap;
 
-  private HashSet<Object> consumedConditions, thisLocals;
+  private Map<Integer, Value> pMap;
+  private Set<Object> consumedConditions;
+  private HashSet<Object> thisLocals;
 
   private IterableSet<ExceptionNode> synchronizedBlockFacts;
   private IterableSet<ExceptionNode> exceptionFacts;
@@ -209,22 +208,19 @@ public class DavaBody extends Body {
   /**
    * Construct an empty DavaBody
    */
-
   DavaBody(SootMethod m) {
     super(m);
 
-    pMap = new HashMap<Integer, Value>();
-    consumedConditions = new HashSet<Object>();
-    thisLocals = new HashSet<Object>();
-    synchronizedBlockFacts = new IterableSet<ExceptionNode>();
-    exceptionFacts = new IterableSet<ExceptionNode>();
-    monitorFacts = new IterableSet<AugmentedStmt>();
-    importList = new IterableSet<String>();
-    // packagesUsed = new IterableSet();
-    caughtrefs = new LinkedList<CaughtExceptionRef>();
-
-    controlLocal = null;
-    constructorExpr = null;
+    this.pMap = new HashMap<Integer, Value>();
+    this.consumedConditions = new HashSet<Object>();
+    this.thisLocals = new HashSet<Object>();
+    this.synchronizedBlockFacts = new IterableSet<ExceptionNode>();
+    this.exceptionFacts = new IterableSet<ExceptionNode>();
+    this.monitorFacts = new IterableSet<AugmentedStmt>();
+    this.importList = new IterableSet<String>();
+    this.caughtrefs = new LinkedList<CaughtExceptionRef>();
+    this.controlLocal = null;
+    this.constructorExpr = null;
   }
 
   public Unit get_ConstructorUnit() {
@@ -307,7 +303,7 @@ public class DavaBody extends Body {
     Dava.v().log("\nstart method " + body.getMethod().toString());
 
     if (DEBUG) {
-      if (body.getMethod().getExceptions().size() != 0) {
+      if (!body.getMethod().getExceptions().isEmpty()) {
         debug("DavaBody", "printing NON EMPTY exception list for " + body.getMethod().toString() + " "
             + body.getMethod().getExceptions().toString());
       }
@@ -375,7 +371,7 @@ public class DavaBody extends Body {
       /*
        * January 12th, 2006 Deal with the super() problem before continuing
        */
-      Map options = PhaseOptions.v().getPhaseOptions("db.force-recompile");
+      Map<String, String> options = PhaseOptions.v().getPhaseOptions("db.force-recompile");
       boolean force = PhaseOptions.getBoolean(options, "enabled");
       // System.out.println("force is "+force);
       if (force) {
@@ -667,15 +663,13 @@ public class DavaBody extends Body {
           ts.setDefaultTarget((Unit) bindings.get(original_switch.getDefaultTarget()));
 
           LinkedList<Unit> new_target_list = new LinkedList<Unit>();
-
           int target_count = ts.getHighIndex() - ts.getLowIndex() + 1;
           for (int i = 0; i < target_count; i++) {
             new_target_list.add((Unit) bindings.get(original_switch.getTarget(i)));
           }
           ts.setTargets(new_target_list);
 
-        }
-        if (s instanceof LookupSwitchStmt) {
+        } else if (s instanceof LookupSwitchStmt) {
           LookupSwitchStmt ls = (LookupSwitchStmt) s;
 
           LookupSwitchStmt original_switch = (LookupSwitchStmt) reverse_binding.get(u);
@@ -683,7 +677,7 @@ public class DavaBody extends Body {
 
           Unit[] new_target_list = new Unit[original_switch.getTargetCount()];
           for (int i = 0; i < original_switch.getTargetCount(); i++) {
-            new_target_list[i] = (Unit) (bindings.get(original_switch.getTarget(i)));
+            new_target_list[i] = (Unit) bindings.get(original_switch.getTarget(i));
           }
           ls.setTargets(new_target_list);
 
@@ -703,19 +697,18 @@ public class DavaBody extends Body {
 
       // Patch up references within units using our (old <-> new) map.
       for (UnitBox box : getAllUnitBoxes()) {
-        Unit newObject, oldObject = box.getUnit();
-
-        // if we have a reference to an old object, replace it
-        // it's clone.
-        if ((newObject = (Unit) bindings.get(oldObject)) != null) {
+        Unit newObject = (Unit) bindings.get(box.getUnit());
+        // if we have a reference to an old object, replace it with its clone.
+        if (newObject != null) {
           box.setUnit(newObject);
         }
       }
 
       // backpatch all local variables.
       for (ValueBox vb : getUseAndDefBoxes()) {
-        if (vb.getValue() instanceof Local) {
-          vb.setValue((Value) bindings.get(vb.getValue()));
+        Value val = vb.getValue();
+        if (val instanceof Local) {
+          vb.setValue((Value) bindings.get(val));
         }
       }
 
@@ -723,9 +716,7 @@ public class DavaBody extends Body {
       for (Trap originalTrap : grimpBody.getTraps()) {
         Trap cloneTrap = (Trap) originalTrap.clone();
 
-        Unit handlerUnit = (Unit) bindings.get(originalTrap.getHandlerUnit());
-
-        cloneTrap.setHandlerUnit(handlerUnit);
+        cloneTrap.setHandlerUnit((Unit) bindings.get(originalTrap.getHandlerUnit()));
         cloneTrap.setBeginUnit((Unit) bindings.get(originalTrap.getBeginUnit()));
         cloneTrap.setEndUnit((Unit) bindings.get(originalTrap.getEndUnit()));
 
@@ -739,67 +730,58 @@ public class DavaBody extends Body {
      */
     {
       PatchingChain<Unit> units = getUnits();
-      Iterator<Unit> it = units.snapshotIterator();
-      while (it.hasNext()) {
+      for (Iterator<Unit> it = units.snapshotIterator(); it.hasNext();) {
         Unit u = it.next();
-        Stmt s = (Stmt) u;
+        if (u instanceof IfStmt) {
+          IfStmt ifs = (IfStmt) u;
 
-        if (s instanceof IfStmt) {
-          IfStmt ifs = (IfStmt) s;
-
-          JGotoStmt jgs = new JGotoStmt((Unit) units.getSuccOf(u));
+          JGotoStmt jgs = new JGotoStmt(units.getSuccOf(u));
           units.insertAfter(jgs, u);
 
-          JGotoStmt jumper = new JGotoStmt((Unit) ifs.getTarget());
+          JGotoStmt jumper = new JGotoStmt(ifs.getTarget());
           units.insertAfter(jumper, jgs);
-          ifs.setTarget((Unit) jumper);
-        }
-
-        else if (s instanceof TableSwitchStmt) {
-          TableSwitchStmt tss = (TableSwitchStmt) s;
+          ifs.setTarget(jumper);
+        } else if (u instanceof TableSwitchStmt) {
+          TableSwitchStmt tss = (TableSwitchStmt) u;
 
           int targetCount = tss.getHighIndex() - tss.getLowIndex() + 1;
           for (int i = 0; i < targetCount; i++) {
-            JGotoStmt jgs = new JGotoStmt((Unit) tss.getTarget(i));
+            JGotoStmt jgs = new JGotoStmt(tss.getTarget(i));
             units.insertAfter(jgs, tss);
-            tss.setTarget(i, (Unit) jgs);
+            tss.setTarget(i, jgs);
           }
 
-          JGotoStmt jgs = new JGotoStmt((Unit) tss.getDefaultTarget());
+          JGotoStmt jgs = new JGotoStmt(tss.getDefaultTarget());
           units.insertAfter(jgs, tss);
-          tss.setDefaultTarget((Unit) jgs);
-        }
-
-        else if (s instanceof LookupSwitchStmt) {
-          LookupSwitchStmt lss = (LookupSwitchStmt) s;
+          tss.setDefaultTarget(jgs);
+        } else if (u instanceof LookupSwitchStmt) {
+          LookupSwitchStmt lss = (LookupSwitchStmt) u;
 
           for (int i = 0; i < lss.getTargetCount(); i++) {
-            JGotoStmt jgs = new JGotoStmt((Unit) lss.getTarget(i));
+            JGotoStmt jgs = new JGotoStmt(lss.getTarget(i));
             units.insertAfter(jgs, lss);
-            lss.setTarget(i, (Unit) jgs);
+            lss.setTarget(i, jgs);
           }
 
-          JGotoStmt jgs = new JGotoStmt((Unit) lss.getDefaultTarget());
+          JGotoStmt jgs = new JGotoStmt(lss.getDefaultTarget());
           units.insertAfter(jgs, lss);
-          lss.setDefaultTarget((Unit) jgs);
+          lss.setDefaultTarget(jgs);
         }
       }
 
       for (Trap t : getTraps()) {
-        JGotoStmt jgs = new JGotoStmt((Unit) t.getHandlerUnit());
+        JGotoStmt jgs = new JGotoStmt(t.getHandlerUnit());
         units.addLast(jgs);
-        t.setHandlerUnit((Unit) jgs);
+        t.setHandlerUnit(jgs);
       }
     }
 
     /*
      * Fix up the grimp representations of statements so they can be compiled as java.
      */
-
     {
       for (Local l : getLocals()) {
         Type t = l.getType();
-
         if (t instanceof RefType) {
           RefType rt = (RefType) t;
 
@@ -807,7 +789,6 @@ public class DavaBody extends Body {
           String packageName = rt.getSootClass().getJavaPackageName();
 
           String classPackageName = packageName;
-
           if (className.lastIndexOf('.') > 0) {
             // 0 doesnt make sense
             classPackageName = className.substring(0, className.lastIndexOf('.'));
@@ -817,47 +798,42 @@ public class DavaBody extends Body {
           }
 
           addToImportList(className);
-
           // addPackage(rt.getSootClass().getJavaPackageName());
         }
       }
 
       for (Unit u : getUnits()) {
-        Stmt s = (Stmt) u;
-
-        if (s instanceof IfStmt) {
-          javafy(((IfStmt) s).getConditionBox());
-        } else if (s instanceof ThrowStmt) {
-          javafy(((ThrowStmt) s).getOpBox());
-        } else if (s instanceof TableSwitchStmt) {
-          javafy(((TableSwitchStmt) s).getKeyBox());
-        } else if (s instanceof LookupSwitchStmt) {
-          javafy(((LookupSwitchStmt) s).getKeyBox());
-        } else if (s instanceof MonitorStmt) {
-          javafy(((MonitorStmt) s).getOpBox());
-        } else if (s instanceof DefinitionStmt) {
-          DefinitionStmt ds = (DefinitionStmt) s;
+        if (u instanceof IfStmt) {
+          javafy(((IfStmt) u).getConditionBox());
+        } else if (u instanceof ThrowStmt) {
+          javafy(((ThrowStmt) u).getOpBox());
+        } else if (u instanceof TableSwitchStmt) {
+          javafy(((TableSwitchStmt) u).getKeyBox());
+        } else if (u instanceof LookupSwitchStmt) {
+          javafy(((LookupSwitchStmt) u).getKeyBox());
+        } else if (u instanceof MonitorStmt) {
+          javafy(((MonitorStmt) u).getOpBox());
+        } else if (u instanceof DefinitionStmt) {
+          DefinitionStmt ds = (DefinitionStmt) u;
 
           javafy(ds.getRightOpBox());
           javafy(ds.getLeftOpBox());
 
-          if (ds.getRightOp() instanceof IntConstant) {
-            ds.getRightOpBox().setValue(DIntConstant.v(((IntConstant) ds.getRightOp()).value, ds.getLeftOp().getType()));
+          Value rightOp = ds.getRightOp();
+          if (rightOp instanceof IntConstant) {
+            ds.getRightOpBox().setValue(DIntConstant.v(((IntConstant) rightOp).value, ds.getLeftOp().getType()));
           }
-        }
+        } else if (u instanceof ReturnStmt) {
+          ReturnStmt rs = (ReturnStmt) u;
 
-        else if (s instanceof ReturnStmt) {
-          ReturnStmt rs = (ReturnStmt) s;
-
-          if (rs.getOp() instanceof IntConstant) {
-            rs.getOpBox().setValue(DIntConstant.v(((IntConstant) rs.getOp()).value, body.getMethod().getReturnType()));
+          Value op = rs.getOp();
+          if (op instanceof IntConstant) {
+            rs.getOpBox().setValue(DIntConstant.v(((IntConstant) op).value, body.getMethod().getReturnType()));
           } else {
             javafy(rs.getOpBox());
           }
-        }
-
-        else if (s instanceof InvokeStmt) {
-          javafy(((InvokeStmt) s).getInvokeExprBox());
+        } else if (u instanceof InvokeStmt) {
+          javafy(((InvokeStmt) u).getInvokeExprBox());
         }
       }
     }
@@ -865,35 +841,28 @@ public class DavaBody extends Body {
     /*
      * Convert references to "this" and parameters.
      */
+    for (Unit u : getUnits()) {
+      if (u instanceof IdentityStmt) {
+        IdentityStmt ids = (IdentityStmt) u;
+        Value ids_rightOp = ids.getRightOp();
+        Value ids_leftOp = ids.getLeftOp();
 
-    {
-      for (Unit u : getUnits()) {
-        Stmt s = (Stmt) u;
+        if ((ids_leftOp instanceof Local) && (ids_rightOp instanceof ThisRef)) {
+          Local thisLocal = (Local) ids_leftOp;
+          thisLocals.add(thisLocal);
+          thisLocal.setName("this");
+        }
+      }
+      if (u instanceof DefinitionStmt) {
+        DefinitionStmt ds = (DefinitionStmt) u;
+        Value rightOp = ds.getRightOp();
 
-        if (s instanceof IdentityStmt) {
-          IdentityStmt ids = (IdentityStmt) s;
-          Value ids_rightOp = ids.getRightOp();
-          Value ids_leftOp = ids.getLeftOp();
-
-          if ((ids_leftOp instanceof Local) && (ids_rightOp instanceof ThisRef)) {
-            Local thisLocal = (Local) ids_leftOp;
-
-            thisLocals.add(thisLocal);
-            thisLocal.setName("this");
-          }
+        if (rightOp instanceof ParameterRef) {
+          pMap.put(((ParameterRef) rightOp).getIndex(), ds.getLeftOp());
         }
 
-        if (s instanceof DefinitionStmt) {
-          DefinitionStmt ds = (DefinitionStmt) s;
-          Value rightOp = ds.getRightOp();
-
-          if (rightOp instanceof ParameterRef) {
-            pMap.put(((ParameterRef) rightOp).getIndex(), ds.getLeftOp());
-          }
-
-          if (rightOp instanceof CaughtExceptionRef) {
-            caughtrefs.add((CaughtExceptionRef) rightOp);
-          }
+        if (rightOp instanceof CaughtExceptionRef) {
+          caughtrefs.add((CaughtExceptionRef) rightOp);
         }
       }
     }
@@ -901,34 +870,25 @@ public class DavaBody extends Body {
     /*
      * Fix up the calls to other constructors. Note, this is seriously underbuilt.
      */
+    for (Unit u : getUnits()) {
+      if (u instanceof InvokeStmt) {
+        InvokeStmt ivs = (InvokeStmt) u;
+        Value ie = ivs.getInvokeExpr();
 
-    {
-      for (Unit u : getUnits()) {
-        Stmt s = (Stmt) u;
+        if (ie instanceof InstanceInvokeExpr) {
+          InstanceInvokeExpr iie = (InstanceInvokeExpr) ie;
+          Value base = iie.getBase();
 
-        if (s instanceof InvokeStmt) {
+          if ((base instanceof Local) && "this".equals(((Local) base).getName())) {
+            String name = iie.getMethodRef().name();
 
-          InvokeStmt ivs = (InvokeStmt) s;
-          Value ie = ivs.getInvokeExpr();
-
-          if (ie instanceof InstanceInvokeExpr) {
-
-            InstanceInvokeExpr iie = (InstanceInvokeExpr) ie;
-            Value base = iie.getBase();
-
-            if ((base instanceof Local) && (((Local) base).getName().equals("this"))) {
-              SootMethodRef m = iie.getMethodRef();
-              String name = m.name();
-
-              if ((name.equals(SootMethod.constructorName)) || (name.equals(SootMethod.staticInitializerName))) {
-
-                if (constructorUnit != null) {
-                  throw new RuntimeException("More than one candidate for constructor found.");
-                }
-
-                constructorExpr = iie;
-                constructorUnit = (Unit) s;
+            if (SootMethod.constructorName.equals(name) || SootMethod.staticInitializerName.equals(name)) {
+              if (constructorUnit != null) {
+                throw new RuntimeException("More than one candidate for constructor found.");
               }
+
+              constructorExpr = iie;
+              constructorUnit = u;
             }
           }
         }
@@ -987,7 +947,6 @@ public class DavaBody extends Body {
       String packageName = fieldRef.declaringClass().getJavaPackageName();
 
       String classPackageName = packageName;
-
       if (className.lastIndexOf('.') > 0) {
         // 0 doesnt make sense
         classPackageName = className.substring(0, className.lastIndexOf('.'));
@@ -1004,17 +963,13 @@ public class DavaBody extends Body {
 
       javafy(ar.getBaseBox());
       javafy(ar.getIndexBox());
-    }
-
-    else if (r instanceof InstanceFieldRef) {
+    } else if (r instanceof InstanceFieldRef) {
       InstanceFieldRef ifr = (InstanceFieldRef) r;
 
       javafy(ifr.getBaseBox());
 
       vb.setValue(new DInstanceFieldRef(ifr.getBase(), ifr.getFieldRef(), thisLocals));
-    }
-
-    else if (r instanceof ThisRef) {
+    } else if (r instanceof ThisRef) {
       ThisRef tr = (ThisRef) r;
 
       vb.setValue(new DThisRef((RefType) tr.getType()));
@@ -1034,7 +989,7 @@ public class DavaBody extends Body {
     Value leftOp = leftOpBox.getValue(), rightOp = rightOpBox.getValue();
 
     if (rightOp instanceof IntConstant) {
-      if ((leftOp instanceof IntConstant) == false) {
+      if (!(leftOp instanceof IntConstant)) {
         javafy(leftOpBox);
         leftOp = leftOpBox.getValue();
 
@@ -1138,22 +1093,16 @@ public class DavaBody extends Body {
       if (ie instanceof VirtualInvokeExpr) {
         VirtualInvokeExpr vie = (VirtualInvokeExpr) ie;
         vb.setValue(new DVirtualInvokeExpr(vie.getBase(), vie.getMethodRef(), vie.getArgs(), thisLocals));
-      }
-
-      else if (ie instanceof SpecialInvokeExpr) {
+      } else if (ie instanceof SpecialInvokeExpr) {
         SpecialInvokeExpr sie = (SpecialInvokeExpr) ie;
         vb.setValue(new DSpecialInvokeExpr(sie.getBase(), sie.getMethodRef(), sie.getArgs()));
-      }
-
-      else if (ie instanceof InterfaceInvokeExpr) {
+      } else if (ie instanceof InterfaceInvokeExpr) {
         InterfaceInvokeExpr iie = (InterfaceInvokeExpr) ie;
         vb.setValue(new DInterfaceInvokeExpr(iie.getBase(), iie.getMethodRef(), iie.getArgs()));
       } else {
         throw new RuntimeException("InstanceInvokeExpr " + ie + " not javafied correctly");
       }
-    }
-
-    else if (ie instanceof StaticInvokeExpr) {
+    } else if (ie instanceof StaticInvokeExpr) {
       StaticInvokeExpr sie = (StaticInvokeExpr) ie;
 
       if (sie instanceof NewInvokeExpr) {
@@ -1165,7 +1114,6 @@ public class DavaBody extends Body {
         packageName = rt.getSootClass().getJavaPackageName();
 
         classPackageName = packageName;
-
         if (className.lastIndexOf('.') > 0) {
           // 0 doesnt make sense
           classPackageName = className.substring(0, className.lastIndexOf('.'));
@@ -1208,7 +1156,6 @@ public class DavaBody extends Body {
     String packageName = ne.getBaseType().getSootClass().getJavaPackageName();
 
     String classPackageName = packageName;
-
     if (className.lastIndexOf('.') > 0) {
       // 0 doesnt make sense
       classPackageName = className.substring(0, className.lastIndexOf('.'));

--- a/src/main/java/soot/grimp/GrimpBody.java
+++ b/src/main/java/soot/grimp/GrimpBody.java
@@ -22,10 +22,9 @@ package soot.grimp;
  * #L%
  */
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,19 +56,22 @@ import soot.jimple.TableSwitchStmt;
 import soot.jimple.ThrowStmt;
 import soot.jimple.internal.StmtBox;
 import soot.options.Options;
+import soot.util.Chain;
 
-/** Implementation of the Body class for the Grimp IR. */
+/**
+ * Implementation of the Body class for the Grimp IR.
+ */
 public class GrimpBody extends StmtBody {
   private static final Logger logger = LoggerFactory.getLogger(GrimpBody.class);
 
   /**
    * Construct an empty GrimpBody
-   **/
-
+   */
   GrimpBody(SootMethod m) {
     super(m);
   }
 
+  @Override
   public Object clone() {
     Body b = Grimp.v().newBody(getMethod());
     b.importBodyContentsFrom(this);
@@ -79,7 +81,6 @@ public class GrimpBody extends StmtBody {
   /**
    * Constructs a GrimpBody from the given Body.
    */
-
   GrimpBody(Body body) {
     super(body.getMethod());
 
@@ -87,110 +88,118 @@ public class GrimpBody extends StmtBody {
       logger.debug("[" + getMethod().getName() + "] Constructing GrimpBody...");
     }
 
-    JimpleBody jBody = null;
-
-    if (body instanceof JimpleBody) {
-      jBody = (JimpleBody) body;
-    } else {
+    if (!(body instanceof JimpleBody)) {
       throw new RuntimeException("Can only construct GrimpBody's from JimpleBody's (for now)");
     }
+    final JimpleBody jBody = (JimpleBody) body;
 
-    Iterator<Local> localIt = jBody.getLocals().iterator();
-    while (localIt.hasNext()) {
-      getLocals().add(((localIt.next())));
-      // getLocals().add(((Local)(it.next())).clone());
+    {
+      final Chain<Local> thisLocals = this.getLocals();
+      for (Local loc : jBody.getLocals()) {
+        thisLocals.add(loc);
+        // thisLocals.add((Local)loc.clone());
+      }
     }
 
-    Iterator<Unit> it = jBody.getUnits().iterator();
-
-    final HashMap<Stmt, Stmt> oldToNew = new HashMap<Stmt, Stmt>(getUnits().size() * 2 + 1, 0.7f);
-    List<Unit> updates = new LinkedList<Unit>();
+    final Grimp grimp = Grimp.v();
+    final Chain<Unit> thisUnits = getUnits();
+    final HashMap<Stmt, Stmt> oldToNew = new HashMap<Stmt, Stmt>(thisUnits.size() * 2 + 1, 0.7f);
+    final ArrayList<Unit> updates = new ArrayList<Unit>();
 
     /* we should Grimpify the Stmt's here... */
-    while (it.hasNext()) {
-      Stmt oldStmt = (Stmt) (it.next());
-      final StmtBox newStmtBox = (StmtBox) Grimp.v().newStmtBox(null);
-      final StmtBox updateStmtBox = (StmtBox) Grimp.v().newStmtBox(null);
+    for (Unit u : jBody.getUnits()) {
+      Stmt oldStmt = (Stmt) u;
+      final StmtBox newStmtBox = (StmtBox) grimp.newStmtBox(null);
+      final StmtBox updateStmtBox = (StmtBox) grimp.newStmtBox(null);
 
       /* we can't have a general StmtSwapper on Grimp.v() */
       /* because we need to collect a list of updates */
       oldStmt.apply(new AbstractStmtSwitch() {
+        @Override
         public void caseAssignStmt(AssignStmt s) {
-          newStmtBox.setUnit(Grimp.v().newAssignStmt(s));
+          newStmtBox.setUnit(grimp.newAssignStmt(s));
         }
 
+        @Override
         public void caseIdentityStmt(IdentityStmt s) {
-          newStmtBox.setUnit(Grimp.v().newIdentityStmt(s));
+          newStmtBox.setUnit(grimp.newIdentityStmt(s));
         }
 
+        @Override
         public void caseBreakpointStmt(BreakpointStmt s) {
-          newStmtBox.setUnit(Grimp.v().newBreakpointStmt(s));
+          newStmtBox.setUnit(grimp.newBreakpointStmt(s));
         }
 
+        @Override
         public void caseInvokeStmt(InvokeStmt s) {
-          newStmtBox.setUnit(Grimp.v().newInvokeStmt(s));
+          newStmtBox.setUnit(grimp.newInvokeStmt(s));
         }
 
+        @Override
         public void caseEnterMonitorStmt(EnterMonitorStmt s) {
-          newStmtBox.setUnit(Grimp.v().newEnterMonitorStmt(s));
+          newStmtBox.setUnit(grimp.newEnterMonitorStmt(s));
         }
 
+        @Override
         public void caseExitMonitorStmt(ExitMonitorStmt s) {
-          newStmtBox.setUnit(Grimp.v().newExitMonitorStmt(s));
+          newStmtBox.setUnit(grimp.newExitMonitorStmt(s));
         }
 
+        @Override
         public void caseGotoStmt(GotoStmt s) {
-          newStmtBox.setUnit(Grimp.v().newGotoStmt(s));
+          newStmtBox.setUnit(grimp.newGotoStmt(s));
           updateStmtBox.setUnit(s);
         }
 
+        @Override
         public void caseIfStmt(IfStmt s) {
-          newStmtBox.setUnit(Grimp.v().newIfStmt(s));
+          newStmtBox.setUnit(grimp.newIfStmt(s));
           updateStmtBox.setUnit(s);
         }
 
+        @Override
         public void caseLookupSwitchStmt(LookupSwitchStmt s) {
-          newStmtBox.setUnit(Grimp.v().newLookupSwitchStmt(s));
+          newStmtBox.setUnit(grimp.newLookupSwitchStmt(s));
           updateStmtBox.setUnit(s);
         }
 
+        @Override
         public void caseNopStmt(NopStmt s) {
-          newStmtBox.setUnit(Grimp.v().newNopStmt(s));
+          newStmtBox.setUnit(grimp.newNopStmt(s));
         }
 
+        @Override
         public void caseReturnStmt(ReturnStmt s) {
-          newStmtBox.setUnit(Grimp.v().newReturnStmt(s));
+          newStmtBox.setUnit(grimp.newReturnStmt(s));
         }
 
+        @Override
         public void caseReturnVoidStmt(ReturnVoidStmt s) {
-          newStmtBox.setUnit(Grimp.v().newReturnVoidStmt(s));
+          newStmtBox.setUnit(grimp.newReturnVoidStmt(s));
         }
 
+        @Override
         public void caseTableSwitchStmt(TableSwitchStmt s) {
-          newStmtBox.setUnit(Grimp.v().newTableSwitchStmt(s));
+          newStmtBox.setUnit(grimp.newTableSwitchStmt(s));
           updateStmtBox.setUnit(s);
         }
 
+        @Override
         public void caseThrowStmt(ThrowStmt s) {
-          newStmtBox.setUnit(Grimp.v().newThrowStmt(s));
+          newStmtBox.setUnit(grimp.newThrowStmt(s));
         }
       });
 
       /* map old Expr's to new Expr's. */
-      Stmt newStmt = (Stmt) (newStmtBox.getUnit());
-      Iterator<ValueBox> useBoxesIt;
-      useBoxesIt = newStmt.getUseBoxes().iterator();
-      while (useBoxesIt.hasNext()) {
-        ValueBox b = (useBoxesIt.next());
-        b.setValue(Grimp.v().newExpr(b.getValue()));
+      Stmt newStmt = (Stmt) newStmtBox.getUnit();
+      for (ValueBox box : newStmt.getUseBoxes()) {
+        box.setValue(grimp.newExpr(box.getValue()));
       }
-      useBoxesIt = newStmt.getDefBoxes().iterator();
-      while (useBoxesIt.hasNext()) {
-        ValueBox b = (useBoxesIt.next());
-        b.setValue(Grimp.v().newExpr(b.getValue()));
+      for (ValueBox box : newStmt.getDefBoxes()) {
+        box.setValue(grimp.newExpr(box.getValue()));
       }
 
-      getUnits().add(newStmt);
+      thisUnits.add(newStmt);
       oldToNew.put(oldStmt, newStmt);
       if (updateStmtBox.getUnit() != null) {
         updates.add(updateStmtBox.getUnit());
@@ -204,49 +213,54 @@ public class GrimpBody extends StmtBody {
     }
 
     /* fixup stmt's which have had moved targets */
-    it = updates.iterator();
-    while (it.hasNext()) {
-      Stmt stmt = (Stmt) (it.next());
-
-      stmt.apply(new AbstractStmtSwitch() {
+    {
+      final AbstractStmtSwitch tgtUpdateSwitch = new AbstractStmtSwitch() {
+        @Override
         public void caseGotoStmt(GotoStmt s) {
-          GotoStmt newStmt = (GotoStmt) (oldToNew.get(s));
-          newStmt.setTarget(oldToNew.get(newStmt.getTarget()));
+          GotoStmt newStmt = (GotoStmt) oldToNew.get(s);
+          newStmt.setTarget(oldToNew.get((Stmt) newStmt.getTarget()));
         }
 
+        @Override
         public void caseIfStmt(IfStmt s) {
-          IfStmt newStmt = (IfStmt) (oldToNew.get(s));
+          IfStmt newStmt = (IfStmt) oldToNew.get(s);
           newStmt.setTarget(oldToNew.get(newStmt.getTarget()));
         }
 
+        @Override
         public void caseLookupSwitchStmt(LookupSwitchStmt s) {
-          LookupSwitchStmt newStmt = (LookupSwitchStmt) (oldToNew.get(s));
-          newStmt.setDefaultTarget((oldToNew.get(newStmt.getDefaultTarget())));
+          LookupSwitchStmt newStmt = (LookupSwitchStmt) oldToNew.get(s);
+          newStmt.setDefaultTarget(oldToNew.get((Stmt) newStmt.getDefaultTarget()));
           Unit[] newTargList = new Unit[newStmt.getTargetCount()];
-          for (int i = 0; i < newStmt.getTargetCount(); i++) {
-            newTargList[i] = (oldToNew.get(newStmt.getTarget(i)));
+          for (int i = 0; i < newTargList.length; i++) {
+            newTargList[i] = oldToNew.get((Stmt) newStmt.getTarget(i));
           }
           newStmt.setTargets(newTargList);
         }
 
+        @Override
         public void caseTableSwitchStmt(TableSwitchStmt s) {
-          TableSwitchStmt newStmt = (TableSwitchStmt) (oldToNew.get(s));
-          newStmt.setDefaultTarget((oldToNew.get(newStmt.getDefaultTarget())));
+          TableSwitchStmt newStmt = (TableSwitchStmt) oldToNew.get(s);
+          newStmt.setDefaultTarget(oldToNew.get((Stmt) newStmt.getDefaultTarget()));
           int tc = newStmt.getHighIndex() - newStmt.getLowIndex() + 1;
           LinkedList<Unit> newTargList = new LinkedList<Unit>();
           for (int i = 0; i < tc; i++) {
-            newTargList.add(oldToNew.get(newStmt.getTarget(i)));
+            newTargList.add(oldToNew.get((Stmt) newStmt.getTarget(i)));
           }
           newStmt.setTargets(newTargList);
         }
-      });
+      };
+      for (Unit u : updates) {
+        u.apply(tgtUpdateSwitch);
+      }
     }
 
-    Iterator<Trap> trapIt = jBody.getTraps().iterator();
-    while (trapIt.hasNext()) {
-      Trap oldTrap = trapIt.next();
-      getTraps().add(Grimp.v().newTrap(oldTrap.getException(), (oldToNew.get(oldTrap.getBeginUnit())),
-          (oldToNew.get(oldTrap.getEndUnit())), (oldToNew.get(oldTrap.getHandlerUnit()))));
+    {
+      final Chain<Trap> thisTraps = getTraps();
+      for (Trap oldTrap : jBody.getTraps()) {
+        thisTraps.add(grimp.newTrap(oldTrap.getException(), oldToNew.get((Stmt) oldTrap.getBeginUnit()),
+            oldToNew.get((Stmt) oldTrap.getEndUnit()), oldToNew.get((Stmt) oldTrap.getHandlerUnit())));
+      }
     }
 
     PackManager.v().getPack("gb").apply(this);

--- a/src/main/java/soot/jimple/JimpleBody.java
+++ b/src/main/java/soot/jimple/JimpleBody.java
@@ -23,8 +23,9 @@ package soot.jimple;
  */
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import soot.Body;
 import soot.Local;
@@ -48,31 +49,34 @@ import soot.util.Chain;
 import soot.validation.BodyValidator;
 import soot.validation.ValidationException;
 
-/** Implementation of the Body class for the Jimple IR. */
+/**
+ * Implementation of the Body class for the Jimple IR.
+ */
 public class JimpleBody extends StmtBody {
-  private static BodyValidator[] validators;
+  private static final Logger logger = LoggerFactory.getLogger(JimpleBody.class);
 
   /**
-   * Returns an array containing some validators in order to validate the JimpleBody
-   *
-   * @return the array containing validators
+   * Lazy initialized array containing some validators in order to validate the JimpleBody.
    */
-  private synchronized static BodyValidator[] getValidators() {
-    if (validators == null) {
-      validators = new BodyValidator[] { IdentityStatementsValidator.v(), TypesValidator.v(), ReturnStatementsValidator.v(),
-          InvokeArgumentValidator.v(), FieldRefValidator.v(), NewValidator.v(), JimpleTrapValidator.v(),
-          IdentityValidator.v(), MethodValidator.v()
-          // InvokeValidator.v()
-      };
+  private static class LazyValidatorsSingleton {
+    static final BodyValidator[] V = new BodyValidator[] { IdentityStatementsValidator.v(), TypesValidator.v(),
+        ReturnStatementsValidator.v(), InvokeArgumentValidator.v(), FieldRefValidator.v(), NewValidator.v(),
+        JimpleTrapValidator.v(), IdentityValidator.v(), MethodValidator.v() /* InvokeValidator.v() */ };
+
+    private LazyValidatorsSingleton() {
     }
-    return validators;
-  };
+  }
 
   /**
    * Construct an empty JimpleBody
+   * 
+   * @param m
    */
   public JimpleBody(SootMethod m) {
     super(m);
+    if (Options.v().verbose()) {
+      logger.debug("[" + getMethod().getName() + "] Constructing JimpleBody...");
+    }
   }
 
   /**
@@ -81,7 +85,11 @@ public class JimpleBody extends StmtBody {
   public JimpleBody() {
   }
 
-  /** Clones the current body, making deep copies of the contents. */
+  /**
+   * Clones the current body, making deep copies of the contents.
+   * 
+   * @return
+   */
   @Override
   public Object clone() {
     Body b = new JimpleBody(getMethod());
@@ -111,11 +119,10 @@ public class JimpleBody extends StmtBody {
   public void validate(List<ValidationException> exceptionList) {
     super.validate(exceptionList);
     final boolean runAllValidators = Options.v().debug() || Options.v().validate();
-    for (BodyValidator validator : getValidators()) {
-      if (!validator.isBasicValidator() && !runAllValidators) {
-        continue;
+    for (BodyValidator validator : LazyValidatorsSingleton.V) {
+      if (runAllValidators || validator.isBasicValidator()) {
+        validator.validate(this, exceptionList);
       }
-      validator.validate(this, exceptionList);
     }
   }
 
@@ -123,7 +130,9 @@ public class JimpleBody extends StmtBody {
     runValidation(IdentityStatementsValidator.v());
   }
 
-  /** Inserts usual statements for handling this & parameters into body. */
+  /**
+   * Inserts usual statements for handling this & parameters into body.
+   */
   public void insertIdentityStmts() {
     insertIdentityStmts(getMethod().getDeclaringClass());
   }
@@ -136,8 +145,8 @@ public class JimpleBody extends StmtBody {
    */
   public void insertIdentityStmts(SootClass declaringClass) {
     final Jimple jimple = Jimple.v();
-    final PatchingChain<Unit> unitChain = getUnits();
-    final Chain<Local> localChain = getLocals();
+    final PatchingChain<Unit> unitChain = this.getUnits();
+    final Chain<Local> localChain = this.getLocals();
     Unit lastUnit = null;
 
     // add this-ref before everything else
@@ -171,18 +180,22 @@ public class JimpleBody extends StmtBody {
     }
   }
 
-  /** Returns the first non-identity stmt in this body. */
+  /**
+   * Returns the first non-identity stmt in this body.
+   * 
+   * @return
+   */
   public Stmt getFirstNonIdentityStmt() {
-    Iterator<Unit> it = getUnits().iterator();
-    Object o = null;
-    while (it.hasNext()) {
-      if (!((o = it.next()) instanceof IdentityStmt)) {
+    Unit r = null;
+    for (Unit u : getUnits()) {
+      r = u;
+      if (!(r instanceof IdentityStmt)) {
         break;
       }
     }
-    if (o == null) {
+    if (r == null) {
       throw new RuntimeException("no non-id statements!");
     }
-    return (Stmt) o;
+    return (Stmt) r;
   }
 }

--- a/src/main/java/soot/shimple/ShimpleBody.java
+++ b/src/main/java/soot/shimple/ShimpleBody.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import soot.Body;
 import soot.SootMethod;
+import soot.Unit;
 import soot.jimple.Jimple;
 import soot.jimple.JimpleBody;
 import soot.jimple.StmtBody;
@@ -50,31 +51,35 @@ import soot.util.HashChain;
  * @see soot.shimple.internal.ShimpleBodyBuilder
  * @see <a href="http://citeseer.nj.nec.com/cytron91efficiently.html">Efficiently Computing Static Single Assignment Form and
  *      the Control Dependence Graph</a>
- **/
+ */
 public class ShimpleBody extends StmtBody {
   private static final Logger logger = LoggerFactory.getLogger(ShimpleBody.class);
+
   /**
    * Holds our options map...
-   **/
+   */
   protected ShimpleOptions options;
 
   protected ShimpleBodyBuilder sbb;
 
-  protected boolean isExtendedSSA = false;
+  /**
+   * Set isSSA boolean to indicate whether a ShimpleBody is still in SSA form or not. Could be useful for book-keeping
+   * purposes.
+   */
+  protected boolean isSSA = false;
 
   /**
    * Construct an empty ShimpleBody associated with m.
-   **/
-  ShimpleBody(SootMethod m, Map options) {
+   */
+  ShimpleBody(SootMethod m, Map<String, String> options) {
     super(m);
 
     // must happen before SPatchingChain gets created
     this.options = new ShimpleOptions(options);
-    setSSA(true);
-    isExtendedSSA = this.options.extended();
 
-    unitChain = new SPatchingChain(this, new HashChain());
-    sbb = new ShimpleBodyBuilder(this);
+    setSSA(true);
+    this.unitChain = new SPatchingChain(this, new HashChain<Unit>());
+    this.sbb = new ShimpleBodyBuilder(this);
   }
 
   /**
@@ -83,12 +88,12 @@ public class ShimpleBody extends StmtBody {
    * <p>
    * Currently available option is "naive-phi-elimination", typically in the "shimple" phase (eg, -p shimple
    * naive-phi-elimination) which can be useful for understanding the effect of analyses.
-   **/
-  ShimpleBody(Body body, Map options) {
+   */
+  ShimpleBody(Body body, Map<String, String> options) {
     super(body.getMethod());
 
     if (!(body instanceof JimpleBody || body instanceof ShimpleBody)) {
-      throw new RuntimeException("Cannot construct ShimpleBody from given Body type.");
+      throw new RuntimeException("Cannot construct ShimpleBody from given Body type: " + body.getClass());
     }
 
     if (Options.v().verbose()) {
@@ -98,17 +103,12 @@ public class ShimpleBody extends StmtBody {
     // must happen before SPatchingChain gets created
     this.options = new ShimpleOptions(options);
 
-    unitChain = new SPatchingChain(this, new HashChain());
+    this.unitChain = new SPatchingChain(this, new HashChain<Unit>());
     importBodyContentsFrom(body);
 
     /* Shimplise body */
-    sbb = new ShimpleBodyBuilder(this);
-
-    if (body instanceof ShimpleBody) {
-      rebuild(true);
-    } else {
-      rebuild(false);
-    }
+    this.sbb = new ShimpleBodyBuilder(this);
+    rebuild(body instanceof ShimpleBody);
   }
 
   /**
@@ -117,7 +117,7 @@ public class ShimpleBody extends StmtBody {
    * <p>
    * Note: assumes presence of Phi nodes in body that require elimination. If you *know* there are no Phi nodes present, you
    * may prefer to use rebuild(false) in order to skip some transformations during the Phi elimination process.
-   **/
+   */
   public void rebuild() {
     rebuild(true);
   }
@@ -132,9 +132,8 @@ public class ShimpleBody extends StmtBody {
    * <p>
    * The eliminate Phi nodes stage is harmless, but if you *know* that no Phi nodes are present and you wish to avoid the
    * transformations involved in eliminating Phi nodes, use rebuild(false).
-   **/
+   */
   public void rebuild(boolean hasPhiNodes) {
-    isExtendedSSA = options.extended();
     sbb.transform();
     setSSA(true);
   }
@@ -151,7 +150,7 @@ public class ShimpleBody extends StmtBody {
    * Remember to setActiveBody() if necessary in your SootMethod.
    *
    * @see #eliminatePhiNodes()
-   **/
+   */
   public JimpleBody toJimpleBody() {
     ShimpleBody sBody = (ShimpleBody) this.clone();
 
@@ -170,7 +169,7 @@ public class ShimpleBody extends StmtBody {
    * This can be useful for understanding the effect of analyses.
    *
    * @see #toJimpleBody()
-   **/
+   */
   public void eliminatePhiNodes() {
     sbb.preElimOpt();
     sbb.eliminatePhiNodes();
@@ -185,7 +184,7 @@ public class ShimpleBody extends StmtBody {
   public void eliminateNodes() {
     sbb.preElimOpt();
     sbb.eliminatePhiNodes();
-    if (isExtendedSSA) {
+    if (options.extended()) {
       sbb.eliminatePiNodes();
     }
     sbb.postElimOpt();
@@ -194,7 +193,8 @@ public class ShimpleBody extends StmtBody {
 
   /**
    * Returns a copy of the current ShimpleBody.
-   **/
+   */
+  @Override
   public Object clone() {
     Body b = Shimple.v().newBody(getMethod());
     b.importBodyContentsFrom(this);
@@ -202,15 +202,9 @@ public class ShimpleBody extends StmtBody {
   }
 
   /**
-   * Set isSSA boolean to indicate whether a ShimpleBody is still in SSA form or not. Could be useful for book-keeping
-   * purposes.
-   **/
-  protected boolean isSSA = false;
-
-  /**
    * Sets a flag that indicates whether ShimpleBody is still in SSA form after a transformation or not. It is often up to the
    * user to indicate if a body is no longer in SSA form.
-   **/
+   */
   public void setSSA(boolean isSSA) {
     this.isSSA = isSSA;
   }
@@ -219,18 +213,18 @@ public class ShimpleBody extends StmtBody {
    * Returns value of, optional, user-maintained SSA boolean.
    *
    * @see #setSSA(boolean)
-   **/
+   */
   public boolean isSSA() {
     return isSSA;
   }
 
   public boolean isExtendedSSA() {
-    return isExtendedSSA;
+    return options.extended();
   }
 
   /**
    * Returns the Shimple options applicable to this body.
-   **/
+   */
   public ShimpleOptions getOptions() {
     return options;
   }
@@ -241,7 +235,7 @@ public class ShimpleBody extends StmtBody {
    * underscore notation is used to differentiate locals previously of the same name.
    *
    * @see soot.jimple.toolkits.scalar.LocalNameStandardizer
-   **/
+   */
   public void makeUniqueLocalNames() {
     sbb.makeUniqueLocalNames();
   }

--- a/src/main/java/soot/tagkit/AbstractHost.java
+++ b/src/main/java/soot/tagkit/AbstractHost.java
@@ -24,7 +24,6 @@ package soot.tagkit;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 // extended by SootClass, SootField, SootMethod, Scene
@@ -41,57 +40,76 @@ public class AbstractHost implements Host {
   // use lazy instantiation (in addTag) instead
   protected List<Tag> mTagList = null;
 
-  /** get the list of tags. This list should not be modified! */
+  /**
+   * Get the {@link List} of {@link Tag Tags} on {@code this} {@link Host}. This list should not be modified!
+   * 
+   * @return
+   */
   @Override
   public List<Tag> getTags() {
     return (mTagList == null) ? Collections.<Tag>emptyList() : mTagList;
   }
 
-  /** remove the tag named <code>aName</code> */
+  /**
+   * Remove the {@link Tag} named {@code aName} from {@code this} {@link Host}.
+   * 
+   * @param aName
+   */
   @Override
   public void removeTag(String aName) {
-    int tagIndex;
-    if ((tagIndex = searchForTag(aName)) != -1) {
+    int tagIndex = searchForTag(aName);
+    if (tagIndex != -1) {
       mTagList.remove(tagIndex);
     }
   }
 
-  /** search for tag named <code>aName</code> */
+  /**
+   * Search for {@link Tag} named {@code aName}.
+   */
   private int searchForTag(String aName) {
-    if (mTagList == null) {
-      return -1;
-    }
-
-    int i = 0;
-    Iterator<Tag> it = mTagList.iterator();
-    while (it.hasNext()) {
-      Tag tag = it.next();
-      if (tag != null && tag.getName().equals(aName)) {
-        return i;
+    if (mTagList != null) {
+      int i = 0;
+      for (Tag tag : mTagList) {
+        if (tag != null && tag.getName().equals(aName)) {
+          return i;
+        }
+        i++;
       }
-      i++;
     }
     return -1;
   }
 
-  /** get the Tag object named <code>aName</code> */
+  /**
+   * Return the {@link Tag} named {@code aName} from {@code this} {@link Host} or {@code null} if there is no such
+   * {@link Tag}.
+   * 
+   * @param aName
+   * 
+   * @return
+   */
   @Override
   public Tag getTag(String aName) {
-    int tagIndex;
-    if ((tagIndex = searchForTag(aName)) != -1) {
-      return mTagList.get(tagIndex);
-    }
-
-    return null;
+    int tagIndex = searchForTag(aName);
+    return (tagIndex == -1) ? null : mTagList.get(tagIndex);
   }
 
-  /** look if this host has a tag named <code>aName</code> */
+  /**
+   * Check if {@code this} {@link Host} has a {@link Tag} named {@code aName}.
+   * 
+   * @param aName
+   * 
+   * @return
+   */
   @Override
   public boolean hasTag(String aName) {
     return (searchForTag(aName) != -1);
   }
 
-  /** add tag <code>t</code> to this host */
+  /**
+   * Add the given {@link Tag} to {@code this} {@link Host}.
+   * 
+   * @param t
+   */
   @Override
   public void addTag(Tag t) {
     if (mTagList == null) {
@@ -100,25 +118,28 @@ public class AbstractHost implements Host {
     mTagList.add(t);
   }
 
-  /** Removes all the tags from this host. */
+  /**
+   * Removes all the tags from {@code this} {@link Host}.
+   */
   @Override
   public void removeAllTags() {
     mTagList = null;
   }
 
-  /** Adds all the tags from h to this host. */
+  /**
+   * Adds all the tags from the given {@link Host} to {@code this} {@link Host}.
+   * 
+   * @param h
+   */
   @Override
   public void addAllTagsOf(Host h) {
     List<Tag> tags = h.getTags();
-    if (tags.isEmpty()) {
-      return;
+    if (!tags.isEmpty()) {
+      if (mTagList == null) {
+        mTagList = new ArrayList<Tag>(tags.size());
+      }
+      mTagList.addAll(tags);
     }
-
-    if (mTagList == null) {
-      mTagList = new ArrayList<Tag>(tags.size());
-    }
-
-    mTagList.addAll(tags);
   }
 
   @Override
@@ -131,11 +152,7 @@ public class AbstractHost implements Host {
       } else {
         // get line from bytecode
         LineNumberTag tag2 = (LineNumberTag) getTag(LineNumberTag.IDENTIFIER);
-        if (tag2 != null) {
-          line = tag2.getLineNumber();
-        } else {
-          line = -1;
-        }
+        line = (tag2 == null) ? -1 : tag2.getLineNumber();
       }
     }
     return line;
@@ -145,12 +162,8 @@ public class AbstractHost implements Host {
   public int getJavaSourceStartColumnNumber() {
     if (col <= 0) {
       // get line from source
-      SourceLnPosTag tag = (SourceLnPosTag) getTag("SourceLnPosTag");
-      if (tag != null) {
-        col = tag.startPos();
-      } else {
-        col = -1;
-      }
+      SourceLnPosTag tag = (SourceLnPosTag) getTag(SourceLnPosTag.IDENTIFIER);
+      col = (tag == null) ? -1 : tag.startPos();
     }
     return col;
   }


### PR DESCRIPTION
* formatting, foreach loop, etc.
* bugfix: getParameter* methods would fail if ParameterRef IdentityStmts were in non-increasing order in the body. The methods also did not correctly detect duplicate or missing ParameterRefs.
* add thread-safe single-initialization of validators arrays without explicit synchronization (per "Effective Java")
* add getMethodUnsafe() to Body to allow null-safe retrieval of the method