### PR TITLE
RefType added for getValueBitSize

### DIFF
--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeUtils.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeUtils.java
@@ -30,6 +30,7 @@ import soot.DoubleType;
 import soot.FloatType;
 import soot.IntType;
 import soot.LongType;
+import soot.RefType;
 import soot.ShortType;
 import soot.Type;
 
@@ -72,6 +73,9 @@ public class TypeUtils {
     }
     if (type instanceof Integer1Type) {
       return 1;
+    }
+    if (type instanceof RefType) {
+      return 64; // not valid for 32 bit Java VMs, but I don't see a different way to handle this in a static analysis
     }
     throw new IllegalArgumentException(type + " not supported.");
   }


### PR DESCRIPTION
Another type is missing in TypeUtils.getValueBitSize

This time it is `RefType` that I assinged to 64bit even though in a 32bit VM it has to my knowledge only 32bits, but I don't see a way to handle this different in a static analysis. 

App de.prosiebensat1digital.seventv_5.36.3-AOS-536309041 base apk
SHA-1: E5D6F346D240EEFC845E2774257DDFD073D4E62E

While parsing body of <de.prosiebensat1digital.oasisjsbridge.PayloadObject: boolean exists(java.lang.Object[])> without this PR you get an IllegalArgumentException.

A stripped down version is attached to this issue:
[de.prosiebensat1digital.seventv_5.36.3-AOS-536309041 - stripped.apk.zip](https://github.com/soot-oss/soot/files/8153531/de.prosiebensat1digital.seventv_5.36.3-AOS-536309041.-.stripped.apk.zip)

