### PR TITLE
Fix soot-oss/soot#1936

### DIFF
--- a/src/main/java/soot/FastHierarchy.java
+++ b/src/main/java/soot/FastHierarchy.java
@@ -859,10 +859,11 @@ public class FastHierarchy {
 
     // When there is no proper dispatch found, we simply return null to let the caller decide what to do
     SootMethod candidate = null;
+    boolean calleeExist = declaringClass.getMethodUnsafe(subsignature) != null;
     for (SootClass concreteType = baseType; concreteType != null && ignoreList.add(concreteType);) {
       candidate = getSignaturePolymorphicMethod(concreteType, name, parameterTypes, returnType);
       if (candidate != null) {
-        if (isVisible(declaringClass, concreteType, candidate.getModifiers())) {
+        if (!calleeExist || isVisible(concreteType, declaringClass, candidate.getModifiers())) {
           if (!allowAbstract && candidate.isAbstract()) {
             candidate = null;
             break;


### PR DESCRIPTION
Remove the visibility check when the callee does not exist. Also swap the arguments of the isVisible invoke.