### PR TITLE
Fixes Concurrent Modification Exception

### DIFF
--- a/src/main/java/soot/dava/toolkits/base/finders/ExceptionNode.java
+++ b/src/main/java/soot/dava/toolkits/base/finders/ExceptionNode.java
@@ -190,7 +190,7 @@ public class ExceptionNode {
       as.remove_CSucc(newCatchTarget);
       newCatchTarget.remove_CPred(as);
     }
-
+    IterableSet<ExceptionNode> toAdd = new IterableSet<ExceptionNode>();
     for (ExceptionNode en : enlist) {
       if (this == en) {
         continue;
@@ -204,10 +204,10 @@ public class ExceptionNode {
           clonedTryBody.add(asg.get_CloneOf(au));
         }
 
-        enlist.addLast(new ExceptionNode(clonedTryBody, en.exception, asg.get_CloneOf(en.handlerAugmentedStmt)));
+        toAdd.addLast(new ExceptionNode(clonedTryBody, en.exception, asg.get_CloneOf(en.handlerAugmentedStmt)));
       }
     }
-
+    enlist.addAll(toAdd);
     enlist.addLast(new ExceptionNode(newTryBody, exception, asg.get_CloneOf(handlerAugmentedStmt)));
 
     for (ExceptionNode en : enlist) {


### PR DESCRIPTION
Hello,

I had some problems with a Concurrent Modification Exception in the ExceptionNode Class:

Exception in thread "Thread-16" java.util.ConcurrentModificationException
	at soot.util.HashChain$LinkIterator.hasNext(HashChain.java:582)
	at soot.dava.toolkits.base.finders.ExceptionNode.splitOff_ExceptionNode(ExceptionNode.java:194)
	at soot.dava.internal.SET.SETTryNode.resolve(SETTryNode.java:188)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:301)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.toolkits.base.finders.ExceptionFinder.find(ExceptionFinder.java:70)
	at soot.dava.DavaBody.<init>(DavaBody.java:334)
	at soot.dava.Dava.newBody(Dava.java:87)
	at soot.PackManager.runBodyPacks(PackManager.java:1028)
	at soot.PackManager.lambda$runBodyPacks$0(PackManager.java:667)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
java.util.ConcurrentModificationException
	at soot.util.HashChain$LinkIterator.hasNext(HashChain.java:582)
	at soot.dava.toolkits.base.finders.ExceptionNode.splitOff_ExceptionNode(ExceptionNode.java:194)
	at soot.dava.internal.SET.SETTryNode.resolve(SETTryNode.java:188)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:301)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.internal.SET.SETNode.nest(SETNode.java:323)
	at soot.dava.toolkits.base.finders.ExceptionFinder.find(ExceptionFinder.java:70)
	at soot.dava.DavaBody.<init>(DavaBody.java:334)
	at soot.dava.Dava.newBody(Dava.java:87)
	at soot.PackManager.runBodyPacks(PackManager.java:1028)
	at soot.PackManager.lambda$runBodyPacks$0(PackManager.java:667)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)

Easily fixed by adding the elements to the list after the iteration.

Best,
Paul