### PR TITLE
Fix race on declaringClass of SootField between creation and getFieldUnsafe

### DIFF
--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -266,9 +266,9 @@ public class SootClass extends AbstractHost implements Numberable {
     if (fields == null) {
       fields = new HashChain<>();
     }
-    fields.add(f);
     f.setDeclared(true);
     f.setDeclaringClass(this);
+    fields.add(f);
   }
 
   /**
@@ -726,9 +726,9 @@ public class SootClass extends AbstractHost implements Numberable {
       this.fields = new HashChain<>();
     }
 
-    this.fields.add(f);
     f.setDeclared(true);
     f.setDeclaringClass(this);
+    this.fields.add(f);
     return f;
   }
 


### PR DESCRIPTION
StubDroid's subLinkedListTest triggered a race between the lazy creation of a field from a signature string and the retrieval of the field, resulting in getDeclaringClass unexpectedly returning null.