### PR TITLE
Adding a soot option for specifying virtualedges file used in call graph construction

### DIFF
--- a/doc/soot_options.htm
+++ b/doc/soot_options.htm
@@ -577,6 +577,10 @@
             </td>
          </tr>
          <tr>
+            <td><tt>-virtualedges-path <var>arg</var></tt><br></td>
+            <td colspan="2">Path to virtual edges configuration used in call graphs</td>
+         </tr>
+         <tr>
             <td><tt>-derive-java-version </tt><br></td>
             <td colspan="2">Java version for output and internal processing will be derived from the given input
                classes

--- a/doc/soot_options.html
+++ b/doc/soot_options.html
@@ -577,6 +577,10 @@
             </td>
          </tr>
          <tr>
+            <td><tt>-virtualedges-path <var>arg</var></tt><br></td>
+            <td colspan="2">Path to virtual edges configuration used in call graphs</td>
+         </tr>
+         <tr>
             <td><tt>-derive-java-version </tt><br></td>
             <td colspan="2">Java version for output and internal processing will be derived from the given input
                classes

--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
@@ -1242,6 +1242,12 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		if ((!(stringRes.equals(defStringRes))) && (stringRes != null) && (stringRes.length() != 0)) {
 			getConfig().put(getInput_Optionsprocess_jar_dir_widget().getAlias(), stringRes);
 		}
+		stringRes = getInput_Optionsvirtualedges_path_widget().getText().getText();
+		defStringRes = "";
+
+		if ((!(stringRes.equals(defStringRes))) && (stringRes != null) && (stringRes.length() != 0)) {
+			getConfig().put(getInput_Optionsvirtualedges_path_widget().getAlias(), stringRes);
+		}
 		stringRes = getInput_Optionsandroid_jars_widget().getText().getText();
 		defStringRes = "";
 
@@ -4966,6 +4972,18 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 	
 	public StringOptionWidget getInput_Optionsdotnet_nativehost_path_widget() {
 		return Input_Optionsdotnet_nativehost_path_widget;
+	}
+	
+	
+	
+	private StringOptionWidget Input_Optionsvirtualedges_path_widget;
+	
+	private void setInput_Optionsvirtualedges_path_widget(StringOptionWidget widget) {
+		Input_Optionsvirtualedges_path_widget = widget;
+	}
+	
+	public StringOptionWidget getInput_Optionsvirtualedges_path_widget() {
+		return Input_Optionsvirtualedges_path_widget;
 	}
 	
 	
@@ -9131,6 +9149,18 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		}
 
 		setInput_Optionsdotnet_nativehost_path_widget(new StringOptionWidget(editGroupInput_Options, SWT.NONE, new OptionData("Dotnet NativeHost Path",  "", "","dotnet-nativehost-path", "\nUse dotnet-nativehost-path to load the NativeHost library which \nis needed for soot.dotnet.", defaultString)));
+		
+
+		defKey = ""+" "+""+" "+"virtualedges-path";
+		defKey = defKey.trim();
+
+		if (isInDefList(defKey)) {
+			defaultString = getStringDef(defKey);	
+		} else {
+			defaultString = "";
+		}
+
+		setInput_Optionsvirtualedges_path_widget(new StringOptionWidget(editGroupInput_Options, SWT.NONE, new OptionData("VirtualEdges Path",  "", "","virtualedges-path", "\nUse virtual edges configuration file from location used in call \ngraph algorithms.", defaultString)));
 		
 
 		defKey = ""+" "+""+" "+"android-jars";

--- a/src/main/generated/options/soot/AntTask.java
+++ b/src/main/generated/options/soot/AntTask.java
@@ -249,6 +249,11 @@ public class AntTask extends MatchingTask {
             return process_jar_dir.createPath();
         }
   
+        public void setvirtualedges_path(String arg) {
+            addArg("-virtualedges-path");
+            addArg(arg);
+        }
+  
         public void setderive_java_version(boolean arg) {
             if(arg) addArg("-derive-java-version");
         }

--- a/src/main/generated/options/soot/options/Options.java
+++ b/src/main/generated/options/soot/options/Options.java
@@ -330,6 +330,22 @@ public class Options extends OptionsBase {
                 process_jar_dir.add(value);
             }
             else if (false
+                    || option.equals("virtualedges-path")
+            ) {
+                if (!hasMoreOptions()) {
+                    G.v().out.println("No value given for option -" + option);
+                    return false;
+                }
+
+                String value = nextOption();
+                if (virtualedges_path.isEmpty())
+                    virtualedges_path = value;
+                else {
+                    G.v().out.println("Duplicate values " + virtualedges_path + " and " + value + " for option -" + option);
+                    return false;
+                }
+            }
+            else if (false
                     || option.equals("no-derive-java-version")
             )
                 derive_java_version = false;
@@ -1565,6 +1581,10 @@ public class Options extends OptionsBase {
     public void set_process_jar_dir(List<String> setting) { process_jar_dir = setting; }
     private List<String> process_jar_dir = null;
 
+    public String virtualedges_path() { return virtualedges_path; }
+    public void set_virtualedges_path(String setting) { virtualedges_path = setting; }
+    private String virtualedges_path = "";
+
     public boolean derive_java_version() { return derive_java_version; }
     private boolean derive_java_version = true;
     public void set_derive_java_version(boolean setting) { derive_java_version = setting; }
@@ -1852,6 +1872,7 @@ public class Options extends OptionsBase {
                 + padOpt("-search-dex-in-archives", "Also includes Jar and Zip files when searching for DEX files under the provided classpath.")
                 + padOpt("-process-path ARG -process-dir ARG", "Process all classes found in ARG (but not classes within JAR files in ARG , use process-jar-dir for that)")
                 + padOpt("-process-jar-dir ARG", "Process all classes found in JAR files found in ARG")
+                + padOpt("-virtualedges-path ARG", "Path to virtual edges configuration used in call graphs")
                 + padOpt("-derive-java-version", "Java version for output and internal processing will be derived from the given input classes")
                 + padOpt("-oaat", "From the process-dir, processes one class at a time.")
                 + padOpt("-android-jars ARG", "Use ARG as the path for finding the android.jar file")

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
@@ -58,6 +58,7 @@ import soot.ModuleUtil;
 import soot.RefType;
 import soot.Scene;
 import soot.jimple.Stmt;
+import soot.options.Options;
 import soot.util.StringNumberer;
 
 /**
@@ -81,7 +82,19 @@ public class VirtualEdgesSummaries {
    * <code>virtualedges.xml</code> that comes with Soot.
    */
   public VirtualEdgesSummaries() {
-    Path summariesFile = Paths.get(SUMMARIESFILE);
+    final String virtualEdgesPath = Options.v().virtualedges_path();
+    Path summariesFile = null;
+    if (virtualEdgesPath != null && !virtualEdgesPath.isEmpty()) {
+      final Path virtualEdgesFilePath = Paths.get(virtualEdgesPath);
+      if (Files.exists(virtualEdgesFilePath)) {
+        summariesFile = virtualEdgesFilePath;
+      } else {
+        logger.error("The virtual edges path {} does not exist", virtualEdgesPath);
+      }
+    }
+    if (summariesFile == null) {
+      summariesFile = Paths.get(SUMMARIESFILE);
+    }
     try (InputStream in = Files.exists(summariesFile) ? Files.newInputStream(summariesFile)
         : ModuleUtil.class.getResourceAsStream("/" + SUMMARIESFILE)) {
       if (in == null) {

--- a/src/main/xml/options/soot_options.xml
+++ b/src/main/xml/options/soot_options.xml
@@ -596,6 +596,16 @@
                 </p>
             </long_desc>
         </listopt>
+        <stropt>
+            <name>VirtualEdges Path</name>
+            <alias>virtualedges-path</alias>
+            <short_desc>Path to virtual edges configuration used in call graphs</short_desc>
+            <long_desc>
+                <p>
+                    Use virtual edges configuration file from location <alias/> used in call graph algorithms.
+                </p>
+            </long_desc>
+        </stropt>
         <boolopt>
             <name>Derive Java version from input</name>
             <alias>derive-java-version</alias>


### PR DESCRIPTION
Adding a soot option for specifying virtualedges file used in call graphs. The current version can only get the user provided file from the current working directory. If multiple JVMs are running on the same current working directory, the processes race on the file location. 