### PR TITLE
Ensuring Soot can handle jars with ':' in the name

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -362,6 +362,9 @@ public class Scene {
         StringBuilder pds = new StringBuilder();
         for (String path : dirs) {
           if (!cp.contains(path)) {
+            // To support paths to jars with ':' in the name, escape the path separator if it was not already escaped.
+            path = path.replaceAll("(?<!\\\\)" + Pattern.quote(File.pathSeparator),
+              "\\\\" + File.pathSeparator);
             pds.append(path).append(File.pathSeparatorChar);
           }
         }

--- a/src/main/java/soot/SourceLocator.java
+++ b/src/main/java/soot/SourceLocator.java
@@ -189,6 +189,7 @@ public class SourceLocator {
     for (String originalDir : classPath.split(regex)) {
       if (!originalDir.isEmpty()) {
         try {
+          originalDir = originalDir.replaceAll("\\\\" + Pattern.quote(File.pathSeparator), File.pathSeparator);
           String canonicalDir = new File(originalDir).getCanonicalPath();
           if (ModulePathSourceLocator.DUMMY_CLASSPATH_JDK9_FS.equals(originalDir)) {
             SourceLocator.v().java9Mode = true;


### PR DESCRIPTION
…ors with the path separator. Making sure to escape ':' when appending process_dir to classpath.

This avoids a file not found exception and allows specifying jars with ':' in the name.