### PR TITLE
Include concrete methods of abstract classes in PAG construction

### DIFF
--- a/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
+++ b/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
@@ -104,7 +104,7 @@ public class ContextInsensitiveBuilder {
     }
     while (callEdges.hasNext()) {
       Edge e = callEdges.next();
-      if (!e.isInvalid() && e.getTgt().method().getDeclaringClass().isConcrete()) {
+      if (!e.isInvalid()) {
         if (e.tgt().isConcrete() || e.tgt().isNative()) {
           MethodPAG.v(pag, e.tgt()).addToPAG(null);
         }
@@ -123,7 +123,7 @@ public class ContextInsensitiveBuilder {
   /* End of package methods. */
   protected void handleClass(SootClass c) {
     boolean incedClasses = false;
-    if (c.isConcrete()) {
+    if (c.isConcrete() || Scene.v().getFastHierarchy().getSubclassesOf(c).stream().anyMatch(SootClass::isConcrete)) {
       for (SootMethod m : c.getMethods()) {
         if (!m.isConcrete() && !m.isNative()) {
           continue;

--- a/src/systemTest/java/soot/jimple/toolkit/callgraph/VtaCallGraphBaseClassTest.java
+++ b/src/systemTest/java/soot/jimple/toolkit/callgraph/VtaCallGraphBaseClassTest.java
@@ -1,0 +1,104 @@
+package soot.jimple.toolkit.callgraph;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2021 Qidan He
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
+import soot.PhaseOptions;
+import soot.Scene;
+import soot.SootMethod;
+import soot.Unit;
+import soot.jimple.toolkits.callgraph.Edge;
+import soot.testing.framework.AbstractTestingFramework;
+
+
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
+public class VtaCallGraphBaseClassTest {
+    private static final String PACKAGE = "soot.jimple.toolkit.callgraph";
+    private static final String FOO = String.format("<%s.BaseClassFooCallsBar: void foo()>", PACKAGE);
+    private static final String BAR = String.format("<%s.BaseClassFooCallsBar: void bar()>", PACKAGE);
+    private static final String MAIN = String.format("<%s.EntryPointCallsSubClassFoo: void main()>", PACKAGE);
+    private static final String CLASSES_OR_PACKAGE_TO_ANALYZE = String.format("%s.*", PACKAGE);
+    private static final String TARGET_METHOD_SIGNATURE = MAIN;
+
+    private static class TestingFramework extends AbstractTestingFramework {
+        private final boolean vta;
+
+        private TestingFramework(final boolean vta) {
+            this.vta = vta;
+        }
+
+        @Override
+        protected void setupSoot() {
+            super.setupSoot();
+            PhaseOptions.v().setPhaseOption("cg.spark", String.format("vta:%s", vta));
+        }
+
+        private void run() {
+            prepareTarget(TARGET_METHOD_SIGNATURE, CLASSES_OR_PACKAGE_TO_ANALYZE);
+        }
+    }
+
+    private Unit callSite(final SootMethod caller, final SootMethod callee) {
+        final String calleeSignature = callee.getSignature();
+        return caller.getActiveBody().getUnits().stream()
+                .filter(unit -> unit.toString().contains(calleeSignature))
+                .findFirst()
+                .get();
+    }
+
+    private List<SootMethod> callTargets(final Unit unit) {
+        final Iterable<Edge> iterable = () -> Scene.v().getCallGraph().edgesOutOf(unit);
+        return StreamSupport.stream(iterable.spliterator(), false)
+                .map(Edge::tgt)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void callTargetsWithoutVta() {
+        new TestingFramework(false).run();
+        final SootMethod main = Scene.v().getMethod(MAIN);
+        final SootMethod foo = Scene.v().getMethod(FOO);
+        final SootMethod bar = Scene.v().getMethod(BAR);
+        assertEquals("expected target foo", Collections.singletonList(foo), callTargets(callSite(main, foo)));
+        assertEquals("expected target bar", Collections.singletonList(bar), callTargets(callSite(foo, bar)));
+    }
+
+    @Test
+    public void callTargetsWithVta() {
+        new TestingFramework(true).run();
+        final SootMethod main = Scene.v().getMethod(MAIN);
+        final SootMethod foo = Scene.v().getMethod(FOO);
+        final SootMethod bar = Scene.v().getMethod(BAR);
+        assertEquals("expected target foo", Collections.singletonList(foo), callTargets(callSite(main, foo)));
+        assertEquals("expected target bar", Collections.singletonList(bar), callTargets(callSite(foo, bar)));
+    }
+}

--- a/src/systemTest/targets/soot/jimple/toolkit/callgraph/BaseClassFooCallsBar.java
+++ b/src/systemTest/targets/soot/jimple/toolkit/callgraph/BaseClassFooCallsBar.java
@@ -1,0 +1,33 @@
+package soot.jimple.toolkit.callgraph;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2018 John Toman
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+public abstract class BaseClassFooCallsBar {
+    public void foo() {
+        bar();
+    }
+
+    public void bar() { }
+
+    public abstract void baz();
+}

--- a/src/systemTest/targets/soot/jimple/toolkit/callgraph/EntryPointCallsSubClassFoo.java
+++ b/src/systemTest/targets/soot/jimple/toolkit/callgraph/EntryPointCallsSubClassFoo.java
@@ -1,0 +1,30 @@
+package soot.jimple.toolkit.callgraph;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2018 John Toman
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+public class EntryPointCallsSubClassFoo {
+    public void main() {
+        final BaseClassFooCallsBar baseClassFooCallsBar = new SubClassImplementsBaz();
+        baseClassFooCallsBar.foo();
+    }
+}

--- a/src/systemTest/targets/soot/jimple/toolkit/callgraph/SubClassImplementsBaz.java
+++ b/src/systemTest/targets/soot/jimple/toolkit/callgraph/SubClassImplementsBaz.java
@@ -1,0 +1,28 @@
+package soot.jimple.toolkit.callgraph;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2018 John Toman
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+public class SubClassImplementsBaz extends BaseClassFooCallsBar {
+    @Override
+    public void baz() { }
+}


### PR DESCRIPTION
This PR adds a test witnessing Issue #1901 in VTA call graph construction: call sites in the methods of abstract base classes have empty targets. This PR also builds pointer-assignment graphs (PAGs) for (concrete) methods of abstract classes to resolve Issue #1901.