### PR TITLE
Unpack units from unit containers

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -2373,10 +2373,16 @@ public class AsmMethodSource implements MethodSource {
               for (AbstractInsnNode i = lvn.start.getPrevious(); (uStart = units.get(i)) == null;) {
                 i = i.getNext();
               }
+              if (uStart instanceof UnitContainer) {
+                uStart = ((UnitContainer) uStart).getFirstUnit();
+              }
               // Get the previous real instruction before 'end'
               Unit uEnd;
               for (AbstractInsnNode i = lvn.end.getPrevious(); (uEnd = units.get(i)) == null;) {
                 i = i.getPrevious();
+              }
+              if (uEnd instanceof UnitContainer) {
+                uEnd = ((UnitContainer) uEnd).getFirstUnit();
               }
               if (newLocals == null) {
                 newLocals = HashBasedTable.create(this.maxLocals, 1);


### PR DESCRIPTION
When running Soot with the following command line…
```
java -cp <myclasspath> soot.Main -v -w -keep-line-number -process-dir <my.jar> -cp <my.jar> -pp -allow-phantom-refs -p jb use-original-names:true
```

… we are getting the following exception.
```
Soot started on Wed Jun 01 16:06:44 UTC 2022
java.util.NoSuchElementException: HashChain.LinkIterator.next() reached end of chain without reaching specified tail unit
        at soot.util.HashChain$LinkIterator.next(HashChain.java:609)
        at soot.PatchingChain$PatchingIterator.next(PatchingChain.java:325)
        at soot.PatchingChain$PatchingIterator.next(PatchingChain.java:296)
        at soot.asm.AsmMethodSource.tryCorrectingLocalNames(AsmMethodSource.java:2391)
        at soot.asm.AsmMethodSource.getBody(AsmMethodSource.java:2259)
        at soot.SootMethod.retrieveActiveBody(SootMethod.java:446)
        at soot.jimple.toolkits.annotation.LineNumberAdder.internalTransform(LineNumberAdder.java:61)
        at soot.PackManager.runPacksNormally(PackManager.java:496)
        at soot.PackManager.runPacks(PackManager.java:425)
        at soot.Main.run(Main.java:280)
        at soot.Main.main(Main.java:142)
```

Unfortunately I am unable to share the source or byte code. But this PR fixes the issue.