### PR TITLE
Ensure sound type propagation when Type Mask was not found for Cast Operations

### DIFF
--- a/src/main/java/soot/jimple/spark/internal/TypeManager.java
+++ b/src/main/java/soot/jimple/spark/internal/TypeManager.java
@@ -160,7 +160,7 @@ public final class TypeManager {
                 "and no type mask was found. This may affect the precision of the point-to set.");
         BitVector soundOverApproxRet = new BitVector();
         for (int i = 0; i <= 63; i++) {
-          soundOverApproxRet.set(i);‚
+          soundOverApproxRet.set(i);
         }
         return soundOverApproxRet;
       }

--- a/src/main/java/soot/jimple/spark/internal/TypeManager.java
+++ b/src/main/java/soot/jimple/spark/internal/TypeManager.java
@@ -158,7 +158,11 @@ public final class TypeManager {
         logger.warn("Type mask not found for type " + type
                 + ". This is casued by a cast operation to a type which is a phantom class " +
                 "and no type mask was found. This may affect the precision of the point-to set.");
-        return new BitVector();
+        BitVector soundOverApproxRet = new BitVector();
+        for (int i = 0; i <= 63; i++) {
+          soundOverApproxRet.set(i);‚
+        }
+        return soundOverApproxRet;
       }
     }
     return ret;


### PR DESCRIPTION
This PR makes a sound improvement of the PR #1987. 
In the previous change the BitVector was set to 0s which will prevent any type known to be propagate. To ensure sound type propagation for the special case in this part of the code, we need to return a BitVector set to all 1s. 

