### PR TITLE
Fix: null check

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -228,11 +228,13 @@ public class CallGraph implements Iterable<Edge> {
    */
   public Edge findEdge(Unit u, SootMethod callee) {
     Edge e = srcUnitToEdge.get(u);
-    while (e.srcUnit() == u && e.kind() != Kind.INVALID) {
-      if (e.tgt() == callee) {
-        return e;
-      }
-      e = e.nextByUnit();
+    if (e != null) {
+        while (e.srcUnit() == u && e.kind() != Kind.INVALID) {
+            if (e.tgt() == callee) {
+                return e;
+            }
+            e = e.nextByUnit();
+        }
     }
     return null;
   }

--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -229,12 +229,12 @@ public class CallGraph implements Iterable<Edge> {
   public Edge findEdge(Unit u, SootMethod callee) {
     Edge e = srcUnitToEdge.get(u);
     if (e != null) {
-        while (e.srcUnit() == u && e.kind() != Kind.INVALID) {
-            if (e.tgt() == callee) {
-                return e;
-            }
-            e = e.nextByUnit();
+      while (e.srcUnit() == u && e.kind() != Kind.INVALID) {
+        if (e.tgt() == callee) {
+          return e;
         }
+        e = e.nextByUnit();
+      }
     }
     return null;
   }


### PR DESCRIPTION
Null check makes sense here since one could use `findEdge` to search an edge that does not exist --> therefore a `NullPointerException` occurs.