### PR TITLE
fix: missing support for fast types

### DIFF
--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeUtils.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeUtils.java
@@ -64,7 +64,15 @@ public class TypeUtils {
     if (type instanceof DoubleType) {
       return 64;
     }
-
+    if (type instanceof Integer127Type) {
+      return 7;
+    }
+    if (type instanceof Integer32767Type) {
+      return 15;
+    }
+    if (type instanceof Integer1Type) {
+      return 1;
+    }
     throw new IllegalArgumentException(type + " not supported.");
   }
 

--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeUtils.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeUtils.java
@@ -65,10 +65,10 @@ public class TypeUtils {
       return 64;
     }
     if (type instanceof Integer127Type) {
-      return 7;
+      return 8;
     }
     if (type instanceof Integer32767Type) {
-      return 15;
+      return 16;
     }
     if (type instanceof Integer1Type) {
       return 1;


### PR DESCRIPTION
The class `soot.jimple.toolkits.typing.fast.TypeUtils` misses support for the fast types 
* Integer127Type
* Integer32767Type
* Integer1Type added

Without this patch you can get the following exception:

```
java.lang.IllegalArgumentException: [0..127] not supported.
	at soot.jimple.toolkits.typing.fast.TypeUtils.getValueBitSize(TypeUtils.java:67)
	at soot.jimple.toolkits.typing.fast.UseChecker.merge(UseChecker.java:447)
	at soot.jimple.toolkits.typing.fast.UseChecker.caseAssignStmt(UseChecker.java:374)
	at soot.jimple.internal.JAssignStmt.apply(JAssignStmt.java:215)
	at soot.jimple.toolkits.typing.fast.UseChecker.check(UseChecker.java:138)
	at soot.jimple.toolkits.typing.fast.TypeResolver.insertCasts(TypeResolver.java:369)
	at soot.jimple.toolkits.typing.fast.TypeResolver.minCasts(TypeResolver.java:392)
	at soot.jimple.toolkits.typing.fast.TypeResolver.inferTypes(TypeResolver.java:159)
	at soot.jimple.toolkits.typing.TypeAssigner.internalTransform(TypeAssigner.java:129)
	at soot.BodyTransformer.transform(BodyTransformer.java:52)
	at soot.BodyTransformer.transform(BodyTransformer.java:56)
	at soot.dexpler.DexBody.jimplify(DexBody.java:769)
	at soot.dexpler.DexMethod$1.getBody(DexMethod.java:120)
	at soot.SootMethod.retrieveActiveBody(SootMethod.java:446)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.processNewMethod(OnFlyCallGraphBuilder.java:791)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.processReachables(OnFlyCallGraphBuilder.java:287)
	at soot.jimple.toolkits.callgraph.CallGraphBuilder.build(CallGraphBuilder.java:108)
	at soot.jimple.toolkits.callgraph.CHATransformer.internalTransform(CHATransformer.java:54)
	at soot.SceneTransformer.transform(SceneTransformer.java:36)
	at soot.Transform.apply(Transform.java:105)
	at soot.RadioScenePack.internalApply(RadioScenePack.java:64)
	at soot.jimple.toolkits.callgraph.CallGraphPack.internalApply(CallGraphPack.java:61)
	at soot.Pack.apply(Pack.java:118)
```

For the StackTrace you can see that the error occurs when I build the call graph: `PackManager.v().getPack("cg").apply();`

I am not sure if those non-Java-standard types are really supposed to appear here, there I don't know if this PR is just a work-around preventing the Exception (and the real problem is located somewhere else) of a real fix.

Binary: The same as attached to #1806