### PR TITLE
Fix reading names of parameters from .dex

### DIFF
--- a/src/main/java/soot/dexpler/DexAnnotation.java
+++ b/src/main/java/soot/dexpler/DexAnnotation.java
@@ -335,7 +335,9 @@ public class DexAnnotation {
     for (MethodParameter p : method.getParameters()) {
       String name = p.getName();
       if (name != null) {
-        parameterNames = new String[method.getParameters().size()];
+        if (parameterNames == null) {
+          parameterNames = new String[method.getParameters().size()];
+        }
         parameterNames[i] = name;
       }
       i++;


### PR DESCRIPTION
Previously `parameterNames` array was recreated on every iteration, leaving only last parameter name set