### PR TITLE
fix: NullPointerException in soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -882,13 +882,16 @@ public class OnFlyCallGraphBuilder {
       // addVirtualCallSite() may change receiverToSites, which may lead to a ConcurrentModificationException
       // I'm not entirely sure whether we ought to deal with the new call sites that are being added, instead of
       // just working on a snapshot, though.
-      List<VirtualCallSite> indirectSites = new ArrayList<>(receiverToSites.get(targetLocal));
-      for (final VirtualCallSite site : indirectSites) {
-        if (w.getTargetMethod().equals(site.subSig())) {
-          for (VirtualEdgeTarget siteTarget : w.getTargets()) {
-            Stmt siteStmt = site.getStmt();
-            if (siteStmt.containsInvokeExpr()) {
-              processVirtualEdgeSummary(callSiteMethod, callSite, siteStmt, receiver, siteTarget, edgeType);
+
+      List<VirtualCallSite> indirectSites = receiverToSites.get(targetLocal);
+      if (indirectSites != null) {
+        for (final VirtualCallSite site : new ArrayList<>(indirectSites)) {
+          if (w.getTargetMethod().equals(site.subSig())) {
+            for (VirtualEdgeTarget siteTarget : w.getTargets()) {
+              Stmt siteStmt = site.getStmt();
+              if (siteStmt.containsInvokeExpr()) {
+                processVirtualEdgeSummary(callSiteMethod, callSite, siteStmt, receiver, siteTarget, edgeType);
+              }
             }
           }
         }


### PR DESCRIPTION
The return value of `receiverToSites.get(targetLocal);` in the changed code section can be `null`.
If that happens this ends up in a `NullPointerException`, thus I added a check for `null`.

Not sure if this is a work-around of a fix. 

Stack trace of the exception to be fixed by this PR:

```
java.lang.NullPointerException: null
	at java.util.ArrayList.<init>(ArrayList.java:179)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.processVirtualEdgeSummary(OnFlyCallGraphBuilder.java:885)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.processVirtualEdgeSummary(OnFlyCallGraphBuilder.java:850)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.findReceivers(OnFlyCallGraphBuilder.java:811)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.processNewMethod(OnFlyCallGraphBuilder.java:793)
	at soot.jimple.toolkits.callgraph.OnFlyCallGraphBuilder.processReachables(OnFlyCallGraphBuilder.java:287)
	at soot.jimple.toolkits.callgraph.CallGraphBuilder.build(CallGraphBuilder.java:108)
	at soot.jimple.toolkits.callgraph.CHATransformer.internalTransform(CHATransformer.java:54)
	at soot.SceneTransformer.transform(SceneTransformer.java:36)
	at soot.Transform.apply(Transform.java:105)
	at soot.RadioScenePack.internalApply(RadioScenePack.java:64)
	at soot.jimple.toolkits.callgraph.CallGraphPack.internalApply(CallGraphPack.java:61)
	at soot.Pack.apply(Pack.java:118)
```

Observed while building the call graph of the binary attached to #1806