### PR TITLE
Avoid NPE casued by PR #1987

### DIFF
--- a/src/main/java/soot/jimple/spark/internal/TypeManager.java
+++ b/src/main/java/soot/jimple/spark/internal/TypeManager.java
@@ -158,6 +158,7 @@ public final class TypeManager {
         logger.warn("Type mask not found for type " + type
                 + ". This is casued by a cast operation to a type which is a phantom class " +
                 "and no type mask was found. This may affect the precision of the point-to set.");
+        return new BitVector();
       }
     }
     return ret;


### PR DESCRIPTION
This relates to the previous PR  #1987. 

Returning NULL may cause NPE in later stages. This PR fixes this by returning an empty BitVector. 