### PR TITLE
[Bug fix]return incorrect nullness in the method Scene#getTypeUnsafe

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1031,12 +1031,35 @@ public class Scene {
    * representation of the type is an array, the returned type will be an ArrayType with the base type resolved as described
    * above.
    *
+   * Notice: Recommend to use {@link #getTypeUnsafeUnescape}
+   *
    * @param arg
    *          A string description of the type
    * @return The Type if it can be resolved and null otherwise
    */
   public Type getTypeUnsafe(String arg) {
     return getTypeUnsafe(arg, true);
+  }
+
+  /**
+   * The method do the same thing as the method {@link #getTypeUnsafe(String)} except for unescaping the argument.
+   *
+   * An argument passed into the method {@link #getTypeUnsafe} may be <b>quoted</b>, like them: <br/>
+   * <li>1. "sun.reflect.'annotation'.AnnotationType"<li/> <br/>
+   * <li>2. "java.lang.'annotation'.Annotation"<li/> <br/>
+   *
+   * If calling {@link #getTypeUnsafe(String)} with <b>quoted</b> argument, the method maybe return null. <br/>
+   *
+   * For example, after we call {@link #loadNecessaryClasses}, getTypeUnsafe("java.lang.'annotation'.Annotation") <br/>
+   * will return null but getTypeUnsafe("java.lang.annotation.Annotation") will not return null.
+   *
+   * @param arg
+   *          A string description of the type
+   * @return The Type if it can be resolved and null otherwise
+   */
+  public Type getTypeUnsafeUnescape(String arg) {
+    String unescapeName = unescapeName(arg);
+    return getTypeUnsafe(unescapeName);
   }
 
   /**

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -602,10 +602,10 @@ public class OnFlyCallGraphBuilder {
                 String parameters = m.group("parameters");
                 if (parameters != null && !parameters.isEmpty()) {
                   for (String p : parameters.split(",")) {
-                    params.add(sc.getTypeUnsafe(p.trim()));
+                    params.add(sc.getTypeUnsafeUnescape(p.trim()));
                   }
                 }
-                ref = sc.makeMethodRef(receiverClass, methodName, params, sc.getTypeUnsafe(returnType),
+                ref = sc.makeMethodRef(receiverClass, methodName, params, sc.getTypeUnsafeUnescape(returnType),
                     Kind.isStatic(site.kind()));
               }
             }

--- a/src/test/java/soot/SootResolverTest.java
+++ b/src/test/java/soot/SootResolverTest.java
@@ -23,12 +23,14 @@ package soot;
  * #L%
  */
 
+import org.junit.Assert;
 import org.junit.Test;
 import soot.options.Options;
 
 /**
  * Created by canliture on 2021/6/28 <br/>
  *
+ * 1. Bug fixing description about 'test1' and 'test2':
  * A minimal Test for evaluating the bug in the Method {@link soot.Scene#defaultJavaClassPath}. <br/>
  *
  * When {@link soot.SootResolver} and {@link soot.SourceLocator#getClassSource} resolve classes,
@@ -43,6 +45,15 @@ import soot.options.Options;
  * After fixed the bug, we will get default java class path when <br/>
  * - we set <pre>Options.v().set_whole_program(true);</pre>: `path/to/rt.jar;path/to/jce.jar` <br/>
  * - we set <pre>Options.v().set_whole_shimple(true);</pre>: `path/to/rt.jar;path/to/jce.jar` <br/>
+ *
+ * 2. Bug fixing description about 'test3':
+ * In method {@link soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder#addType), it calls {@link Scene#getTypeUnsafe(String)},
+ * but the argument passed into the method {@link Scene#getTypeUnsafe(String)} may be <b>quoted</b>, just like: <br/>
+ * <li>1. "sun.reflect.'annotation'.AnnotationType"</li> <br/>
+ * <li>2. "java.lang.'annotation'.Annotation" </li> <br/>
+ * But {@link Scene#getTypeUnsafe(String)} will return null if the argument passed into is <b>quoted<b/>, it will lead to <br/>
+ * Soot crashing with NullPointerException or IllegalArgumentException somewhere, just like 'test3' failing to pass the test <br/>
+ * with IllegalArgumentException
  *
  * @author canliture
  */
@@ -68,5 +79,23 @@ public class SootResolverTest {
 
         // throw java.lang.AssertionError !!!
         Scene.v().loadNecessaryClasses();
+    }
+
+    @Test
+    public void test3() {
+        G.reset();
+
+        Options.v().set_whole_program(true);
+
+        Scene.v().loadNecessaryClasses();
+
+        Assert.assertNotNull(Scene.v().getTypeUnsafe("java.lang.annotation.Annotation"));
+        Assert.assertNotNull(Scene.v().getTypeUnsafeUnescape("java.lang.annotation.Annotation"));
+
+        Assert.assertNull(Scene.v().getTypeUnsafe("java.lang.'annotation'.Annotation"));
+        Assert.assertNotNull(Scene.v().getTypeUnsafeUnescape("java.lang.'annotation'.Annotation"));
+
+        /* returnType maybe be null in SootMethodRefImpl's constructor, resulting in throwing IllegalArgumentException */
+        PackManager.v().runPacks();
     }
 }


### PR DESCRIPTION
In method soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder#addType, it calls Scene#getTypeUnsafe(String),
but the argument passed into the method Scene#getTypeUnsafe(String) may be <b>quoted</b>, just like: <br/>
<li>"sun.reflect.'annotation'.AnnotationType"</li> <br/>
<li>"java.lang.'annotation'.Annotation" </li> <br/>

Scene#getTypeUnsafe(String) will return null if the argument passed into is <b>quoted</b>, it will lead to Soot crashing with NullPointerException or IllegalArgumentException somewhere, just like the following 'test3' failing to pass the test with IllegalArgumentException

Here is a minimal test for evaluating the bug fixing.

<pre>
public class SootResolverTest {
    @Test
    public void test3() {
        G.reset();

        Options.v().set_whole_program(true);

        Scene.v().loadNecessaryClasses();

        /* returnType maybe be null in SootMethodRefImpl's constructor, resulting in throwing IllegalArgumentException */
        PackManager.v().runPacks();
    }
}
</pre>

Before fixing the bug, soot will crash with the messages:
<pre>
java.lang.IllegalArgumentException: Attempt to create SootMethodRef with null returnType

	at soot.SootMethodRefImpl.<init>(SootMethodRefImpl.java:86)
	at soot.Scene.makeMethodRef(Scene.java:1962)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.addType(OnFlyCallGraphBuilder.java:608)
	at soot.jimple.toolkits.callgraph.CallGraphBuilder.processReceivers(CallGraphBuilder.java:201)
	at soot.jimple.toolkits.callgraph.CallGraphBuilder.process(CallGraphBuilder.java:128)
	at soot.jimple.toolkits.callgraph.CallGraphBuilder.build(CallGraphBuilder.java:114)
	at soot.jimple.toolkits.callgraph.CHATransformer.internalTransform(CHATransformer.java:54)
	at soot.SceneTransformer.transform(SceneTransformer.java:36)
	at soot.Transform.apply(Transform.java:105)
	at soot.RadioScenePack.internalApply(RadioScenePack.java:64)
	at soot.jimple.toolkits.callgraph.CallGraphPack.internalApply(CallGraphPack.java:61)
	at soot.Pack.apply(Pack.java:118)
	at soot.PackManager.runWholeProgramPacks(PackManager.java:619)
	at soot.PackManager.runPacksNormally(PackManager.java:500)
	at soot.PackManager.runPacks(PackManager.java:425)
        ... ...
        ... ...
</pre>