### PR TITLE
Avoid adding duplicate interfaces in Lambda Meta Factory

### DIFF
--- a/src/main/java/soot/LambdaMetaFactory.java
+++ b/src/main/java/soot/LambdaMetaFactory.java
@@ -181,9 +181,12 @@ public class LambdaMetaFactory {
       tclass.addInterface(RefType.v("java.io.Serializable").getSootClass());
     }
     for (int i = 0; i < markerInterfaces.size(); i++) {
-      tclass.addInterface(
-          ((RefType) AsmUtil.toBaseType(markerInterfaces.get(i).getValue(), Optional.fromNullable(tclass.moduleName)))
-              .getSootClass());
+      String internal = markerInterfaces.get(i).getValue();
+      RefType refType = ((RefType) AsmUtil.toBaseType(internal, Optional.fromNullable(tclass.moduleName)));
+      SootClass interfaceClass = refType.getSootClass();
+      if (!interfaceClass.equals(functionalInterfaceToImplement)) {
+        tclass.addInterface(interfaceClass);
+      }
     }
 
     // It contains fields for all the captures in the lambda
@@ -241,7 +244,7 @@ public class LambdaMetaFactory {
 
   /**
    * Invalidates the class hierarchy due to some newly added class.
-   * 
+   *
    * @param tclass
    */
   protected void addClassAndInvalidateHierarchy(SootClass tclass) {


### PR DESCRIPTION
This PR avoids adding the same interface twice when constructing artificial classes in the lambda meta factory. In particular, if a given marker interface is already accounted for as the “functional interface to implement”, we avoid re-adding that interface. This avoids a “duplicate interface on class” exception in SootClass::addInterface.