### PR TITLE
avoid dead code insertion during insertOnEdge

### DIFF
--- a/src/main/java/soot/UnitPatchingChain.java
+++ b/src/main/java/soot/UnitPatchingChain.java
@@ -134,7 +134,7 @@ public class UnitPatchingChain extends PatchingChain<Unit> {
       innerChain.insertBefore(toInsert, point_tgt);
 
       if (originalPred != point_src) {
-        if (originalPred instanceof GotoStmt) {
+        if (!originalPred.fallsThrough()) {
           return;
         }
 


### PR DESCRIPTION
if originalPred does not fall through, but is not a gotoStmt, then dead code can be inserted. For example, if inserting on the edge (`point_src`, `point_tgt`) here:

```
    if [some condition] goto label1    // point_src
    throw exception                    // originalPred
label1:
    return                             // point_tgt
```

This can be generating using a function such as
```
class Example
{
    public void example(int x)
    {
        if(x == 0)
        {
            throw new IllegalArgumentException("x should not be zero!");
        }
        return;
    }
}
```