### PR TITLE
Add AsmJava9ClassProvider after other class providers. This allows se…

### DIFF
--- a/src/main/java/soot/SourceLocator.java
+++ b/src/main/java/soot/SourceLocator.java
@@ -273,9 +273,6 @@ public class SourceLocator {
 
   protected void setupClassProviders() {
     final List<ClassProvider> classProviders = new LinkedList<ClassProvider>();
-    if (this.java9Mode) {
-      classProviders.add(new AsmJava9ClassProvider());
-    }
     final ClassProvider classFileClassProvider = Options.v().coffi() ? new CoffiClassProvider() : new AsmClassProvider();
     switch (Options.v().src_prec()) {
       case Options.src_prec_class:
@@ -313,6 +310,9 @@ public class SourceLocator {
         break;
       default:
         throw new RuntimeException("Other source precedences are not currently supported.");
+    }
+    if (this.java9Mode) {
+      classProviders.add(new AsmJava9ClassProvider());
     }
     this.classProviders = classProviders;
   }


### PR DESCRIPTION
The class providers and their order determine how a class is searched in the soot classpath. AsmJava9ClassProvider which was added ahead of all class providers does not search the classpath paths and instead searches a class in the Java 9 modules. This affects the expected behavior when a stub is provided for example for JDK classes, where Soot loads the class from Java 9 module instead of the stub. This PR adds the AsmJava9ClassProvider at the end, which allows other class providers that can look into Jars to look for a class before AsmJava9ClassProvider.