### PR TITLE
Fix bugs, cleanup, and modernize Scene and ModuleScene

### DIFF
--- a/src/main/java/soot/ModuleScene.java
+++ b/src/main/java/soot/ModuleScene.java
@@ -1,3 +1,5 @@
+package soot;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -20,26 +22,19 @@
  * #L%
  */
 
-/*
- * Modified by the Sable Research Group and others 1997-1999.
- * See the 'credits' file distributed with Soot for the complete list of
- * contributors.  (Soot is distributed at http://www.sable.mcgill.ca/soot)
- */
-
-package soot;
-
 import com.google.common.base.Optional;
 
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import soot.options.Options;
 import soot.util.Chain;
@@ -50,36 +45,36 @@ import soot.util.HashChain;
  *
  * @author Andreas Dann
  */
-public class ModuleScene extends Scene // extends original Scene
-{
+public class ModuleScene extends Scene {
+  private static final Logger logger = LoggerFactory.getLogger(Scene.class);
 
   /*
    * holds the references to SootClass 1: String the class name 2: Map<String, RefType>: The String represents the module
    * that holds the corresponding RefType since multiple modules may contain the same class this is a map (for fast look ups)
    * TODO: evaluate if Guava's multimap is faster
    */
-  private final Map<String, Map<String, RefType>> nameToClass = new HashMap<>();
+  private final Map<String, Map<String, RefType>> nameToClass = new HashMap<String, Map<String, RefType>>();
+
   // instead of using a class path, java 9 uses a module path
   private String modulePath = null;
-  private List<SootClass> dynamicClasses = null;
 
   public ModuleScene(Singletons.Global g) {
     super(g);
-    String smp = System.getProperty("soot.module.path");
 
+    String smp = System.getProperty("soot.module.path");
     if (smp != null) {
       setSootModulePath(smp);
     }
 
     // this is a new Class in JAVA 9; that is added to Soot Basic Classes in loadNecessaryClasses method
     addBasicClass("java.lang.invoke.StringConcatFactory");
-
   }
 
   public static ModuleScene v() {
     return G.v().soot_ModuleScene();
   }
 
+  @Override
   public SootMethod getMainMethod() {
     if (!hasMainClass()) {
       throw new RuntimeException("There is no main class set!");
@@ -100,7 +95,7 @@ public class ModuleScene extends Scene // extends original Scene
   }
 
   public void extendSootModulePath(String newPathElement) {
-    modulePath += File.pathSeparator + newPathElement;
+    modulePath += File.pathSeparatorChar + newPathElement;
     ModulePathSourceLocator.v().extendClassPath(newPathElement);
   }
 
@@ -116,33 +111,30 @@ public class ModuleScene extends Scene // extends original Scene
 
   public String getSootModulePath() {
     if (modulePath == null) {
-      String optionsmp = Options.v().soot_modulepath();
-      if (optionsmp != null && optionsmp.length() > 0) {
-        modulePath = optionsmp;
+      // First, check Options for a module path
+      String cp = Options.v().soot_modulepath();
+      // If no module path is given via Options, just use the default.
+      // Otherwise, if the prepend flag is set, append the default.
+      if (cp == null || cp.isEmpty()) {
+        cp = defaultJavaModulePath();
+      } else if (Options.v().prepend_classpath()) {
+        cp += File.pathSeparatorChar + defaultJavaModulePath();
       }
 
-      // if no classpath is given on the command line, take the default
-      if (modulePath == null) {
-        modulePath = defaultJavaModulePath();
-      } else {
-        // if one is given...
-        if (Options.v().prepend_classpath()) {
-          // if the prepend flag is set, append the default classpath
-          modulePath += File.pathSeparator + defaultJavaModulePath();
+      // add process-dirs (if applicable)
+      List<String> dirs = Options.v().process_dir();
+      if (!dirs.isEmpty()) {
+        StringBuilder pds = new StringBuilder();
+        for (String path : dirs) {
+          if (!cp.contains(path)) {
+            pds.append(path).append(File.pathSeparatorChar);
+          }
         }
-        // else, leave it as it is
+        cp = pds.append(cp).toString();
       }
 
-      // add process-dirs
-      List<String> process_dir = Options.v().process_dir();
-      StringBuilder pds = new StringBuilder();
-      for (String path : process_dir) {
-        if (!modulePath.contains(path)) {
-          pds.append(path);
-          pds.append(File.pathSeparator);
-        }
-      }
-      modulePath = pds + modulePath;
+      // Set the new module path
+      modulePath = cp;
     }
 
     return modulePath;
@@ -173,16 +165,17 @@ public class ModuleScene extends Scene // extends original Scene
       throw new RuntimeException("already managed: " + c.getName());
     }
 
-    if (containsClass(c.getName(), Optional.fromNullable(c.moduleName))) {
-      throw new RuntimeException("duplicate class: " + c.getName());
+    final String className = c.getName();
+    if (containsClass(className, Optional.fromNullable(c.moduleName))) {
+      throw new RuntimeException("duplicate class: " + className);
     }
 
     classes.add(c);
 
-    if (!nameToClass.containsKey(c.getName())) {
-      nameToClass.put(c.getName(), new HashMap<>());
+    Map<String, RefType> map = nameToClass.get(className);
+    if (map == null) {
+      nameToClass.put(className, map = new HashMap<String, RefType>());
     }
-    Map<String, RefType> map = nameToClass.get(c.getName());
     map.put(c.moduleName, c.getType());
 
     c.getType().setSootClass(c);
@@ -193,46 +186,35 @@ public class ModuleScene extends Scene // extends original Scene
     if (!c.isPhantom) {
       modifyHierarchy();
     }
-
   }
 
+  @Override
   public boolean containsClass(String className) {
     // TODO: since this code is called from MethodNodeFactory.caseStringConstants
     // check if the wrapper is actually required
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return containsClass(wrapper.getClassName(), wrapper.getModuleNameOptional());
   }
 
   public boolean containsClass(String className, Optional<String> moduleName) {
-
     RefType type = null;
     Map<String, RefType> map = nameToClass.get(className);
     if (map != null && !map.isEmpty()) {
       if (moduleName.isPresent()) {
-        String module = ModuleUtil.v().declaringModule(className, moduleName.get());
-
-        type = map.get(module);
-      }
-      // return first element
-      else {
+        type = map.get(ModuleUtil.v().declaringModule(className, moduleName.get()));
+      } else {
+        // return first element
         type = map.values().iterator().next();
-        if (ModuleUtil.module_mode() && Options.v().verbose()) {
-          G.v().out.println("[WARN] containsClass called with empty module for: " + className);
+        if (Options.v().verbose() && ModuleUtil.module_mode()) {
+          logger.warn("containsClass called with empty module for: " + className);
         }
       }
     }
 
-    if (type == null) {
-      return false;
-    }
-    if (!type.hasSootClass()) {
-      return false;
-    }
-    SootClass c = type.getSootClass();
-    return c.isInScene();
+    return type != null && type.hasSootClass() && type.getSootClass().isInScene();
   }
 
+  @Override
   public boolean containsType(String className) {
     return nameToClass.containsKey(className);
   }
@@ -241,9 +223,7 @@ public class ModuleScene extends Scene // extends original Scene
    * Attempts to load the given class and all of the required support classes. Returns the original class if it was loaded,
    * or null otherwise.
    */
-
   public SootClass tryLoadClass(String className, int desiredLevel, Optional<String> moduleName) {
-
     setPhantomRefs(true);
     ClassSource source = ModulePathSourceLocator.v().getClassSource(className, moduleName);
     try {
@@ -256,22 +236,17 @@ public class ModuleScene extends Scene // extends original Scene
         source.close();
       }
     }
-    SootModuleResolver resolver = SootModuleResolver.v();
-    SootClass toReturn = resolver.resolveClass(className, desiredLevel, moduleName);
+    SootClass toReturn = SootModuleResolver.v().resolveClass(className, desiredLevel, moduleName);
     setPhantomRefs(false);
-
     return toReturn;
-
   }
 
   /**
    * Loads the given class and all of the required support classes. Returns the first class.
    */
-
+  @Override
   public SootClass loadClassAndSupport(String className) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return loadClassAndSupport(wrapper.getClassName(), wrapper.getModuleNameOptional());
   }
 
@@ -283,10 +258,9 @@ public class ModuleScene extends Scene // extends original Scene
     return ret;
   }
 
+  @Override
   public SootClass loadClass(String className, int desiredLevel) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return loadClass(wrapper.getClassName(), desiredLevel, wrapper.getModuleNameOptional());
   }
 
@@ -296,8 +270,7 @@ public class ModuleScene extends Scene // extends original Scene
      */
 
     setPhantomRefs(true);
-    SootModuleResolver resolver = SootModuleResolver.v();
-    SootClass toReturn = resolver.resolveClass(className, desiredLevel, moduleName);
+    SootClass toReturn = SootModuleResolver.v().resolveClass(className, desiredLevel, moduleName);
     setPhantomRefs(false);
 
     return toReturn;
@@ -316,38 +289,43 @@ public class ModuleScene extends Scene // extends original Scene
    */
   public Type getType(String arg, Optional<String> moduleName) {
     String type = arg.replaceAll("([^\\[\\]]*)(.*)", "$1");
-    int arrayCount = arg.contains("[") ? arg.replaceAll("([^\\[\\]]*)(.*)", "$2").length() / 2 : 0;
-
     Type result = getRefTypeUnsafe(type, moduleName);
-
     if (result == null) {
-      if (type.equals("long")) {
-        result = LongType.v();
-      } else if (type.equals("short")) {
-        result = ShortType.v();
-      } else if (type.equals("double")) {
-        result = DoubleType.v();
-      } else if (type.equals("int")) {
-        result = IntType.v();
-      } else if (type.equals("float")) {
-        result = FloatType.v();
-      } else if (type.equals("byte")) {
-        result = ByteType.v();
-      } else if (type.equals("char")) {
-        result = CharType.v();
-      } else if (type.equals("void")) {
-        result = VoidType.v();
-      } else if (type.equals("boolean")) {
-        result = BooleanType.v();
-      } else {
-        throw new RuntimeException("unknown type: '" + type + "'");
+      switch (type) {
+        case "long":
+          result = LongType.v();
+          break;
+        case "short":
+          result = ShortType.v();
+          break;
+        case "double":
+          result = DoubleType.v();
+          break;
+        case "int":
+          result = IntType.v();
+          break;
+        case "float":
+          result = FloatType.v();
+          break;
+        case "byte":
+          result = ByteType.v();
+          break;
+        case "char":
+          result = CharType.v();
+          break;
+        case "void":
+          result = VoidType.v();
+          break;
+        case "boolean":
+          result = BooleanType.v();
+          break;
+        default:
+          throw new RuntimeException("unknown type: '" + type + "'");
       }
     }
 
-    if (arrayCount != 0) {
-      result = ArrayType.v(result, arrayCount);
-    }
-    return result;
+    int arrayCount = arg.contains("[") ? arg.replaceAll("([^\\[\\]]*)(.*)", "$2").length() / 2 : 0;
+    return (arrayCount == 0) ? result : ArrayType.v(result, arrayCount);
   }
 
   /**
@@ -358,7 +336,6 @@ public class ModuleScene extends Scene // extends original Scene
    *           registered
    */
   public RefType getRefType(String className, Optional<String> moduleName) {
-
     RefType refType = getRefTypeUnsafe(className, moduleName);
     if (refType == null) {
       throw new IllegalStateException("RefType " + className + " not loaded. "
@@ -370,9 +347,7 @@ public class ModuleScene extends Scene // extends original Scene
 
   @Override
   public RefType getRefType(String className) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return getRefType(wrapper.getClassName(), wrapper.getModuleNameOptional());
   }
 
@@ -384,7 +359,6 @@ public class ModuleScene extends Scene // extends original Scene
   /**
    * Returns the RefType with the given className. Returns null if no type with the given name can be found.
    */
-
   public RefType getRefTypeUnsafe(String className, Optional<String> moduleName) {
     // RefType refType = nameToClass.get(className);
     RefType refType = null;
@@ -392,12 +366,11 @@ public class ModuleScene extends Scene // extends original Scene
     if (map != null && !map.isEmpty()) {
       if (moduleName.isPresent()) {
         refType = map.get(moduleName.get());
-      }
-      // return first element
-      else {
+      } else {
+        // return first element
         refType = map.values().iterator().next();
         if (Options.v().verbose() && ModuleUtil.module_mode()) {
-          G.v().out.println("[Warning] getRefTypeUnsafe called with empty module for: " + className);
+          logger.warn("getRefTypeUnsafe called with empty module for: " + className);
         }
       }
     }
@@ -408,43 +381,35 @@ public class ModuleScene extends Scene // extends original Scene
   @Override
   public RefType getRefTypeUnsafe(String className) {
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return getRefTypeUnsafe(wrapper.getClassName(), wrapper.getModuleNameOptional());
   }
 
   public void addRefType(RefType type) {
-
-    if (!nameToClass.containsKey(type.getClassName())) {
-      nameToClass.put(type.getClassName(), new HashMap<>());
+    final String className = type.getClassName();
+    Map<String, RefType> map = nameToClass.get(className);
+    if (map == null) {
+      nameToClass.put(className, map = new HashMap<String, RefType>());
     }
-    Map<String, RefType> map = nameToClass.get(type.getClassName());
     map.put(((ModuleRefType) type).getModuleName(), type);
-
   }
 
   @Override
   public SootClass getSootClassUnsafe(String className) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return getSootClassUnsafe(wrapper.getClassName(), wrapper.getModuleNameOptional());
   }
 
   public SootClass getSootClassUnsafe(String className, Optional<String> moduleName) {
     RefType type = null;
     Map<String, RefType> map = nameToClass.get(className);
-
-    String module;
     if (map != null && !map.isEmpty()) {
       if (moduleName.isPresent()) {
-        module = ModuleUtil.v().declaringModule(className, moduleName.get());
-        type = map.get(module);
-      }
-      // return first element
-      else {
+        type = map.get(ModuleUtil.v().declaringModule(className, moduleName.get()));
+      } else {
+        // return first element
         type = map.values().iterator().next();
         if (Options.v().verbose() && ModuleUtil.module_mode()) {
-          G.v().out.println("[Warning] getSootClassUnsafe called with empty for: " + className);
+          logger.warn("getSootClassUnsafe called with empty for: " + className);
         }
       }
     }
@@ -456,7 +421,7 @@ public class ModuleScene extends Scene // extends original Scene
       }
     }
 
-    if (allowsPhantomRefs() || className.equals(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME)) {
+    if (allowsPhantomRefs() || SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME.equals(className)) {
       SootClass c = new SootClass(className);
       addClassSilent(c);
       c.setPhantomClass();
@@ -468,9 +433,7 @@ public class ModuleScene extends Scene // extends original Scene
 
   @Override
   public SootClass getSootClass(String className) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return getSootClass(wrapper.getClassName(), wrapper.getModuleNameOptional());
   }
 
@@ -479,19 +442,18 @@ public class ModuleScene extends Scene // extends original Scene
     if (sc != null) {
       return sc;
     }
-
-    throw new RuntimeException(System.getProperty("line.separator") + "Aborting: can't find classfile " + className);
+    throw new RuntimeException(System.lineSeparator() + "Aborting: can't find classfile " + className);
   }
 
   @Override
   public void loadBasicClasses() {
     addReflectionTraceClasses();
-    Set<String>[] basicclasses = getBasicClassesIncludingResolveLevel();
-    int loadedClasses = 0;
 
+    final ModuleUtil modU = ModuleUtil.v();
+    int loadedClasses = 0;
     for (int i = SootClass.BODIES; i >= SootClass.HIERARCHY; i--) {
       for (String name : basicclasses[i]) {
-        ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(name);
+        ModuleUtil.ModuleClassNameWrapper wrapper = modU.makeWrapper(name);
         SootClass sootClass = tryLoadClass(wrapper.getClassName(), i, wrapper.getModuleNameOptional());
         if (sootClass != null && !sootClass.isPhantom()) {
           loadedClasses++;
@@ -499,23 +461,18 @@ public class ModuleScene extends Scene // extends original Scene
       }
     }
     if (loadedClasses == 0) {
-      // Missing basic classes means no Exceptions could be loaded and no Exception hierarchy can lead
-      // to non-deterministic Jimple code generation: catch blocks may be removed because of
+      // Missing basic classes means no Exceptions could be loaded and no Exception hierarchy can
+      // lead to non-deterministic Jimple code generation: catch blocks may be removed because of
       // non-existing Exception hierarchy.
       throw new RuntimeException("None of the basic classes could be loaded! Check your Soot class path!");
     }
-  }
-
-  private void loadNecessaryClass(String name) {
-    SootClass c;
-    c = loadClassAndSupport(name);
-    c.setApplicationClass();
   }
 
   /**
    * Load the set of classes that soot needs, including those specified on the command-line. This is the standard way of
    * initialising the list of classes soot should use.
    */
+  @Override
   public void loadNecessaryClasses() {
     loadBasicClasses();
 
@@ -530,7 +487,7 @@ public class ModuleScene extends Scene // extends original Scene
         throw new IllegalArgumentException("If switch -oaat is used, then also -process-dir must be given.");
       }
     } else {
-      for (final String path : Options.v().process_dir()) {
+      for (String path : Options.v().process_dir()) {
         for (Map.Entry<String, List<String>> entry : ModulePathSourceLocator.v().getClassUnderModulePath(path).entrySet()) {
           for (String cl : entry.getValue()) {
             SootClass theClass = loadClassAndSupport(cl, Optional.fromNullable(entry.getKey()));
@@ -544,23 +501,25 @@ public class ModuleScene extends Scene // extends original Scene
     setDoneResolving();
   }
 
+  @Override
   public void loadDynamicClasses() {
-    dynamicClasses = new ArrayList<>();
-    Map<String, List<String>> dynClasses = new HashMap<>();
-    dynClasses.put(null, Options.v().dynamic_class());
+    final ArrayList<SootClass> dynamicClasses = new ArrayList<SootClass>();
+    final Options opts = Options.v();
 
-    for (final String path : Options.v().dynamic_dir()) {
+    final Map<String, List<String>> temp = new HashMap<String, List<String>>();
+    temp.put(null, opts.dynamic_class());
 
-      dynClasses.putAll(ModulePathSourceLocator.v().getClassUnderModulePath(path));
+    final ModulePathSourceLocator msloc = ModulePathSourceLocator.v();
+    for (String path : opts.dynamic_dir()) {
+      temp.putAll(msloc.getClassUnderModulePath(path));
     }
 
-    for (final String pkg : Options.v().dynamic_package()) {
-
-      List<String> classPathClasses = dynClasses.get(null);
-      classPathClasses.addAll(SourceLocator.v().classesInDynamicPackage(pkg));
+    final SourceLocator sloc = SourceLocator.v();
+    for (String pkg : opts.dynamic_package()) {
+      temp.get(null).addAll(sloc.classesInDynamicPackage(pkg));
     }
 
-    for (Map.Entry<String, List<String>> entry : dynClasses.entrySet()) {
+    for (Map.Entry<String, List<String>> entry : temp.entrySet()) {
       for (String className : entry.getValue()) {
         dynamicClasses.add(loadClassAndSupport(className, Optional.fromNullable(entry.getKey())));
       }
@@ -570,32 +529,25 @@ public class ModuleScene extends Scene // extends original Scene
     for (Iterator<SootClass> iterator = dynamicClasses.iterator(); iterator.hasNext();) {
       SootClass c = iterator.next();
       if (!c.isConcrete()) {
-        if (Options.v().verbose()) {
-          G.v().out.println(
-              "Warning: dynamic class " + c.getName() + " is abstract or an interface, and it will not be considered.");
+        if (opts.verbose()) {
+          logger.warn("dynamic class " + c.getName() + " is abstract or an interface, and it will not be considered.");
         }
         iterator.remove();
       }
     }
-  }
-
-  // the field is private in superclass Scene thus, these methods needs to be overwritten
-  @Override
-  public Collection<SootClass> dynamicClasses() {
-    if (dynamicClasses == null) {
-      throw new IllegalStateException("Have to call loadDynamicClasses() first!");
-    }
-    return dynamicClasses;
+    this.dynamicClasses = dynamicClasses;
   }
 
   /*
    * Generate classes to process, adding or removing package marked by command line options.
    */
-  private void prepareClasses() {
+  @Override
+  protected void prepareClasses() {
+    final List<String> optionsClasses = Options.v().classes();
     // Remove/add all classes from packageInclusionMask as per -i option
-    Chain<SootClass> processedClasses = new HashChain<>();
+    Chain<SootClass> processedClasses = new HashChain<SootClass>();
     while (true) {
-      Chain<SootClass> unprocessedClasses = new HashChain<>(getClasses());
+      Chain<SootClass> unprocessedClasses = new HashChain<SootClass>(getClasses());
       unprocessedClasses.removeAll(processedClasses);
       if (unprocessedClasses.isEmpty()) {
         break;
@@ -608,7 +560,7 @@ public class ModuleScene extends Scene // extends original Scene
         if (Options.v().app()) {
           s.setApplicationClass();
         }
-        if (Options.v().classes().contains(s.getName())) {
+        if (optionsClasses.contains(s.getName())) {
           s.setApplicationClass();
           continue;
         }
@@ -626,33 +578,32 @@ public class ModuleScene extends Scene // extends original Scene
     }
   }
 
+  @Override
   public void setMainClassFromOptions() {
-    if (mainClass != null) {
-      return;
-    }
-    if (Options.v().main_class() != null && Options.v().main_class().length() > 0) {
-      setMainClass(getSootClass(Options.v().main_class(), null));
-    } else {
-      // try to infer a main class from the command line if none is given
-      for (String s : Options.v().classes()) {
-        SootClass c = getSootClass(s, null);
-        if (c.declaresMethod("main",
-            Collections.singletonList(ArrayType.v(ModuleRefType.v("java.lang.String", Optional.of("java.base")), 1)),
-            VoidType.v())) {
-          G.v().out.println("No main class given. Inferred '" + c.getName() + "' as main class.");
-          setMainClass(c);
-          return;
+    if (mainClass == null) {
+      String optsMain = Options.v().main_class();
+      if (optsMain != null && !optsMain.isEmpty()) {
+        setMainClass(getSootClass(optsMain, null));
+      } else {
+        final List<Type> mainArgs =
+            Collections.singletonList(ArrayType.v(ModuleRefType.v("java.lang.String", Optional.of("java.base")), 1));
+        // try to infer a main class from the command line if none is given
+        for (String s : Options.v().classes()) {
+          SootClass c = getSootClass(s, null);
+          if (c.declaresMethod("main", mainArgs, VoidType.v())) {
+            logger.debug("No main class given. Inferred '" + c.getName() + "' as main class.");
+            setMainClass(c);
+            return;
+          }
         }
-      }
 
-      // try to infer a main class from the usual classpath if none is given
-      for (SootClass c : getApplicationClasses()) {
-        if (c.declaresMethod("main",
-            Collections.singletonList(ArrayType.v(ModuleRefType.v("java.lang.String", Optional.of("java.base")), 1)),
-            VoidType.v())) {
-          G.v().out.println("No main class given. Inferred '" + c.getName() + "' as main class.");
-          setMainClass(c);
-          return;
+        // try to infer a main class from the usual classpath if none is given
+        for (SootClass c : getApplicationClasses()) {
+          if (c.declaresMethod("main", mainArgs, VoidType.v())) {
+            logger.debug("No main class given. Inferred '" + c.getName() + "' as main class.");
+            setMainClass(c);
+            return;
+          }
         }
       }
     }
@@ -660,29 +611,25 @@ public class ModuleScene extends Scene // extends original Scene
 
   @Override
   public SootClass forceResolve(String className, int level) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return forceResolve(wrapper.getClassName(), level, wrapper.getModuleNameOptional());
   }
 
   public SootClass forceResolve(String className, int level, Optional<String> moduleName) {
-    boolean tmp = super.doneResolving();
-    super.setResolving(false);
+    boolean tmp = doneResolving;
+    doneResolving = false;
     SootClass c;
     try {
       c = SootModuleResolver.v().resolveClass(className, level, moduleName);
     } finally {
-      super.setResolving(tmp);
+      doneResolving = tmp;
     }
     return c;
   }
 
   @Override
   public SootClass makeSootClass(String className) {
-
     ModuleUtil.ModuleClassNameWrapper wrapper = ModuleUtil.v().makeWrapper(className);
-
     return makeSootClass(wrapper.getClassName(), wrapper.getModuleName());
   }
 
@@ -708,5 +655,4 @@ public class ModuleScene extends Scene // extends original Scene
     this.addRefType(tp);
     return tp;
   }
-
 }


### PR DESCRIPTION
1. Move android code to an inner class to reduce runtime jar dependencies when running with non-Android inputs 
   Move the code using pxb.android.axml.* into the AndroidVersionInfo class so that the AXML jar is not necessary when running Soot on non-Android inputs (i.e. the AndroidVersionInfo class will not be loaded thus the references in that package will not be seen).
2. Fix bug: methods getting class name from signature must unescape the class name in case it contains reserved words because the Scene will contain the original/unescaped version of the name
3. optimize signature parsing methods to avoid repeat work, etc.
4. organize fields more clearly
5. make dynamicClasses and doneResolving fields protected so ModuleScene doesn't need its own version or to use the methods to get/set (also allowed removing a few override methods from ModuleScene)
6. use logger instead of G.v().out in ModuleScene
7. Additional cleanup, optimization steps throughout the 2 files
8. Handle possible exceptions due to empty string
9. Make some methods static that do not rely on internal state