### PR TITLE
Update Scene.java

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -1758,6 +1758,8 @@ public class Scene {
             classNames.add(source.substring(0, source.lastIndexOf('.')));
             switch (kind) {
               case "Class.forName":
+              case "Class.getFields":
+              case "Class.getMethods":  
                 classNames.add(target);
                 break;
               case "Class.newInstance":
@@ -1765,11 +1767,33 @@ public class Scene {
                 break;
               case "Method.invoke":
               case "Constructor.newInstance":
+              case "Method.toString":
+              case "Class.getDeclaredField":
+              case "Class.getDeclaredMethod":
+              case "Class.getMethod":
+              case "Class.getField":
+              case "Constructor.getModifiers":
+              case "Field.getModifiers":
+              case "Method.getModifiers":
+              case "Method.getName":
+              case "Method.getDeclaringClass":  
                 classNames.add(signatureToClass(target));
+                break;
+              case "Class.getDeclaredFields":
+              case "Class.getDeclaredMethods":
+                if (!target.startsWith("[")) {
+                  classNames.add(target);
+                }
                 break;
               case "Field.set*":
               case "Field.get*":
+              case "Field.toString":
+              case "Field.getName":
+              case "Field.getDeclaringClass":
                 classNames.add(signatureToClass(target));
+                break;
+              case "Array.newInstance":
+                // not do anything
                 break;
               default:
                 throw new RuntimeException("Unknown entry kind: " + kind);


### PR DESCRIPTION
Tamiflex log contains more kinds of reflections. It needs to support all of them rather than throwing a runtime exception for them.