### PR TITLE
Increase maximum path cache capacity

### DIFF
--- a/src/main/java/soot/SourceLocator.java
+++ b/src/main/java/soot/SourceLocator.java
@@ -95,7 +95,7 @@ public class SourceLocator {
   // size must be able to contain all paths in the classpath or else
   // methods such as lookupInClassPath(..) that search for a file by
   // traversing each path in the classpath will cause cache thrashing.
-  private static final int PATH_CACHE_CAPACITY = 1000;
+  private static final int PATH_CACHE_CAPACITY = 100000;
 
   final SharedZipFileCacheWrapper archivePathToZip = new SharedZipFileCacheWrapper(5, PATH_CACHE_CAPACITY);
 


### PR DESCRIPTION
Class loading takes an extraordinarily long time due to cache thrashing for large class paths (100s-1000s of elements). See attached graph:

<img width="578" alt="Screen Shot 2022-10-06 at 10 54 08 AM" src="https://user-images.githubusercontent.com/1457498/194375696-94a7d275-40ba-4817-b724-56d3d2715f8a.png">

Increasing this limit greatly reduces cache loading time.