### PR TITLE
Added support for ILSpy8 instructions

### DIFF
--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -14,6 +14,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1726,9 +1727,9 @@ public class Scene {
   }
 
   private void addSootBasicDotnetClasses() {
-    basicclasses[SootClass.HIERARCHY] = new HashSet<>();
-    basicclasses[SootClass.SIGNATURES] = new HashSet<>();
-    basicclasses[SootClass.BODIES] = new HashSet<>();
+    basicclasses[SootClass.HIERARCHY] = new LinkedHashSet<>();
+    basicclasses[SootClass.SIGNATURES] = new LinkedHashSet<>();
+    basicclasses[SootClass.BODIES] = new LinkedHashSet<>();
 
     addBasicClass(DotnetBasicTypes.SYSTEM_OBJECT, SootClass.SIGNATURES);
     addBasicClass(DotnetBasicTypes.SYSTEM_VOID, SootClass.SIGNATURES);

--- a/src/main/java/soot/dotnet/instructions/CilBinaryNumericInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilBinaryNumericInstruction.java
@@ -70,9 +70,9 @@ public class CilBinaryNumericInstruction extends AbstractCilnstruction {
   @Override
   public Value jimplifyExpr(Body jb) {
     Value left = CilInstructionFactory.fromInstructionMsg(instruction.getLeft(), dotnetBody, cilBlock).jimplifyExpr(jb);
-    left = inlineCastExpr(left);
+    left = dotnetBody.variableManager.simplifyIfNotPrimitiveWithLocal((inlineCastExpr(left))); 
     Value right = CilInstructionFactory.fromInstructionMsg(instruction.getRight(), dotnetBody, cilBlock).jimplifyExpr(jb);
-    right = inlineCastExpr(right);
+    right = dotnetBody.variableManager.simplifyIfNotPrimitiveWithLocal((inlineCastExpr(right)));
     switch (instruction.getOperator()) {
       case Add:
         return Jimple.v().newAddExpr(left, right);

--- a/src/main/java/soot/dotnet/instructions/CilCastClassUnBoxInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilCastClassUnBoxInstruction.java
@@ -50,6 +50,7 @@ public class CilCastClassUnBoxInstruction extends AbstractCilnstruction {
     Type type = DotnetTypeFactory.toSootType(instruction.getType());
     CilInstruction cilExpr = CilInstructionFactory.fromInstructionMsg(instruction.getArgument(), dotnetBody, cilBlock);
     Value argument = cilExpr.jimplifyExpr(jb);
-    return Jimple.v().newCastExpr(argument, type);
+
+    return Jimple.v().newCastExpr(dotnetBody.variableManager.simplifyIfNotPrimitiveWithLocal(argument), type);
   }
 }

--- a/src/main/java/soot/dotnet/instructions/CilConvInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilConvInstruction.java
@@ -92,7 +92,6 @@ public class CilConvInstruction extends AbstractCilnstruction {
         convType = UnknownType.v();
         break;
     }
-
-    return Jimple.v().newCastExpr(argument, convType);
+    return Jimple.v().newCastExpr(dotnetBody.variableManager.simplifyIfNotPrimitiveWithLocal(argument), convType);
   }
 }

--- a/src/main/java/soot/dotnet/instructions/CilLdElemaInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilLdElemaInstruction.java
@@ -68,7 +68,7 @@ public class CilLdElemaInstruction extends AbstractCilnstruction {
   public Value jimplifyExpr(Body jb) {
     CilInstruction cilExpr = CilInstructionFactory.fromInstructionMsg(instruction.getArray(), dotnetBody, cilBlock);
     baseArrayLocal = cilExpr.jimplifyExpr(jb);
-
+    baseArrayLocal = dotnetBody.variableManager.simplifyIfNotPrimitiveWithLocal(baseArrayLocal);
     if (instruction.getIndicesCount() == 1) {
       Value ind
           = CilInstructionFactory.fromInstructionMsg(instruction.getIndices(0), dotnetBody, cilBlock).jimplifyExpr(jb);

--- a/src/main/java/soot/dotnet/instructions/CilNewArrInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilNewArrInstruction.java
@@ -57,6 +57,7 @@ public class CilNewArrInstruction extends AbstractCilnstruction {
     for (ProtoIlInstructions.IlInstructionMsg index : instruction.getIndicesList()) {
       CilInstruction cilExpr = CilInstructionFactory.fromInstructionMsg(index, dotnetBody, cilBlock);
       Value value = cilExpr.jimplifyExpr(jb);
+      value = dotnetBody.variableManager.simplifyIfNotPrimitiveWithLocal((value));
       Value val = value instanceof Immediate ? value : DotnetBodyVariableManager.inlineLocals(value, jb);
       sizesOfArr.add(val);
     }

--- a/src/main/java/soot/dotnet/instructions/CilStLocInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilStLocInstruction.java
@@ -1,7 +1,5 @@
 package soot.dotnet.instructions;
 
-import java.util.List;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -68,13 +66,10 @@ public class CilStLocInstruction extends AbstractCilnstruction {
 
     // cast for validation
     if (cilExpr instanceof CilCallVirtInstruction) {
-      List<Pair<Local, Local>> locals = ((CilCallVirtInstruction) cilExpr).getLocalsToCastForCall();
-      if (locals.size() != 0) {
-        for (Pair<Local, Local> pair : locals) {
-          CastExpr castExpr = Jimple.v().newCastExpr(pair.getO1(), pair.getO2().getType());
-          AssignStmt assignStmt = Jimple.v().newAssignStmt(pair.getO2(), castExpr);
-          jb.getUnits().add(assignStmt);
-        }
+      for (Pair<Value, Value> pair : ((CilCallVirtInstruction) cilExpr).getPrimitivesToCastForCall()) {
+        CastExpr castExpr = Jimple.v().newCastExpr(pair.getO1(), pair.getO2().getType());
+        AssignStmt assignStmt = Jimple.v().newAssignStmt(pair.getO2(), castExpr);
+        jb.getUnits().add(assignStmt);
       }
     }
     // create this cast, to validate successfully

--- a/src/main/java/soot/dotnet/members/DotnetField.java
+++ b/src/main/java/soot/dotnet/members/DotnetField.java
@@ -2,6 +2,8 @@ package soot.dotnet.members;
 
 import static soot.dotnet.specifications.DotnetModifier.toSootModifier;
 
+import soot.Scene;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -44,6 +46,6 @@ public class DotnetField extends AbstractDotnetMember {
     int modifier = toSootModifier(protoField);
     Type type = DotnetTypeFactory.toSootType(protoField.getType());
     String name = protoField.getName();
-    return new SootField(name, type, modifier);
+    return Scene.v().makeSootField(name, type, modifier);
   }
 }

--- a/src/main/java/soot/dotnet/members/method/DotnetBodyVariableManager.java
+++ b/src/main/java/soot/dotnet/members/method/DotnetBodyVariableManager.java
@@ -44,6 +44,7 @@ import soot.dotnet.types.DotnetTypeFactory;
 import soot.javaToJimple.DefaultLocalGenerator;
 import soot.jimple.AssignStmt;
 import soot.jimple.CastExpr;
+import soot.jimple.Constant;
 import soot.jimple.Jimple;
 import soot.jimple.NullConstant;
 import soot.jimple.internal.JAssignStmt;
@@ -231,5 +232,37 @@ public class DotnetBodyVariableManager {
 
   public boolean localsToCastContains(String local) {
     return localsToCast.contains(local);
+  }
+  /**
+   * Assign expression only to new local variable to use the value in complex operations, when val is not a local or constant
+   *
+   * @param val : assign to local
+   */
+  public Value simplifyIfNotPrimitiveWithLocal(Value val) {
+	 if(!(val instanceof Local || val instanceof Constant))
+		 return (Value) generateLocalAndAssign(val);
+	 return val;
+  }
+  
+  /**
+   * Assign expression only to new local variable to use the value in complex operations, when val is not a local
+   *
+   * @param val : assign to local
+   */
+
+  public Local simplifyWithLocal(Value val) {
+		 if(!(val instanceof Local)) 
+			 return generateLocalAndAssign(val);
+		 return (Local) val;
+	  }
+  /**
+   * Assign expression to new local variable to use the value in complex operations
+   *
+   * @param val : assign to local
+   */
+  private Local generateLocalAndAssign(Value val) {
+	  Local local = localGenerator.generateLocal(val.getType());
+	  mainJb.getUnits().add(Jimple.v().newAssignStmt(local, val));
+      return local;
   }
 }


### PR DESCRIPTION
ILSpy changed the decompiling.

ILSpy 6.x:
stloc obj(ldloc list)
stloc item(ldc.i4 1)
callvirt Add(ldloc obj, ldloc item)

ILSpy 8.x
callvirt Add(ldloc list, ldc.i4 1)
