### PR TITLE
Fix a bug in getFirstNonIdentityStmt which may return an identity stmt

### DIFF
--- a/src/main/java/soot/jimple/JimpleBody.java
+++ b/src/main/java/soot/jimple/JimpleBody.java
@@ -194,16 +194,11 @@ public class JimpleBody extends StmtBody {
    * @return
    */
   public Stmt getFirstNonIdentityStmt() {
-    Unit r = null;
     for (Unit u : getUnits()) {
-      r = u;
-      if (!(r instanceof IdentityStmt)) {
-        break;
+      if (!(u instanceof IdentityStmt)) {
+        return (Stmt) u;
       }
     }
-    if (r == null) {
-      throw new RuntimeException("no non-id statements!");
-    }
-    return (Stmt) r;
+    throw new RuntimeException("no non-id statements!");
   }
 }


### PR DESCRIPTION
If there are only identity statements, the method's implementation happily returned an identity statement, causing all kinds of funny behavior.