### PR TITLE
Relaxing a runtimeexception with warning in Type Manager 

### DIFF
--- a/src/main/java/soot/jimple/spark/internal/TypeManager.java
+++ b/src/main/java/soot/jimple/spark/internal/TypeManager.java
@@ -43,7 +43,6 @@ import soot.Scene;
 import soot.SootClass;
 import soot.Type;
 import soot.TypeSwitch;
-import soot.baf.toolkits.base.LoadStoreOptimizer;
 import soot.jimple.spark.pag.AllocNode;
 import soot.jimple.spark.pag.Node;
 import soot.jimple.spark.pag.PAG;

--- a/src/main/java/soot/jimple/spark/internal/TypeManager.java
+++ b/src/main/java/soot/jimple/spark/internal/TypeManager.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import soot.AnySubType;
 import soot.ArrayType;
 import soot.FastHierarchy;
@@ -41,6 +43,7 @@ import soot.Scene;
 import soot.SootClass;
 import soot.Type;
 import soot.TypeSwitch;
+import soot.baf.toolkits.base.LoadStoreOptimizer;
 import soot.jimple.spark.pag.AllocNode;
 import soot.jimple.spark.pag.Node;
 import soot.jimple.spark.pag.PAG;
@@ -65,6 +68,8 @@ public final class TypeManager {
 
   private Map<SootClass, List<AllocNode>> class2allocs = new HashMap<SootClass, List<AllocNode>>(1024);
   private List<AllocNode> anySubtypeAllocs = new LinkedList<AllocNode>();
+
+  private static final Logger logger = LoggerFactory.getLogger(TypeManager.class);
 
   protected final RefType rtObject;
   protected final RefType rtSerializable;
@@ -151,8 +156,9 @@ public final class TypeManager {
             return new BitVector();
           }
         }
-
-        throw new RuntimeException("Type mask not found for type " + type);
+        logger.warn("Type mask not found for type " + type
+                + ". This is casued by a cast operation to a type which is a phantom class " +
+                "and no type mask was found. This may affect the precision of the point-to set.");
       }
     }
     return ret;


### PR DESCRIPTION
We are facing a runtime exception caused by the Type manager in multiple jars. 
For example the issue appears in the following maven packages when trying to construct the SPARK callgraph:
- https://repo1.maven.org/maven2/org/kie/kie-dmn-core-osgi/7.43.1.Final/kie-dmn-core-osgi-7.43.1.Final.jar
- https://repo1.maven.org/maven2/org/apache/servicemix/bundles/org.apache.servicemix.bundles.spring-data-redis/2.2.0.RELEASE_1/org.apache.servicemix.bundles.spring-data-redis-2.2.0.RELEASE_1.jar
- https://repo1.maven.org/maven2/org/wso2/carbon/analytics/org.wso2.carbon.sp.jobmanager.core/2.0.264/org.wso2.carbon.sp.jobmanager.core-2.0.264.jar

This is caused due to the assumption made for the BitVector representation of the point-to algorithm as documented here: https://github.com/soot-oss/soot/blob/develop/src/main/java/soot/jimple/spark/internal/TypeManager.java#L141
In this special case with cast operation to a type that is a phantom class and the type mask cant be found, Soot throws a runtime exception. 

**This PR relaxes this behavior**, by logging a **warning message** and letting the algorithm continuing **with possible decreased precision**. 

Unfortunately, the paper (https://arxiv.org/pdf/1108.2683.pdf) that introduced the precise points-to algorithm with type information does not explain such corner cases. Hence, a deeper investigation will be needed for better solution. 
