### PR TITLE
added virtual edge to AsyncTask.onCancelled(java.lang.Object)

### DIFF
--- a/src/main/resources/virtualedges.xml
+++ b/src/main/resources/virtualedges.xml
@@ -124,6 +124,7 @@
             <direct subsignature="void onPreExecute()" target-position="base"/>
             <direct subsignature="void onProgressUpdate(java.lang.Object[])" target-position="base"/>
             <direct subsignature="void onPostExecute(java.lang.Object)" target-position="base"/>
+            <direct subsignature="void onCancelled(java.lang.Object)" target-position="base"/>
         </targets>
     </edge>
 	<!-- doPrivileged -->


### PR DESCRIPTION
The virtual edges for `android.os.AsyncTask` methods `onPreExecute()` `onProgressUpdate(java.lang.Object[])` and `onPostExecute(java.lang.Object)` were already defined, but `onCancelled(java.lang.Object)` is missing.

As we already include `onProgressUpdate` without a check if `publishProgress` is ever called we should also add a virtual edge for `onCancelled` (without checking if `cancel(boolean) ` is ever called on the task.

The method signature has been verified in a practical test.