### PR TITLE
Returning view of method list to avoid CME

### DIFF
--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -1316,7 +1316,7 @@ public class SootClass extends AbstractHost implements Numberable {
    */
   public Collection<SootMethod> getMethodsByNameAndParamCount(String name, int paramCount) {
     List<SootMethod> result = null;
-    for (SootMethod m : getMethods()) {
+    for (SootMethod m : new ArrayList<>(getMethods())) {
       if (m.getParameterCount() == paramCount && m.getName().equals(name)) {
         if (result == null) {
           result = new ArrayList<>();


### PR DESCRIPTION
The modified method `getMethodsByNameAndParamCount` is used (and only used) in the `FastHierarchy.getSignaturePolymorphicMethod` for resolving polymorphic methods. The for-loop will return the method list's iterator, but the list itself can be modified by another body pack transform thread, causing a `ConcurrentModificationException`. The patch fix the issue by returning a copy of this list.

This patch also fixes the issue #1811 , and a similar issue is #1199 (fixed by #1886 ).