### PR TITLE
full support for Deprecation annotation (Java 9+ and Android)

### DIFF
--- a/src/main/java/soot/tagkit/DeprecatedTag.java
+++ b/src/main/java/soot/tagkit/DeprecatedTag.java
@@ -24,12 +24,26 @@ package soot.tagkit;
 
 /**
  * Represents the deprecated attribute used by fields, methods and classes
+ * 
+ * The two attributes <code>forRemoval</code> and <code>since</code> can only occur in classes loaded from Android DEX code.
  */
 public class DeprecatedTag implements Tag {
 
   public static final String NAME = "DeprecatedTag";
 
+  private final Boolean forRemoval;
+
+  private final String since;
+
   public DeprecatedTag() {
+    forRemoval = null;
+    since = null;
+  }
+
+  public DeprecatedTag(Boolean forRemoval, String since) {
+    super();
+    this.forRemoval = forRemoval;
+    this.since = since;
   }
 
   @Override
@@ -44,6 +58,24 @@ public class DeprecatedTag implements Tag {
 
   public String getInfo() {
     return "Deprecated";
+  }
+
+  /**
+   * Only possible for Android DEX code
+   * 
+   * @return
+   */
+  public Boolean getForRemoval() {
+    return forRemoval;
+  }
+
+  /**
+   * Only possible for Android DEX code
+   * 
+   * @return
+   */
+  public String getSince() {
+    return since;
   }
 
   @Override

--- a/src/main/java/soot/tagkit/DeprecatedTag.java
+++ b/src/main/java/soot/tagkit/DeprecatedTag.java
@@ -25,7 +25,7 @@ package soot.tagkit;
 /**
  * Represents the deprecated attribute used by fields, methods and classes
  * 
- * The two attributes <code>forRemoval</code> and <code>since</code> can only occur in classes loaded from Android DEX code.
+ * The two attributes <code>forRemoval</code> and <code>since</code> were introduced with Java 9.
  */
 public class DeprecatedTag implements Tag {
 
@@ -60,20 +60,10 @@ public class DeprecatedTag implements Tag {
     return "Deprecated";
   }
 
-  /**
-   * Only possible for Android DEX code
-   * 
-   * @return
-   */
   public Boolean getForRemoval() {
     return forRemoval;
   }
 
-  /**
-   * Only possible for Android DEX code
-   * 
-   * @return
-   */
   public String getSince() {
     return since;
   }


### PR DESCRIPTION
The annotation class `java.lang.Deprecated` since Java 9 has two attributes `forRemoval` and `since` 
These attributes can also be present in Android DEX code (see attached example). 

* https://docs.oracle.com/javase/9/docs/api/java/lang/Deprecated.html
* https://developer.android.com/reference/java/lang/Deprecated
[classes11.apk.zip](https://github.com/soot-oss/soot/files/7618564/classes11.apk.zip)


