### PR TITLE
fix AsmMethodSource assignReadOps(...)

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -573,14 +573,15 @@ public class AsmMethodSource implements MethodSource {
       if (opr == DWORD_DUMMY || opr.stack != null) {
         continue;
       }
-      if (l == null && opr.value instanceof Local) {
-        continue;
-      }
-      int op = opr.insn.getOpcode();
-      if (l == null && op != GETFIELD && op != GETSTATIC && (op < IALOAD || op > SALOAD)) {
-        continue;
-      }
-      if (l != null && !opr.value.equivTo(l)) {
+      if (l == null) {
+        if (opr.value instanceof Local) {
+          continue;
+        }
+        int op = opr.insn.getOpcode();
+        if (op != GETFIELD && op != GETSTATIC && (op < IALOAD || op > SALOAD)) {
+          continue;
+        }
+      } else if (!opr.value.equivTo(l)) {
         List<ValueBox> uses = opr.value.getUseBoxes();
         boolean noref = true;
         for (ValueBox use : uses) {

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -588,7 +588,7 @@ public class AsmMethodSource implements MethodSource {
         }
       }
       int op = opr.insn.getOpcode();
-      if (l == null && op != GETFIELD && op != GETSTATIC && (op < IALOAD && op > SALOAD)) {
+      if (l == null && op != GETFIELD && op != GETSTATIC && (op < IALOAD || op > SALOAD)) {
         continue;
       }
       Local stack = newStackLocal();

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -570,7 +570,14 @@ public class AsmMethodSource implements MethodSource {
       return;
     }
     for (Operand opr : stack) {
-      if (opr == DWORD_DUMMY || opr.stack != null || (l == null && opr.value instanceof Local)) {
+      if (opr == DWORD_DUMMY || opr.stack != null) {
+        continue;
+      }
+      if (l == null && opr.value instanceof Local) {
+        continue;
+      }
+      int op = opr.insn.getOpcode();
+      if (l == null && op != GETFIELD && op != GETSTATIC && (op < IALOAD || op > SALOAD)) {
         continue;
       }
       if (l != null && !opr.value.equivTo(l)) {
@@ -586,10 +593,6 @@ public class AsmMethodSource implements MethodSource {
         if (noref) {
           continue;
         }
-      }
-      int op = opr.insn.getOpcode();
-      if (l == null && op != GETFIELD && op != GETSTATIC && (op < IALOAD || op > SALOAD)) {
-        continue;
       }
       Local stack = newStackLocal();
       opr.stack = stack;

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -566,9 +566,6 @@ public class AsmMethodSource implements MethodSource {
   }
 
   private void assignReadOps(Local l) {
-    if (stack.isEmpty()) {
-      return;
-    }
     for (Operand opr : stack) {
       if (opr == DWORD_DUMMY || opr.stack != null) {
         continue;


### PR DESCRIPTION
There is a if condition in `assignReadOps(Local l)` which is a contradiction and therefore always renders to false.
The intention seems to filter for Operands that resemble a (static) field read or an array load - if it is not the case the method is skipping the assignment of the `Operand` to a `Local`.
As the if statement currently always renders to false (i.e. no skips for that check) there have been (possibly) more `Local` assignments than necessary (and/or just a obsolete/useless check).

Additionally I restructured the if-stmts to avoid redundant condition evaluations.