### PR TITLE
Avoid concurrent modification exception

### DIFF
--- a/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
+++ b/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
@@ -99,7 +99,7 @@ public class ContextInsensitiveBuilder {
       cgb.build();
       reachables = cgb.reachables();
     }
-    for (final SootClass c : Scene.v().getClasses()) {
+    for (final SootClass c : new ArrayList<>(Scene.v().getClasses())) {
       handleClass(c);
     }
     while (callEdges.hasNext()) {


### PR DESCRIPTION
This change avoids a concurrent modification exception on the hash chain of in-scene classes during call graph construction by using the iterator of an array-list copy.