### PR TITLE
fix ClassCastException: class soot.RefType cannot be cast to class soot.ArrayType

### DIFF
--- a/src/main/java/soot/dexpler/DexTransformer.java
+++ b/src/main/java/soot/dexpler/DexTransformer.java
@@ -277,8 +277,11 @@ public abstract class DexTransformer extends BodyTransformer {
 
       } else if (baseDef instanceof IdentityStmt) {
         IdentityStmt stmt = (IdentityStmt) baseDef;
-        ArrayType at = (ArrayType) stmt.getRightOp().getType();
-        Type t = at.getArrayElementType();
+        Type t = stmt.getRightOp().getType();
+        if (t instanceof ArrayType) {
+          ArrayType at = (ArrayType) t;
+          t = at.getArrayElementType();
+        }
         if (depth == 0) {
           aType = t;
           break;


### PR DESCRIPTION
Happens for example when loading method bodies of Android app com.ingka.ikea.app_3.6.1 (6541)

```
java.lang.ClassCastException: class soot.RefType cannot be cast to class soot.ArrayType (soot.RefType and soot.ArrayType are in unnamed module of loader 'app')
	at soot.dexpler.DexTransformer.findArrayType(DexTransformer.java:280)
	at soot.dexpler.DexTransformer.findArrayType(DexTransformer.java:259)
	at soot.dexpler.DexTransformer.findArrayType(DexTransformer.java:259)
	at soot.dexpler.DexTransformer.findArrayType(DexTransformer.java:259)
	at soot.dexpler.DexNumTransformer$1.caseAssignStmt(DexNumTransformer.java:134)
	at soot.jimple.internal.JAssignStmt.apply(JAssignStmt.java:215)
	at soot.dexpler.DexNumTransformer.internalTransform(DexNumTransformer.java:115)
	at soot.BodyTransformer.transform(BodyTransformer.java:52)
	at soot.BodyTransformer.transform(BodyTransformer.java:56)
	at soot.dexpler.DexBody.jimplify(DexBody.java:739)
	at soot.dexpler.DexMethod$1.getBody(DexMethod.java:120)
	at soot.SootMethod.retrieveActiveBody(SootMethod.java:446)
```