### PR TITLE
Making sure MethodPAG is initialized before calling addToPAG.

### DIFF
--- a/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
+++ b/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
@@ -106,7 +106,9 @@ public class ContextInsensitiveBuilder {
       Edge e = callEdges.next();
       if (!e.isInvalid()) {
         if (e.tgt().isConcrete() || e.tgt().isNative()) {
-          MethodPAG.v(pag, e.tgt()).addToPAG(null);
+	  MethodPAG mpag = MethodPAG.v(pag, e.tgt());
+	  mpag.build();
+	  mpag.addToPAG(null);
         }
         pag.addCallTarget(e);
       }


### PR DESCRIPTION
This commit fixes a RuntimeException due to calling `addToPAG` before building the `MethodPAG`. 