### PR TITLE
add step to upload javadoc and options to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           cp ./doc/soot_options.css ${docdir}/options
 
       - name: Deploy JavaDoc to GH pages
-          uses: JamesIves/github-pages-deploy-action@4.1.5
-          with:
-            branch: gh-pages # The branch the action should deploy to.
-            folder: build/docs/ # The folder the action should deploy.
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: build/docs/ # The folder the action should deploy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
           mkdir -p ${docdir}options
           cp ./doc/soot_options.htm ${docdir}/options
           cp ./doc/soot_options.css ${docdir}/options
+          cp ./doc/index.html ${docdir}/
+
 
       - name: Deploy JavaDoc to GH pages
         uses: JamesIves/github-pages-deploy-action@4.1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,4 +135,20 @@ jobs:
             mkdir -p ${basedir}/options
             cp ${file_prefix}-soot_options.htm ${basedir}/options
             rm ${file_prefix}-soot_options.htm
-      
+
+      - name: Organize documentation files for upload
+        shell: bash
+        env:
+          docdir: ./build/docs/{{ steps.version.outputs.version }}
+        run: |
+          mkdir -p ${docdir}/jdoc
+          unzip ./target/sootclasses-trunk-javadoc.jar -d ${docdir}/jdoc/
+          mkdir -p ${docdir}options
+          cp ./doc/soot_options.htm ${docdir}/options
+          cp ./doc/soot_options.css ${docdir}/options
+
+      - name: Deploy JavaDoc to GH pages
+          uses: JamesIves/github-pages-deploy-action@4.1.5
+          with:
+            branch: gh-pages # The branch the action should deploy to.
+            folder: build/docs/ # The folder the action should deploy.

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,19 @@
+<!-- Index.html file to dynamically list on github pages Soot's jdoc and options  for all versions  -->
+<!-- the index approach is adapted from https://stackoverflow.com/questions/39048654/how-to-enable-directory-indexing-on-github-pages -->
+<!-- content url https://api.github.com/repos/soot-oss/soot/contents/docs?ref=gh-pages -->
+<html>
+  <body>
+    <script>
+      (async () => {
+        const response = await fetch('https://api.github.com/repos/soot-oss/soot/contents/docs?ref=gh-pages');
+        const data = await response.json();
+        let htmlString = '<ul>';
+        for (let file of data) {
+          htmlString += `<li><a href="${file.path}">${file.name}</a></li>`;
+        }
+        htmlString += '</ul>';
+        document.getElementsByTagName('body')[0].innerHTML = htmlString;
+      })()
+    </script>
+  <body>
+</html>


### PR DESCRIPTION
I've created two additional GitHub actions steps to deploy Soot's JavaDoc and Options documentation in GH pages directly to get rid of the old soot-build server.

To do so, I've adapted the approach 
https://github.com/JamesIves/github-pages-deploy-action

However, I'm not an expert with GH Pages and GH actions, thus no guarantee. 😸 