### PR TITLE
correct a simple syntax mistake and fix a bug

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -782,7 +782,8 @@ public class Scene {
       }
     }
 
-    if (!javaGEQ9 && (Options.v().whole_program() || Options.v().whole_shimple() || Options.v().output_format() == Options.output_format_dava)) {
+    if (!javaGEQ9
+        && (Options.v().whole_program() || Options.v().whole_shimple() || Options.v().output_format() == Options.output_format_dava)) {
       // add jce.jar, which is necessary for whole program mode
       // (java.security.Signature from rt.jar imports javax.crypto.Cipher from jce.jar)
       sb.append(File.pathSeparatorChar).append(javaHome).append(File.separatorChar).append("lib").append(File.separatorChar)

--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -783,7 +783,8 @@ public class Scene {
     }
 
     if (!javaGEQ9
-        && (Options.v().whole_program() || Options.v().whole_shimple() || Options.v().output_format() == Options.output_format_dava)) {
+        && (Options.v().whole_program() || Options.v().whole_shimple()
+            || Options.v().output_format() == Options.output_format_dava)) {
       // add jce.jar, which is necessary for whole program mode
       // (java.security.Signature from rt.jar imports javax.crypto.Cipher from jce.jar)
       sb.append(File.pathSeparatorChar).append(javaHome).append(File.separatorChar).append("lib").append(File.separatorChar)

--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -782,7 +782,7 @@ public class Scene {
       }
     }
 
-    if (!javaGEQ9 && (Options.v().whole_program() || Options.v().output_format() == Options.output_format_dava)) {
+    if (!javaGEQ9 && (Options.v().whole_program() || Options.v().whole_shimple() || Options.v().output_format() == Options.output_format_dava)) {
       // add jce.jar, which is necessary for whole program mode
       // (java.security.Signature from rt.jar imports javax.crypto.Cipher from jce.jar)
       sb.append(File.pathSeparatorChar).append(javaHome).append(File.separatorChar).append("lib").append(File.separatorChar)

--- a/src/main/xml/options/soot_options.xml.orig
+++ b/src/main/xml/options/soot_options.xml.orig
@@ -5272,7 +5272,7 @@ This locking scheme aims to achieve simple fine-grained locking.
                     <default>false</default>
                     <short_desc>Compute extended SSA (SSI) form.</short_desc>
                     <long_desc>
-                        If enabled, Shimple will created extended SSA (SSI) form.
+                        If enabled, Shimple will create extended SSA (SSI) form.
                     </long_desc>
                 </boolopt>
                 <boolopt>

--- a/src/test/java/soot/SootResolverTest.java
+++ b/src/test/java/soot/SootResolverTest.java
@@ -1,0 +1,62 @@
+package soot;
+
+import org.junit.Assert;
+import org.junit.Test;
+import soot.options.Options;
+
+import java.io.File;
+
+/**
+ * Created by canliture on 2021/6/28 <br/>
+ *
+ * A minimal Test for evaluating the bug in the Method {@link soot.Scene#defaultJavaClassPath}. <br/>
+ *
+ * When {@link soot.SootResolver} and {@link soot.SourceLocator#getClassSource} resolve classes,
+ * they will get default java classPath by call `Scene.v().getSootClassPath()`. <br/>
+ *
+ * <b>Test under Java 8 environment: </b> <br/>
+ *
+ * Before fixed the bug, we will get default java class path when <br/>
+ * - we set <pre>Options.v().set_whole_program(true);</pre>: `path/to/rt.jar;path/to/jce.jar` <br/>
+ * - we set <pre>Options.v().set_whole_shimple(true);</pre>: `path/to/rt.jar` <br/>
+ *
+ * After fixed the bug, we will get default java class path when <br/>
+ * - we set <pre>Options.v().set_whole_program(true);</pre>: `path/to/rt.jar;path/to/jce.jar` <br/>
+ * - we set <pre>Options.v().set_whole_shimple(true);</pre>: `path/to/rt.jar;path/to/jce.jar` <br/>
+ *
+ * @author canliture
+ */
+public class SootResolverTest {
+
+    @Test
+    public void test1() {
+        G.reset();
+
+        // setting
+        Options.v().set_whole_program(true);
+
+        // No throw. ^_^
+        Scene.v().loadNecessaryClasses();
+
+        // assert default class path
+        String classPath = Scene.v().getSootClassPath();
+        String[] paths = classPath.split(File.pathSeparator);
+        Assert.assertEquals(2, paths.length);
+    }
+
+    @Test
+    public void test2() {
+        G.reset();
+
+        // setting
+        Options.v().set_whole_shimple(true);
+
+        // throw java.lang.AssertionError !!!
+        Scene.v().loadNecessaryClasses();
+
+        // assert default class path
+        String classPath = Scene.v().getSootClassPath();
+        String[] paths = classPath.split(File.pathSeparator);
+        Assert.assertEquals(2, paths.length);
+    }
+}

--- a/src/test/java/soot/SootResolverTest.java
+++ b/src/test/java/soot/SootResolverTest.java
@@ -1,10 +1,30 @@
 package soot;
 
-import org.junit.Assert;
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997 - 1999 Raja Vallee-Rai
+ * Copyright (C) 2004 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import org.junit.Test;
 import soot.options.Options;
-
-import java.io.File;
 
 /**
  * Created by canliture on 2021/6/28 <br/>
@@ -37,11 +57,6 @@ public class SootResolverTest {
 
         // No throw. ^_^
         Scene.v().loadNecessaryClasses();
-
-        // assert default class path
-        String classPath = Scene.v().getSootClassPath();
-        String[] paths = classPath.split(File.pathSeparator);
-        Assert.assertEquals(2, paths.length);
     }
 
     @Test
@@ -53,10 +68,5 @@ public class SootResolverTest {
 
         // throw java.lang.AssertionError !!!
         Scene.v().loadNecessaryClasses();
-
-        // assert default class path
-        String classPath = Scene.v().getSootClassPath();
-        String[] paths = classPath.split(File.pathSeparator);
-        Assert.assertEquals(2, paths.length);
     }
 }


### PR DESCRIPTION
- correct a simple syntax mistake
[Last](https://github.com/canliture/soot/commit/621a81dbc9179f9e54f825077a278a9846e5d746), I have corrected the mistake, but missed the same problem in the file 'soot_options.xml.orig'

- fix a bug
When I write the following test code:
```
public class SootResolverTest {

    @Test
    public void test1() {
        G.reset();

        // setting
        Options.v().set_whole_program(true);

        // No throw. ^_^
        Scene.v().loadNecessaryClasses();
    }

    @Test
    public void test2() {
        G.reset();

        // setting
        Options.v().set_whole_shimple(true);

        // throw java.lang.AssertionError !!!
        Scene.v().loadNecessaryClasses();
    }
}
```

'test1' will pass the test and 'test2' will fail to pass the test.

The reason that 'test2' fails to pass the test is written at the header comment of test class 'soot.SootResolverTest':

Before fixing the bug, we will get default java class path when <br/>
- we set <b>Options.v().set_whole_program(true);</b> : `path/to/rt.jar;path/to/jce.jar` <br/>
- we set <b>Options.v().set_whole_shimple(true);</b> : `path/to/rt.jar` <br/>

After fixing the bug, we will get default java class path when <br/>
- we set <b>Options.v().set_whole_program(true);</b> : `path/to/rt.jar;path/to/jce.jar` <br/>
- we set <b>Options.v().set_whole_shimple(true);</b> : `path/to/rt.jar;path/to/jce.jar` <br/>