### PR TITLE
refactor: changing sootclass getname to getpathplusclassname

### DIFF
--- a/src/main/generated/jastadd/soot/JastAddJ/ClassDecl.java
+++ b/src/main/generated/jastadd/soot/JastAddJ/ClassDecl.java
@@ -419,7 +419,7 @@ public class ClassDecl extends ReferenceType implements Cloneable {
     }
     for(Iterator iter = interfacesIterator(); iter.hasNext(); ) {
       TypeDecl typeDecl = (TypeDecl)iter.next();
-      if(!sc.implementsInterface(typeDecl.getSootClassDecl().getName()))
+      if(!sc.implementsInterface(typeDecl.getSootClassDecl().getPathPlusClassName()))
         sc.addInterface(typeDecl.getSootClassDecl());
     }
     if(isNestedType())

--- a/src/main/generated/jastadd/soot/JastAddJ/InterfaceDecl.java
+++ b/src/main/generated/jastadd/soot/JastAddJ/InterfaceDecl.java
@@ -332,7 +332,7 @@ public class InterfaceDecl extends ReferenceType implements Cloneable {
     sc.setSuperclass(typeObject().getSootClassDecl());
     for(Iterator iter = superinterfacesIterator(); iter.hasNext(); ) {
       TypeDecl typeDecl = (TypeDecl)iter.next();
-      if(typeDecl != typeObject() && !sc.implementsInterface(typeDecl.getSootClassDecl().getName()))
+      if(typeDecl != typeObject() && !sc.implementsInterface(typeDecl.getSootClassDecl().getPathPlusClassName()))
         sc.addInterface(typeDecl.getSootClassDecl());
     }
     if(isNestedType())

--- a/src/main/java/soot/AbstractASMBackend.java
+++ b/src/main/java/soot/AbstractASMBackend.java
@@ -325,7 +325,7 @@ public abstract class AbstractASMBackend {
         exceptions = new String[exceptionList.size()];
         int i = 0;
         for (SootClass exc : exceptionList) {
-          exceptions[i] = slashify(exc.getName());
+          exceptions[i] = slashify(exc.getPathPlusClassName());
           ++i;
         }
       } else {
@@ -611,7 +611,7 @@ public abstract class AbstractASMBackend {
    * Emits the bytecode for a reference to an outer class if necessary
    */
   protected void generateOuterClassReference() {
-    String outerClassName = slashify(sc.getOuterClass().getName());
+    String outerClassName = slashify(sc.getOuterClass().getPathPlusClassName());
     String enclosingMethod = null;
     String enclosingMethodSig = null;
     EnclosingMethodTag emTag = (EnclosingMethodTag) sc.getTag(EnclosingMethodTag.NAME);
@@ -641,7 +641,7 @@ public abstract class AbstractASMBackend {
     int modifier = getModifiers(sc.getModifiers(), sc);
 
     // Retrieve class-name
-    String className = slashify(sc.getName());
+    String className = slashify(sc.getPathPlusClassName());
     // Retrieve generics
     SignatureTag sigTag = (SignatureTag) sc.getTag(SignatureTag.NAME);
     String sig = sigTag == null ? null : sigTag.getSignature();
@@ -653,14 +653,14 @@ public abstract class AbstractASMBackend {
     String superClass = "java/lang/Object".equals(className) ? null : "java/lang/Object";
     SootClass csuperClass = sc.getSuperclassUnsafe();
     if (csuperClass != null) {
-      superClass = slashify(csuperClass.getName());
+      superClass = slashify(csuperClass.getPathPlusClassName());
     }
 
     // Retrieve directly implemented interfaces
     String[] interfaces = new String[sc.getInterfaceCount()];
     int i = 0;
     for (SootClass interf : sc.getInterfaces()) {
-      interfaces[i] = slashify(interf.getName());
+      interfaces[i] = slashify(interf.getPathPlusClassName());
       ++i;
     }
 

--- a/src/main/java/soot/AbstractJasminClass.java
+++ b/src/main/java/soot/AbstractJasminClass.java
@@ -411,7 +411,7 @@ public abstract class AbstractJasminClass {
     }
 
     if (Options.v().verbose()) {
-      logger.debug("[" + sootClass.getName() + "] Constructing baf.JasminClass...");
+      logger.debug("[" + sootClass.getPathPlusClassName() + "] Constructing baf.JasminClass...");
     }
 
     code = new LinkedList<String>();
@@ -450,13 +450,13 @@ public abstract class AbstractJasminClass {
       }
       if (Modifier.isInterface(modifiers)) {
         modifiers -= Modifier.INTERFACE;
-        emit(".interface " + Modifier.toString(modifiers) + " " + slashify(sootClass.getName()));
+        emit(".interface " + Modifier.toString(modifiers) + " " + slashify(sootClass.getPathPlusClassName()));
       } else {
-        emit(".class " + Modifier.toString(modifiers) + " " + slashify(sootClass.getName()));
+        emit(".class " + Modifier.toString(modifiers) + " " + slashify(sootClass.getPathPlusClassName()));
       }
 
       if (sootClass.hasSuperclass()) {
-        emit(".super " + slashify(sootClass.getSuperclass().getName()));
+        emit(".super " + slashify(sootClass.getSuperclass().getPathPlusClassName()));
       } else {
         emit(".no_super");
       }
@@ -466,7 +466,7 @@ public abstract class AbstractJasminClass {
 
     // Emit the interfaces
     for (SootClass inter : sootClass.getInterfaces()) {
-      emit(".implements " + slashify(inter.getName()));
+      emit(".implements " + slashify(inter.getPathPlusClassName()));
     }
     /*
      * why do this???? if(sootClass.getInterfaceCount() != 0) emit("");
@@ -663,7 +663,7 @@ public abstract class AbstractJasminClass {
         + jasminDescriptorOf(method.makeRef()));
 
     for (SootClass exceptClass : method.getExceptions()) {
-      emit(".throws " + exceptClass.getName());
+      emit(".throws " + exceptClass.getPathPlusClassName());
     }
     if (method.hasTag(SyntheticTag.NAME) || Modifier.isSynthetic(method.getModifiers())) {
       emit(".synthetic");

--- a/src/main/java/soot/AbstractTrap.java
+++ b/src/main/java/soot/AbstractTrap.java
@@ -151,6 +151,6 @@ public class AbstractTrap implements Trap, Serializable {
 
   private void writeObject(ObjectOutputStream out) throws IOException {
     out.defaultWriteObject();
-    out.writeObject(exception.getName());
+    out.writeObject(exception.getPathPlusClassName());
   }
 }

--- a/src/main/java/soot/BriefUnitPrinter.java
+++ b/src/main/java/soot/BriefUnitPrinter.java
@@ -50,7 +50,7 @@ public class BriefUnitPrinter extends LabeledUnitPrinter {
   public void methodRef(SootMethodRef m) {
     handleIndent();
     if (!baf && m.resolve().isStatic()) {
-      output.append(m.getDeclaringClass().getName());
+      output.append(m.getDeclaringClass().getPathPlusClassName());
       literal(".");
     }
     output.append(m.name());
@@ -60,7 +60,7 @@ public class BriefUnitPrinter extends LabeledUnitPrinter {
   public void fieldRef(SootFieldRef f) {
     handleIndent();
     if (baf || f.resolve().isStatic()) {
-      output.append(f.declaringClass().getName());
+      output.append(f.declaringClass().getPathPlusClassName());
       literal(".");
     }
     output.append(f.name());

--- a/src/main/java/soot/Hierarchy.java
+++ b/src/main/java/soot/Hierarchy.java
@@ -254,7 +254,7 @@ public class Hierarchy {
   public List<SootClass> getSuperclassesOf(SootClass sootClass) {
     sootClass.checkLevel(SootClass.HIERARCHY);
     if (sootClass.isInterface()) {
-      throw new IllegalArgumentException(sootClass.getName() + " is an interface, but class is expected");
+      throw new IllegalArgumentException(sootClass.getPathPlusClassName() + " is an interface, but class is expected");
     }
 
     checkState();
@@ -303,7 +303,7 @@ public class Hierarchy {
   public List<SootClass> getSubinterfacesOf(SootClass sootClass) {
     sootClass.checkLevel(SootClass.HIERARCHY);
     if (!sootClass.isInterface()) {
-      throw new IllegalArgumentException(sootClass.getName() + " is a class, but interface is expected");
+      throw new IllegalArgumentException(sootClass.getPathPlusClassName() + " is a class, but interface is expected");
     }
 
     checkState();

--- a/src/main/java/soot/JastAddInitialResolver.java
+++ b/src/main/java/soot/JastAddInitialResolver.java
@@ -84,7 +84,7 @@ public class JastAddInitialResolver implements IInitialResolver {
         classNameToCU.put(className, u);
       } else {
         for (SootClass sc : types) {
-          classNameToCU.put(sc.getName(), u);
+          classNameToCU.put(sc.getPathPlusClassName(), u);
         }
       }
     }
@@ -113,10 +113,11 @@ public class JastAddInitialResolver implements IInitialResolver {
   }
 
   public Dependencies resolveFromJavaFile(SootClass sootclass) {
-    CompilationUnit u = classNameToCU.get(sootclass.getName());
+    CompilationUnit u = classNameToCU.get(sootclass.getPathPlusClassName());
 
     if (u == null) {
-      throw new RuntimeException("Error: couldn't find class: " + sootclass.getName() + " are the packages set properly?");
+      throw new RuntimeException("Error: couldn't find class: " + sootclass.getPathPlusClassName()
+              + " are the packages set properly?");
     }
 
     HashSet<SootClass> types = new HashSet<SootClass>();
@@ -132,7 +133,7 @@ public class JastAddInitialResolver implements IInitialResolver {
         m.setSource(new MethodSource() {
           public Body getBody(SootMethod m, String phaseName) {
             SootClass sc = m.getDeclaringClass();
-            CompilationUnit u = classNameToCU.get(sc.getName());
+            CompilationUnit u = classNameToCU.get(sc.getPathPlusClassName());
             for (TypeDecl typeDecl : u.getTypeDecls()) {
               typeDecl = findNestedTypeDecl(typeDecl, sc);
               if (typeDecl != null) {
@@ -159,7 +160,7 @@ public class JastAddInitialResolver implements IInitialResolver {
               }
             }
             throw new RuntimeException(
-                "Could not find body for " + m.getSignature() + " in " + m.getDeclaringClass().getName());
+                "Could not find body for " + m.getSignature() + " in " + m.getDeclaringClass().getPathPlusClassName());
           }
         });
       }

--- a/src/main/java/soot/JimpleClassSource.java
+++ b/src/main/java/soot/JimpleClassSource.java
@@ -74,7 +74,7 @@ public class JimpleClassSource extends ClassSource {
       // set outer class if not set (which it should not be) and class name contains outer class indicator
       String outerClassName = null;
       if (!sc.hasOuterClass()) {
-        String className = sc.getName();
+        String className = sc.getPathPlusClassName();
         if (className.contains("$")) {
           if (className.contains("$-")) {
             /*

--- a/src/main/java/soot/LambdaMetaFactory.java
+++ b/src/main/java/soot/LambdaMetaFactory.java
@@ -154,7 +154,7 @@ public class LambdaMetaFactory {
     // Our thunk class implements the functional interface
     SootClass functionalInterfaceToImplement = ((RefType) invokedType[invokedType.length - 1]).getSootClass();
 
-    final String enclosingClassname = enclosingClass.getName();
+    final String enclosingClassname = enclosingClass.getPathPlusClassName();
 
     String className;
     final boolean readableClassnames = true;
@@ -201,7 +201,7 @@ public class LambdaMetaFactory {
     // it can be invoked from the thunk class
     if (MethodHandle.Kind.REF_INVOKE_STATIC.getValue() == implMethod.getKind()) {
       SootClass declClass = implMethod.getMethodRef().getDeclaringClass();
-      if (declClass.getName().equals(enclosingClassname)) {
+      if (declClass.getPathPlusClassName().equals(enclosingClassname)) {
         SootMethod method = implMethod.getMethodRef().resolve();
         method.setModifiers((method.getModifiers() & ~Modifier.PRIVATE) | Modifier.PUBLIC);
       }
@@ -268,11 +268,11 @@ public class LambdaMetaFactory {
     Scene scene = Scene.v();
 
     SootMethodRef methodRef = implMethod.getMethodRef();
-    scene.forceResolve(methodRef.getDeclaringClass().getName(), SootClass.HIERARCHY);
+    scene.forceResolve(methodRef.getDeclaringClass().getPathPlusClassName(), SootClass.HIERARCHY);
 
     Stream.concat(Stream.of(methodRef.getReturnType()), methodRef.getParameterTypes().stream())
         .filter(t -> t instanceof RefType)
-        .forEach(t -> scene.forceResolve(((RefType) t).getSootClass().getName(), SootClass.HIERARCHY));
+        .forEach(t -> scene.forceResolve(((RefType) t).getSootClass().getPathPlusClassName(), SootClass.HIERARCHY));
   }
 
   private void addDispatch(String name, SootClass tclass, MethodType implMethodType, MethodType instantiatedMethodType,

--- a/src/main/java/soot/ModulePathSourceLocator.java
+++ b/src/main/java/soot/ModulePathSourceLocator.java
@@ -92,7 +92,7 @@ public class ModulePathSourceLocator extends SourceLocator {
       if (classesToLoad == null) {
         classesToLoad = new HashSet<String>(ModuleScene.v().getBasicClasses());
         for (SootClass c : ModuleScene.v().getApplicationClasses()) {
-          classesToLoad.add(c.getName());
+          classesToLoad.add(c.getPathPlusClassName());
         }
         this.classesToLoad = classesToLoad;
       }

--- a/src/main/java/soot/ModuleScene.java
+++ b/src/main/java/soot/ModuleScene.java
@@ -163,10 +163,10 @@ public class ModuleScene extends Scene {
   @Override
   protected void addClassSilent(SootClass c) {
     if (c.isInScene()) {
-      throw new RuntimeException("already managed: " + c.getName());
+      throw new RuntimeException("already managed: " + c.getPathPlusClassName());
     }
 
-    final String className = c.getName();
+    final String className = c.getPathPlusClassName();
     if (containsClass(className, Optional.fromNullable(c.moduleName))) {
       throw new RuntimeException("duplicate class: " + className);
     }
@@ -532,7 +532,8 @@ public class ModuleScene extends Scene {
       SootClass c = iterator.next();
       if (!c.isConcrete()) {
         if (opts.verbose()) {
-          logger.warn("dynamic class " + c.getName() + " is abstract or an interface, and it will not be considered.");
+          logger.warn("dynamic class " + c.getPathPlusClassName()
+                  + " is abstract or an interface, and it will not be considered.");
         }
         iterator.remove();
       }
@@ -562,7 +563,7 @@ public class ModuleScene extends Scene {
         if (Options.v().app()) {
           s.setApplicationClass();
         }
-        if (optionsClasses.contains(s.getName())) {
+        if (optionsClasses.contains(s.getPathPlusClassName())) {
           s.setApplicationClass();
           continue;
         }
@@ -574,7 +575,7 @@ public class ModuleScene extends Scene {
         }
         if (s.isApplicationClass()) {
           // make sure we have the support
-          loadClassAndSupport(s.getName(), Optional.fromNullable(s.moduleName));
+          loadClassAndSupport(s.getPathPlusClassName(), Optional.fromNullable(s.moduleName));
         }
       }
     }
@@ -593,7 +594,7 @@ public class ModuleScene extends Scene {
         for (String s : Options.v().classes()) {
           SootClass c = getSootClass(s, null);
           if (c.declaresMethod("main", mainArgs, VoidType.v())) {
-            logger.debug("No main class given. Inferred '" + c.getName() + "' as main class.");
+            logger.debug("No main class given. Inferred '" + c.getPathPlusClassName() + "' as main class.");
             setMainClass(c);
             return;
           }
@@ -602,7 +603,7 @@ public class ModuleScene extends Scene {
         // try to infer a main class from the usual classpath if none is given
         for (SootClass c : getApplicationClasses()) {
           if (c.declaresMethod("main", mainArgs, VoidType.v())) {
-            logger.debug("No main class given. Inferred '" + c.getName() + "' as main class.");
+            logger.debug("No main class given. Inferred '" + c.getPathPlusClassName() + "' as main class.");
             setMainClass(c);
             return;
           }

--- a/src/main/java/soot/PackManager.java
+++ b/src/main/java/soot/PackManager.java
@@ -882,13 +882,13 @@ public class PackManager {
   private void runBodyPacks(SootClass c) {
     final int format = Options.v().output_format();
     if (format == Options.output_format_dava) {
-      logger.debug("Decompiling {}...", c.getName());
+      logger.debug("Decompiling {}...", c.getPathPlusClassName());
 
       // January 13th, 2006 SootMethodAddedByDava is set to false for
       // SuperFirstStmtHandler
       G.v().SootMethodAddedByDava = false;
     } else {
-      logger.debug("Transforming {}...", c.getName());
+      logger.debug("Transforming {}...", c.getPathPlusClassName());
     }
 
     boolean produceBaf = false, produceGrimp = false, produceDava = false, produceJimple = true, produceShimple = false;

--- a/src/main/java/soot/PolymorphicMethodRef.java
+++ b/src/main/java/soot/PolymorphicMethodRef.java
@@ -54,7 +54,7 @@ public class PolymorphicMethodRef extends SootMethodRefImpl {
    * @return if the class is allowed according to the JVM Spec
    */
   public static boolean handlesClass(SootClass declaringClass) {
-    return handlesClass(declaringClass.getName());
+    return handlesClass(declaringClass.getPathPlusClassName());
   }
 
   public static boolean handlesClass(String declaringClassName) {

--- a/src/main/java/soot/Printer.java
+++ b/src/main/java/soot/Printer.java
@@ -265,7 +265,7 @@ public class Printer {
     if (customClassSignaturePrinter != null) {
       return customClassSignaturePrinter.apply(sootClass);
     } else {
-      return Scene.v().quotedNameOf(sootClass.getName());
+      return Scene.v().quotedNameOf(sootClass.getPathPlusClassName());
     }
   }
 

--- a/src/main/java/soot/RefType.java
+++ b/src/main/java/soot/RefType.java
@@ -95,9 +95,9 @@ public class RefType extends RefLikeType implements Comparable<RefType> {
    */
   public static RefType v(SootClass c) {
     if (ModuleUtil.module_mode()) {
-      return ModuleRefType.v(c.getName(), Optional.fromNullable(c.moduleName));
+      return ModuleRefType.v(c.getPathPlusClassName(), Optional.fromNullable(c.moduleName));
     } else {
-      return v(c.getName());
+      return v(c.getPathPlusClassName());
     }
   }
 

--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -844,11 +844,11 @@ public class Scene {
   protected void addClassSilent(SootClass c) {
     synchronized (c) {
       if (c.isInScene()) {
-        throw new RuntimeException("already managed: " + c.getName());
+        throw new RuntimeException("already managed: " + c.getPathPlusClassName());
       }
 
-      if (containsClass(c.getName())) {
-        throw new RuntimeException("duplicate class: " + c.getName());
+      if (containsClass(c.getPathPlusClassName())) {
+        throw new RuntimeException("duplicate class: " + c.getPathPlusClassName());
       }
 
       classes.add(c);
@@ -861,7 +861,7 @@ public class Scene {
       if (!c.isPhantom) {
         modifyHierarchy();
       }
-      nameToClass.computeIfAbsent(c.getName(), k -> c.getType());
+      nameToClass.computeIfAbsent(c.getPathPlusClassName(), k -> c.getType());
     }
   }
 
@@ -2001,7 +2001,8 @@ public class Scene {
       SootClass c = iterator.next();
       if (!c.isConcrete()) {
         if (opts.verbose()) {
-          logger.warn("dynamic class " + c.getName() + " is abstract or an interface, and it will not be considered.");
+          logger.warn("dynamic class " + c.getPathPlusClassName()
+                  + " is abstract or an interface, and it will not be considered.");
         }
         iterator.remove();
       }
@@ -2030,7 +2031,7 @@ public class Scene {
         if (Options.v().app()) {
           s.setApplicationClass();
         }
-        if (optionsClasses.contains(s.getName())) {
+        if (optionsClasses.contains(s.getPathPlusClassName())) {
           s.setApplicationClass();
           continue;
         }
@@ -2042,14 +2043,14 @@ public class Scene {
         }
         if (s.isApplicationClass()) {
           // make sure we have the support
-          loadClassAndSupport(s.getName());
+          loadClassAndSupport(s.getPathPlusClassName());
         }
       }
     }
   }
 
   public boolean isExcluded(SootClass sc) {
-    return isExcluded(sc.getName());
+    return isExcluded(sc.getPathPlusClassName());
   }
 
   public boolean isExcluded(String className) {
@@ -2066,7 +2067,7 @@ public class Scene {
   }
 
   public boolean isIncluded(SootClass sc) {
-    return isIncluded(sc.getName());
+    return isIncluded(sc.getPathPlusClassName());
   }
 
   public boolean isIncluded(String className) {
@@ -2146,7 +2147,7 @@ public class Scene {
               = Options.v().src_prec() != Options.src_prec_dotnet ? c.declaresMethod("main", mainArgs, VoidType.v())
                   : c.declaresMethod("Main", mainArgs, VoidType.v());
           if (declaresMethod) {
-            logger.debug("No main class given. Inferred '" + c.getName() + "' as main class.");
+            logger.debug("No main class given. Inferred '" + c.getPathPlusClassName() + "' as main class.");
             setMainClass(c);
             return;
           }
@@ -2158,7 +2159,7 @@ public class Scene {
               = Options.v().src_prec() != Options.src_prec_dotnet ? c.declaresMethod("main", mainArgs, VoidType.v())
                   : c.declaresMethod("Main", mainArgs, VoidType.v());
           if (declaresMethod) {
-            logger.debug("No main class given. Inferred '" + c.getName() + "' as main class.");
+            logger.debug("No main class given. Inferred '" + c.getPathPlusClassName() + "' as main class.");
             setMainClass(c);
             return;
           }

--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -204,7 +204,7 @@ public class SootClass extends AbstractHost implements Numberable {
     int currentLevel = resolvingLevel();
     if (currentLevel < level) {
       String hint = "\nIf you are extending Soot, try to add the following call before calling soot.Main.main(..):\n"
-          + "Scene.v().addBasicClass(" + getName() + "," + levelToString(level) + ");\n"
+          + "Scene.v().addBasicClass(" + getPathPlusClassName() + "," + levelToString(level) + ");\n"
           + "Otherwise, try whole-program mode (-w).";
       throw new RuntimeException("This operation requires resolving level " + levelToString(level) + " but " + name
           + " is at resolving level " + levelToString(currentLevel) + hint);
@@ -294,7 +294,7 @@ public class SootClass extends AbstractHost implements Numberable {
   public SootField getField(String name, Type type) {
     SootField sf = getFieldUnsafe(name, type);
     if (sf == null) {
-      throw new RuntimeException("No field " + name + " in class " + getName());
+      throw new RuntimeException("No field " + name + " in class " + getPathPlusClassName());
     }
     return sf;
   }
@@ -321,7 +321,7 @@ public class SootClass extends AbstractHost implements Numberable {
   public SootField getFieldByName(String name) {
     SootField foundField = getFieldByNameUnsafe(name);
     if (foundField == null) {
-      throw new RuntimeException("No field " + name + " in class " + getName());
+      throw new RuntimeException("No field " + name + " in class " + getPathPlusClassName());
     }
     return foundField;
   }
@@ -355,7 +355,7 @@ public class SootClass extends AbstractHost implements Numberable {
     // NOTE: getFieldUnsafe(String) calls checkLevel(SIGNATURES)
     SootField sf = getFieldUnsafe(subsignature);
     if (sf == null) {
-      throw new RuntimeException("No field " + subsignature + " in class " + getName());
+      throw new RuntimeException("No field " + subsignature + " in class " + getPathPlusClassName());
     }
     return sf;
   }
@@ -391,7 +391,7 @@ public class SootClass extends AbstractHost implements Numberable {
     // NOTE: getMethodUnsafe(NumberedString) calls checkLevel(SIGNATURES)
     SootMethod ret = getMethodUnsafe(subsignature);
     if (ret == null) {
-      throw new RuntimeException("No method " + subsignature + " in class " + getName());
+      throw new RuntimeException("No method " + subsignature + " in class " + getPathPlusClassName());
     } else {
       return ret;
     }
@@ -422,7 +422,7 @@ public class SootClass extends AbstractHost implements Numberable {
     // NOTE: getMethodUnsafe(NumberedString) calls checkLevel(SIGNATURES)
     NumberedString numberedString = Scene.v().getSubSigNumberer().find(subsignature);
     if (numberedString == null) {
-      throw new RuntimeException("No method " + subsignature + " in class " + getName());
+      throw new RuntimeException("No method " + subsignature + " in class " + getPathPlusClassName());
     }
     return getMethod(numberedString);
   }
@@ -533,7 +533,7 @@ public class SootClass extends AbstractHost implements Numberable {
       return sm;
     }
 
-    throw new RuntimeException("Class " + getName() + " doesn't have method \""
+    throw new RuntimeException("Class " + getPathPlusClassName() + " doesn't have method \""
         + SootMethod.getSubSignature(name, parameterTypes, returnType) + "\"");
   }
 
@@ -795,7 +795,7 @@ public class SootClass extends AbstractHost implements Numberable {
     checkLevel(HIERARCHY);
     if (interfaces != null) {
       for (SootClass sc : interfaces) {
-        if (name.equals(sc.getName())) {
+        if (name.equals(sc.getPathPlusClassName())) {
           return true;
         }
       }
@@ -808,8 +808,9 @@ public class SootClass extends AbstractHost implements Numberable {
    */
   public void addInterface(SootClass interfaceClass) {
     // NOTE: implementsInterface(String) calls checkLevel(HIERARCHY)
-    if (implementsInterface(interfaceClass.getName())) {
-      throw new RuntimeException("duplicate interface on class " + this.getName() + ": " + interfaceClass.getName());
+    if (implementsInterface(interfaceClass.getPathPlusClassName())) {
+      throw new RuntimeException("duplicate interface on class " + this.getPathPlusClassName() + ": "
+              + interfaceClass.getPathPlusClassName());
     }
     if (this.interfaces == null) {
       // Use a small initial size to reduce excess memory usage in the HashChain.
@@ -830,8 +831,9 @@ public class SootClass extends AbstractHost implements Numberable {
    */
   public void removeInterface(SootClass interfaceClass) {
     // NOTE: implementsInterface(String) calls checkLevel(HIERARCHY)
-    if (!implementsInterface(interfaceClass.getName())) {
-      throw new RuntimeException("no such interface on class " + this.getName() + ": " + interfaceClass.getName());
+    if (!implementsInterface(interfaceClass.getPathPlusClassName())) {
+      throw new RuntimeException("no such interface on class " + this.getPathPlusClassName()
+              + ": " + interfaceClass.getPathPlusClassName());
     }
     interfaces.remove(interfaceClass);
     if (interfaces.isEmpty()) {
@@ -855,7 +857,7 @@ public class SootClass extends AbstractHost implements Numberable {
   public SootClass getSuperclass() {
     checkLevel(HIERARCHY);
     if (superClass == null && !isPhantom() && !Options.v().ignore_resolution_errors()) {
-      throw new RuntimeException("no superclass for " + getName());
+      throw new RuntimeException("no superclass for " + getPathPlusClassName());
     } else {
       return superClass;
     }
@@ -914,7 +916,7 @@ public class SootClass extends AbstractHost implements Numberable {
   /**
    * Returns the name of this class.
    */
-  public String getName() {
+  public String getPathPlusClassName() {
     return name;
   }
 
@@ -1056,7 +1058,7 @@ public class SootClass extends AbstractHost implements Numberable {
    */
   @Override
   public String toString() {
-    return getName();
+    return getPathPlusClassName();
   }
 
   /**
@@ -1254,9 +1256,9 @@ public class SootClass extends AbstractHost implements Numberable {
 
   public String getFilePath() {
     if (ModuleUtil.module_mode()) {
-      return moduleName + ':' + this.getName();
+      return moduleName + ':' + this.getPathPlusClassName();
     } else {
-      return this.getName();
+      return this.getPathPlusClassName();
     }
   }
 
@@ -1276,7 +1278,7 @@ public class SootClass extends AbstractHost implements Numberable {
   public boolean isExportedByModule() {
     if (this.getModuleInformation() == null && ModuleUtil.module_mode()) {
       // we are in module mode and obviously the class has not been resolved, therefore we have to resolve it
-      Scene.v().forceResolve(this.getName(), SootClass.BODIES);
+      Scene.v().forceResolve(this.getPathPlusClassName(), SootClass.BODIES);
     }
     SootModuleInfo moduleInfo = this.getModuleInformation();
     // for dummy classes moduleInfo could be null
@@ -1291,7 +1293,7 @@ public class SootClass extends AbstractHost implements Numberable {
   public boolean isExportedByModule(String toModule) {
     if (this.getModuleInformation() == null && ModuleUtil.module_mode()) {
       // we are in module mode and obviously the class has not been resolved, therefore we have to resolve it
-      ModuleScene.v().forceResolve(this.getName(), SootClass.BODIES, Optional.of(this.moduleName));
+      ModuleScene.v().forceResolve(this.getPathPlusClassName(), SootClass.BODIES, Optional.of(this.moduleName));
     }
     return this.getModuleInformation().exportsPackage(this.getJavaPackageName(), toModule);
   }
@@ -1299,7 +1301,7 @@ public class SootClass extends AbstractHost implements Numberable {
   public boolean isOpenedByModule() {
     if (this.getModuleInformation() == null && ModuleUtil.module_mode()) {
       // we are in module mode and obviously the class has not been resolved, therefore we have to resolve it
-      Scene.v().forceResolve(this.getName(), SootClass.BODIES);
+      Scene.v().forceResolve(this.getPathPlusClassName(), SootClass.BODIES);
     }
     SootModuleInfo moduleInfo = this.getModuleInformation();
     return (moduleInfo == null) ? true : moduleInfo.openPackagePublic(this.getJavaPackageName());

--- a/src/main/java/soot/SootField.java
+++ b/src/main/java/soot/SootField.java
@@ -83,7 +83,7 @@ public class SootField extends AbstractHost implements ClassMember, SparkField, 
 
   public static String getSignature(SootClass cl, String subSignature) {
     StringBuilder buffer = new StringBuilder();
-    buffer.append('<').append(Scene.v().quotedNameOf(cl.getName())).append(": ");
+    buffer.append('<').append(Scene.v().quotedNameOf(cl.getPathPlusClassName())).append(": ");
     buffer.append(subSignature).append('>');
     return buffer.toString();
   }

--- a/src/main/java/soot/SootMethod.java
+++ b/src/main/java/soot/SootMethod.java
@@ -508,7 +508,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     if (exceptions == null) {
       exceptions = new ArrayList<SootClass>();
     } else if (exceptions.contains(e)) {
-      throw new RuntimeException("already throws exception " + e.getName());
+      throw new RuntimeException("already throws exception " + e.getPathPlusClassName());
     }
 
     exceptions.add(e);
@@ -521,7 +521,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     logger.trace("Removing exception {}", e);
 
     if (exceptions == null || !exceptions.contains(e)) {
-      throw new RuntimeException("does not throw exception " + e.getName());
+      throw new RuntimeException("does not throw exception " + e.getPathPlusClassName());
     }
 
     exceptions.remove(e);
@@ -676,7 +676,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
   public String getBytecodeSignature() {
     StringBuilder buffer = new StringBuilder();
     buffer.append('<');
-    buffer.append(Scene.v().quotedNameOf(getDeclaringClass().getName()));
+    buffer.append(Scene.v().quotedNameOf(getDeclaringClass().getPathPlusClassName()));
     buffer.append(": ");
     buffer.append(getName());
     buffer.append(AbstractJasminClass.jasminDescriptorOf(makeRef()));
@@ -708,7 +708,7 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
   public static String getSignature(SootClass cl, String subSignature) {
     StringBuilder buffer = new StringBuilder();
     buffer.append('<');
-    buffer.append(Scene.v().quotedNameOf(cl.getName()));
+    buffer.append(Scene.v().quotedNameOf(cl.getPathPlusClassName()));
     buffer.append(": ");
     buffer.append(subSignature);
     buffer.append('>');
@@ -877,9 +877,9 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     if (exceptions != null) {
       Iterator<SootClass> exceptionIt = this.getExceptions().iterator();
       if (exceptionIt.hasNext()) {
-        buffer.append(" throws ").append(exceptionIt.next().getName());
+        buffer.append(" throws ").append(exceptionIt.next().getPathPlusClassName());
         while (exceptionIt.hasNext()) {
-          buffer.append(", ").append(exceptionIt.next().getName());
+          buffer.append(", ").append(exceptionIt.next().getPathPlusClassName());
         }
       }
     }
@@ -927,9 +927,9 @@ public class SootMethod extends AbstractHost implements ClassMember, Numberable,
     if (exceptions != null) {
       Iterator<SootClass> exceptionIt = this.getExceptions().iterator();
       if (exceptionIt.hasNext()) {
-        buffer.append(" throws ").append(Scene.v().quotedNameOf(exceptionIt.next().getName()));
+        buffer.append(" throws ").append(Scene.v().quotedNameOf(exceptionIt.next().getPathPlusClassName()));
         while (exceptionIt.hasNext()) {
-          buffer.append(", ").append(Scene.v().quotedNameOf(exceptionIt.next().getName()));
+          buffer.append(", ").append(Scene.v().quotedNameOf(exceptionIt.next().getPathPlusClassName()));
         }
       }
     }

--- a/src/main/java/soot/SootMethodRefImpl.java
+++ b/src/main/java/soot/SootMethodRefImpl.java
@@ -86,7 +86,7 @@ public class SootMethodRefImpl implements SootMethodRef {
     }
     if (returnType == null) {
       throw new IllegalArgumentException("Attempt to create SootMethodRef with null returnType (Method: " + name
-          + " at declaring class: " + declaringClass.getName() + ")");
+          + " at declaring class: " + declaringClass.getPathPlusClassName() + ")");
     }
 
     this.declaringClass = declaringClass;
@@ -283,7 +283,8 @@ public class SootMethodRefImpl implements SootMethodRef {
     // at runtime. Furthermore, the declaring class of dynamic invocations is
     // not known at compile time, treat as phantom class regardless if phantom
     // classes are enabled or not.
-    if (Options.v().allow_phantom_refs() || SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME.equals(declaringClass.getName())) {
+    if (Options.v().allow_phantom_refs() ||
+            SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME.equals(declaringClass.getPathPlusClassName())) {
       return createUnresolvedErrorMethod(declaringClass);
     }
 

--- a/src/main/java/soot/SootResolver.java
+++ b/src/main/java/soot/SootResolver.java
@@ -176,7 +176,8 @@ public class SootResolver {
         if (resolveEverything) {
           // Whole program mode
           boolean onlySignatures
-              = sc.isPhantom() || (no_bodies_for_excluded && scene.isExcluded(sc) && !scene.isBasicClass(sc.getName()));
+              = sc.isPhantom() || (no_bodies_for_excluded && scene.isExcluded(sc)
+                  && !scene.isBasicClass(sc.getPathPlusClassName()));
           if (onlySignatures) {
             bringToSignatures(sc);
             sc.setPhantomClass();
@@ -244,7 +245,7 @@ public class SootResolver {
   }
 
   protected void bringToHierarchyUnchecked(SootClass sc) {
-    String className = sc.getName();
+    String className = sc.getPathPlusClassName();
     ClassSource is;
     if (ModuleUtil.module_mode()) {
       is = ModulePathSourceLocator.v().getClassSource(className,

--- a/src/main/java/soot/SourceLocator.java
+++ b/src/main/java/soot/SourceLocator.java
@@ -509,19 +509,19 @@ public class SourceLocator {
       case Options.output_format_dava:
         return getDavaFilenameFor(c, b);
       case Options.output_format_class:
-        b.append(c.getName().replace('.', File.separatorChar));
+        b.append(c.getPathPlusClassName().replace('.', File.separatorChar));
         break;
       case Options.output_format_template:
-        b.append(c.getName().replace('.', '_'));
+        b.append(c.getPathPlusClassName().replace('.', '_'));
         b.append("_Maker");
         break;
       default:
         // Generate tree structure for Jimple output or generation
         // fails for deep hierarchies ("file name too long").
         if ((rep == Options.output_format_jimple || rep == Options.output_format_shimple) && Options.v().hierarchy_dirs()) {
-          b.append(c.getName().replace('.', File.separatorChar));
+          b.append(c.getPathPlusClassName().replace('.', File.separatorChar));
         } else {
-          b.append(c.getName());
+          b.append(c.getPathPlusClassName());
         }
         break;
     }

--- a/src/main/java/soot/TrapManager.java
+++ b/src/main/java/soot/TrapManager.java
@@ -140,9 +140,10 @@ public class TrapManager {
       if (trap.getHandlerUnit() == u) {
         RefType type;
         if (module_mode) {
-          type = ModuleRefType.v(trap.getException().getName(), Optional.fromNullable(trap.getException().moduleName));
+          type = ModuleRefType.v(trap.getException().getPathPlusClassName(),
+                  Optional.fromNullable(trap.getException().moduleName));
         } else {
-          type = RefType.v(trap.getException().getName());
+          type = RefType.v(trap.getException().getPathPlusClassName());
         }
         possibleTypes.add(type);
       }

--- a/src/main/java/soot/asm/AsmUtil.java
+++ b/src/main/java/soot/asm/AsmUtil.java
@@ -154,7 +154,7 @@ public class AsmUtil {
    * @return corresponding internal name.
    */
   public static String toInternalName(SootClass cls) {
-    return toInternalName(cls.getName());
+    return toInternalName(cls.getPathPlusClassName());
   }
 
   /**

--- a/src/main/java/soot/asm/SootClassBuilder.java
+++ b/src/main/java/soot/asm/SootClassBuilder.java
@@ -127,8 +127,8 @@ public class SootClassBuilder extends ClassVisitor {
     }
 
     name = AsmUtil.toQualifiedName(name);
-    if (!name.equals(klass.getName()) && Options.v().verbose()) {
-      System.err.println("Class names not equal! " + name + " != " + klass.getName());
+    if (!name.equals(klass.getPathPlusClassName()) && Options.v().verbose()) {
+      System.err.println("Class names not equal! " + name + " != " + klass.getPathPlusClassName());
     }
     // FIXME: ad -- throw excpetion again
     // throw new RuntimeException("Class names not equal! "+name+" != "+klass.getName());

--- a/src/main/java/soot/baf/BafASMBackend.java
+++ b/src/main/java/soot/baf/BafASMBackend.java
@@ -195,7 +195,7 @@ public class BafASMBackend extends AbstractASMBackend {
         Label start = branchTargetLabels.get(trap.getBeginUnit());
         Label end = branchTargetLabels.get(trap.getEndUnit());
         Label handler = branchTargetLabels.get(trap.getHandlerUnit());
-        String type = slashify(trap.getException().getName());
+        String type = slashify(trap.getException().getPathPlusClassName());
         mv.visitTryCatchBlock(start, end, handler, type);
       }
     }
@@ -466,12 +466,12 @@ public class BafASMBackend extends AbstractASMBackend {
           Handle handle;
           if (((MethodHandle) c).isMethodRef()) {
             SootMethodRef methodRef = ((MethodHandle) c).getMethodRef();
-            handle = new Handle(((MethodHandle) c).getKind(), slashify(methodRef.declaringClass().getName()),
-                methodRef.name(), toTypeDesc(methodRef), methodRef.declaringClass().isInterface());
+            handle = new Handle(((MethodHandle) c).getKind(), slashify(methodRef.declaringClass().getPathPlusClassName()),
+                    methodRef.name(), toTypeDesc(methodRef), methodRef.declaringClass().isInterface());
           } else {
             SootFieldRef fieldRef = ((MethodHandle) c).getFieldRef();
-            handle = new Handle(((MethodHandle) c).getKind(), slashify(fieldRef.declaringClass().getName()), fieldRef.name(),
-                toTypeDesc(fieldRef.type()), fieldRef.declaringClass().isInterface());
+            handle = new Handle(((MethodHandle) c).getKind(), slashify(fieldRef.declaringClass().getPathPlusClassName()),
+                    fieldRef.name(), toTypeDesc(fieldRef.type()), fieldRef.declaringClass().isInterface());
           }
           mv.visitLdcInsn(handle);
         } else {
@@ -1164,28 +1164,28 @@ public class BafASMBackend extends AbstractASMBackend {
       @Override
       public void caseStaticGetInst(StaticGetInst i) {
         SootFieldRef field = i.getFieldRef();
-        mv.visitFieldInsn(Opcodes.GETSTATIC, slashify(field.declaringClass().getName()), field.name(),
+        mv.visitFieldInsn(Opcodes.GETSTATIC, slashify(field.declaringClass().getPathPlusClassName()), field.name(),
             toTypeDesc(field.type()));
       }
 
       @Override
       public void caseStaticPutInst(StaticPutInst i) {
         SootFieldRef field = i.getFieldRef();
-        mv.visitFieldInsn(Opcodes.PUTSTATIC, slashify(field.declaringClass().getName()), field.name(),
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, slashify(field.declaringClass().getPathPlusClassName()), field.name(),
             toTypeDesc(field.type()));
       }
 
       @Override
       public void caseFieldGetInst(FieldGetInst i) {
         SootFieldRef field = i.getFieldRef();
-        mv.visitFieldInsn(Opcodes.GETFIELD, slashify(field.declaringClass().getName()), field.name(),
+        mv.visitFieldInsn(Opcodes.GETFIELD, slashify(field.declaringClass().getPathPlusClassName()), field.name(),
             toTypeDesc(field.type()));
       }
 
       @Override
       public void caseFieldPutInst(FieldPutInst i) {
         SootFieldRef field = i.getFieldRef();
-        mv.visitFieldInsn(Opcodes.PUTFIELD, slashify(field.declaringClass().getName()), field.name(),
+        mv.visitFieldInsn(Opcodes.PUTFIELD, slashify(field.declaringClass().getPathPlusClassName()), field.name(),
             toTypeDesc(field.type()));
       }
 
@@ -1336,12 +1336,12 @@ public class BafASMBackend extends AbstractASMBackend {
             public void caseMethodHandle(MethodHandle handle) {
               if (handle.isMethodRef()) {
                 SootMethodRef methodRef = handle.getMethodRef();
-                argsArray[j] = new Handle(handle.getKind(), slashify(methodRef.declaringClass().getName()), methodRef.name(),
-                    toTypeDesc(methodRef), methodRef.declaringClass().isInterface());
+                argsArray[j] = new Handle(handle.getKind(), slashify(methodRef.declaringClass().getPathPlusClassName()),
+                        methodRef.name(), toTypeDesc(methodRef), methodRef.declaringClass().isInterface());
               } else {
                 SootFieldRef fieldRef = handle.getFieldRef();
-                argsArray[j] = new Handle(handle.getKind(), slashify(fieldRef.declaringClass().getName()), fieldRef.name(),
-                    toTypeDesc(fieldRef.type()), fieldRef.declaringClass().isInterface());
+                argsArray[j] = new Handle(handle.getKind(), slashify(fieldRef.declaringClass().getPathPlusClassName()),
+                        fieldRef.name(), toTypeDesc(fieldRef.type()), fieldRef.declaringClass().isInterface());
               }
             }
 
@@ -1380,22 +1380,22 @@ public class BafASMBackend extends AbstractASMBackend {
         SootMethodRef m = i.getMethodRef();
         SootMethodRef bsm = i.getBootstrapMethodRef();
         mv.visitInvokeDynamicInsn(m.name(), toTypeDesc(m), new Handle(i.getHandleTag(),
-            slashify(bsm.declaringClass().getName()), bsm.name(), toTypeDesc(bsm), bsm.declaringClass().isInterface()),
-            argsArray);
+            slashify(bsm.declaringClass().getPathPlusClassName()), bsm.name(), toTypeDesc(bsm),
+                        bsm.declaringClass().isInterface()), argsArray);
       }
 
       @Override
       public void caseStaticInvokeInst(StaticInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        mv.visitMethodInsn(Opcodes.INVOKESTATIC, slashify(m.declaringClass().getName()), m.name(), toTypeDesc(m),
-            m.declaringClass().isInterface() && !m.isStatic());
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, slashify(m.declaringClass().getPathPlusClassName()), m.name(),
+                toTypeDesc(m), m.declaringClass().isInterface() && !m.isStatic());
       }
 
       @Override
       public void caseVirtualInvokeInst(VirtualInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, slashify(m.declaringClass().getName()), m.name(), toTypeDesc(m),
-            m.declaringClass().isInterface());
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, slashify(m.declaringClass().getPathPlusClassName()), m.name(),
+                toTypeDesc(m), m.declaringClass().isInterface());
       }
 
       @Override
@@ -1411,14 +1411,15 @@ public class BafASMBackend extends AbstractASMBackend {
            */
           isInterface = false;
         }
-        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, slashify(declaration.getName()), m.name(), toTypeDesc(m), isInterface);
+        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, slashify(declaration.getPathPlusClassName()), m.name(),
+                toTypeDesc(m), isInterface);
       }
 
       @Override
       public void caseSpecialInvokeInst(SpecialInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, slashify(m.declaringClass().getName()), m.name(), toTypeDesc(m),
-            m.declaringClass().isInterface());
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, slashify(m.declaringClass().getPathPlusClassName()), m.name(),
+                toTypeDesc(m), m.declaringClass().isInterface());
       }
 
       @Override

--- a/src/main/java/soot/baf/JasminClass.java
+++ b/src/main/java/soot/baf/JasminClass.java
@@ -158,8 +158,9 @@ public class JasminClass extends AbstractJasminClass {
     for (Trap trap : body.getTraps()) {
       handlerUnits.add(trap.getHandlerUnit());
       if (trap.getBeginUnit() != trap.getEndUnit()) {
-        emit(".catch " + slashify(trap.getException().getName()) + " from " + unitToLabel.get(trap.getBeginUnit()) + " to "
-            + unitToLabel.get(trap.getEndUnit()) + " using " + unitToLabel.get(trap.getHandlerUnit()));
+        emit(".catch " + slashify(trap.getException().getPathPlusClassName()) + " from "
+                + unitToLabel.get(trap.getBeginUnit()) + " to " + unitToLabel.get(trap.getEndUnit()) + " using "
+                + unitToLabel.get(trap.getHandlerUnit()));
       }
     }
 
@@ -1297,28 +1298,28 @@ public class JasminClass extends AbstractJasminClass {
       @Override
       public void caseStaticGetInst(StaticGetInst i) {
         SootFieldRef field = i.getFieldRef();
-        emit("getstatic " + slashify(field.declaringClass().getName()) + "/" + field.name() + " "
+        emit("getstatic " + slashify(field.declaringClass().getPathPlusClassName()) + "/" + field.name() + " "
             + jasminDescriptorOf(field.type()));
       }
 
       @Override
       public void caseStaticPutInst(StaticPutInst i) {
         SootFieldRef field = i.getFieldRef();
-        emit("putstatic " + slashify(field.declaringClass().getName()) + "/" + field.name() + " "
+        emit("putstatic " + slashify(field.declaringClass().getPathPlusClassName()) + "/" + field.name() + " "
             + jasminDescriptorOf(field.type()));
       }
 
       @Override
       public void caseFieldGetInst(FieldGetInst i) {
         SootFieldRef field = i.getFieldRef();
-        emit("getfield " + slashify(field.declaringClass().getName()) + "/" + field.name() + " "
+        emit("getfield " + slashify(field.declaringClass().getPathPlusClassName()) + "/" + field.name() + " "
             + jasminDescriptorOf(field.type()));
       }
 
       @Override
       public void caseFieldPutInst(FieldPutInst i) {
         SootFieldRef field = i.getFieldRef();
-        emit("putfield " + slashify(field.declaringClass().getName()) + "/" + field.name() + " "
+        emit("putfield " + slashify(field.declaringClass().getPathPlusClassName()) + "/" + field.name() + " "
             + jasminDescriptorOf(field.type()));
       }
 
@@ -1360,7 +1361,8 @@ public class JasminClass extends AbstractJasminClass {
         str.append("invokedynamic \"").append(m.name()).append("\" ").append(jasminDescriptorOf(m)).append(' ');
 
         SootMethodRef bsm = i.getBootstrapMethodRef();
-        str.append(slashify(bsm.declaringClass().getName())).append('/').append(bsm.name()).append(jasminDescriptorOf(bsm));
+        str.append(slashify(bsm.declaringClass().getPathPlusClassName())).append('/').append(bsm.name())
+                .append(jasminDescriptorOf(bsm));
 
         str.append('(');
         for (Iterator<Value> iterator = i.getBootstrapArgs().iterator(); iterator.hasNext();) {
@@ -1378,33 +1380,36 @@ public class JasminClass extends AbstractJasminClass {
       }
 
       private String escape(String bsmArgString) {
-        return bsmArgString.replace(",", "\\comma").replace(" ", "\\blank").replace("\t", "\\tab").replace("\n",
-            "\\newline");
+        return bsmArgString.replace(",", "\\comma").replace(" ", "\\blank")
+                .replace("\t", "\\tab").replace("\n", "\\newline");
       }
 
       @Override
       public void caseStaticInvokeInst(StaticInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        emit("invokestatic " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m));
+        emit("invokestatic " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name()
+                + jasminDescriptorOf(m));
       }
 
       @Override
       public void caseVirtualInvokeInst(VirtualInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        emit("invokevirtual " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m));
+        emit("invokevirtual " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name()
+                + jasminDescriptorOf(m));
       }
 
       @Override
       public void caseInterfaceInvokeInst(InterfaceInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        emit("invokeinterface " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m) + " "
-            + (argCountOf(m) + 1));
+        emit("invokeinterface " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name()
+                + jasminDescriptorOf(m) + " " + (argCountOf(m) + 1));
       }
 
       @Override
       public void caseSpecialInvokeInst(SpecialInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
-        emit("invokespecial " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m));
+        emit("invokespecial " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name()
+                + jasminDescriptorOf(m));
       }
 
       @Override

--- a/src/main/java/soot/coffi/CFG.java
+++ b/src/main/java/soot/coffi/CFG.java
@@ -1056,7 +1056,7 @@ public class CFG {
 
               if (handlerInstructions.contains(s)) {
                 TypeStack exceptionTypeStack
-                    = (TypeStack.v()).push(RefType.v(handlerInstructionToException.get(s).getName()));
+                    = (TypeStack.v()).push(RefType.v(handlerInstructionToException.get(s).getPathPlusClassName()));
 
                 instructionToTypeStack.put(s, exceptionTypeStack);
               } else {
@@ -1077,7 +1077,7 @@ public class CFG {
                 // single object on the stack.
 
                 TypeStack exceptionTypeStack
-                    = (TypeStack.v()).push(RefType.v(handlerInstructionToException.get(s).getName()));
+                    = (TypeStack.v()).push(RefType.v(handlerInstructionToException.get(s).getPathPlusClassName()));
 
                 newTypeStack = exceptionTypeStack;
               } else {
@@ -3990,7 +3990,7 @@ public class CFG {
         SootClass bclass = cm.getSootClass(getClassName(constant_pool, ((Instruction_New) ins).arg_i));
 
         stmt = Jimple.v().newAssignStmt(Util.v().getLocalForStackOp(listBody, postTypeStack, postTypeStack.topIndex()),
-            Jimple.v().newNewExpr(RefType.v(bclass.getName())));
+            Jimple.v().newNewExpr(RefType.v(bclass.getPathPlusClassName())));
         break;
       }
 

--- a/src/main/java/soot/coffi/Util.java
+++ b/src/main/java/soot/coffi/Util.java
@@ -125,7 +125,7 @@ public class Util {
 
   public void resolveFromClassFile(SootClass aClass, InputStream is, String filePath, Collection<Type> references) {
     SootClass bclass = aClass;
-    String className = bclass.getName();
+    String className = bclass.getPathPlusClassName();
     ClassFile coffiClass = new ClassFile(className);
 
     // Load up class file, and retrieve
@@ -135,7 +135,7 @@ public class Util {
 
       if (!success) {
         if (!Scene.v().allowsPhantomRefs()) {
-          throw new RuntimeException("Could not load classfile: " + bclass.getName());
+          throw new RuntimeException("Could not load classfile: " + bclass.getPathPlusClassName());
         } else {
           logger.warn("" + className + " is a phantom class!");
           bclass.setPhantomClass();
@@ -149,9 +149,10 @@ public class Util {
       String name = ((CONSTANT_Utf8_info) (coffiClass.constant_pool[c.name_index])).convert();
       name = name.replace('/', '.');
 
-      if (!name.equals(bclass.getName())) {
+      if (!name.equals(bclass.getPathPlusClassName())) {
         throw new RuntimeException(
-            "Error: class " + name + " read in from a classfile in which " + bclass.getName() + " was expected.");
+            "Error: class " + name + " read in from a classfile in which " + bclass.getPathPlusClassName()
+                    + " was expected.");
       }
     }
 

--- a/src/main/java/soot/dava/DavaBody.java
+++ b/src/main/java/soot/dava/DavaBody.java
@@ -962,7 +962,7 @@ public class DavaBody extends Body {
 
       addToImportList(className);
 
-      vb.setValue(new DStaticFieldRef(fieldRef, getMethod().getDeclaringClass().getName()));
+      vb.setValue(new DStaticFieldRef(fieldRef, getMethod().getDeclaringClass().getPathPlusClassName()));
     } else if (r instanceof ArrayRef) {
       ArrayRef ar = (ArrayRef) r;
 

--- a/src/main/java/soot/dava/DavaPrinter.java
+++ b/src/main/java/soot/dava/DavaPrinter.java
@@ -234,7 +234,7 @@ public class DavaPrinter {
 
     // Print extension
     if (cl.hasSuperclass()) {
-      String superClassName = cl.getSuperclass().getName();
+      String superClassName = cl.getSuperclass().getPathPlusClassName();
       if (!"java.lang.Object".equals(superClassName)) {
         // Nomair Naeem 8th Feb 2006
         // Also check if the super class name is not a fully qualified name,
@@ -253,9 +253,9 @@ public class DavaPrinter {
           out.print(" implements ");
         }
 
-        out.print(interfaceIt.next().getName());
+        out.print(interfaceIt.next().getPathPlusClassName());
         while (interfaceIt.hasNext()) {
-          out.print(", " + interfaceIt.next().getName());
+          out.print(", " + interfaceIt.next().getPathPlusClassName());
         }
       }
     }

--- a/src/main/java/soot/dava/internal/AST/ASTMethodNode.java
+++ b/src/main/java/soot/dava/internal/AST/ASTMethodNode.java
@@ -286,7 +286,7 @@ public class ASTMethodNode extends ASTNode {
 
       if (constructorExpr != null) {
         boolean printCloseBrace = true;
-        if (davaBody.getMethod().getDeclaringClass().getName()
+        if (davaBody.getMethod().getDeclaringClass().getPathPlusClassName()
             .equals(constructorExpr.getMethodRef().declaringClass().toString())) {
           dup.printString("        this(");
         } else {
@@ -450,7 +450,7 @@ public class ASTMethodNode extends ASTNode {
       InstanceInvokeExpr constructorExpr = davaBody.get_ConstructorExpr();
       if (constructorExpr != null) {
 
-        if (davaBody.getMethod().getDeclaringClass().getName()
+        if (davaBody.getMethod().getDeclaringClass().getPathPlusClassName()
             .equals(constructorExpr.getMethodRef().declaringClass().toString())) {
           b.append("        this(");
         } else {

--- a/src/main/java/soot/dava/internal/AST/ASTTryNode.java
+++ b/src/main/java/soot/dava/internal/AST/ASTTryNode.java
@@ -243,7 +243,7 @@ public class ASTTryNode extends ASTLabeledNode {
       container catchBody = (container) cit.next();
 
       b.append("catch (");
-      b.append(((SootClass) exceptionMap.get(catchBody)).getName());
+      b.append(((SootClass) exceptionMap.get(catchBody)).getPathPlusClassName());
       b.append(" ");
       b.append(((Local) paramMap.get(catchBody)).getName());
       b.append(")");

--- a/src/main/java/soot/dava/internal/javaRep/DStaticFieldRef.java
+++ b/src/main/java/soot/dava/internal/javaRep/DStaticFieldRef.java
@@ -40,7 +40,7 @@ public class DStaticFieldRef extends StaticFieldRef {
 
   public DStaticFieldRef(SootFieldRef fieldRef, String myClassName) {
     super(fieldRef);
-    supressDeclaringClass = myClassName.equals(fieldRef.declaringClass().getName());
+    supressDeclaringClass = myClassName.equals(fieldRef.declaringClass().getPathPlusClassName());
   }
 
   public DStaticFieldRef(SootFieldRef fieldRef, boolean supressDeclaringClass) {

--- a/src/main/java/soot/dava/toolkits/base/AST/interProcedural/ConstantFieldValueFinder.java
+++ b/src/main/java/soot/dava/toolkits/base/AST/interProcedural/ConstantFieldValueFinder.java
@@ -104,9 +104,9 @@ public class ConstantFieldValueFinder {
   private void valuesForPrimTypeFields() {
     // go through all the classes
     for (SootClass s : appClasses) {
-      debug("\nvaluesforPrimTypeFields", "Processing class " + s.getName());
+      debug("\nvaluesforPrimTypeFields", "Processing class " + s.getPathPlusClassName());
 
-      String declaringClass = s.getName();
+      String declaringClass = s.getPathPlusClassName();
       // all fields of the class
       for (SootField f : s.getFields()) {
         Type fieldType = f.getType();
@@ -280,7 +280,7 @@ public class ConstantFieldValueFinder {
   private void computeFieldToValuesAssignedList() {
     // go through all the classes
     for (SootClass s : appClasses) {
-      debug("\ncomputeMethodSummaries", "Processing class " + s.getName());
+      debug("\ncomputeMethodSummaries", "Processing class " + s.getPathPlusClassName());
 
       // go though all the methods
       for (Iterator<SootMethod> methodIt = s.methodIterator(); methodIt.hasNext();) {
@@ -323,7 +323,7 @@ public class ConstantFieldValueFinder {
           }
 
           String fieldName = field.getName();
-          String declaringClass = field.getDeclaringClass().getName();
+          String declaringClass = field.getDeclaringClass().getPathPlusClassName();
 
           debug("\tField Name: " + fieldName);
           debug("\tField DeclaringClass: " + declaringClass);

--- a/src/main/java/soot/dava/toolkits/base/AST/interProcedural/InterProceduralAnalyses.java
+++ b/src/main/java/soot/dava/toolkits/base/AST/interProcedural/InterProceduralAnalyses.java
@@ -85,7 +85,7 @@ public class InterProceduralAnalyses {
         boolean deobfuscate = PhaseOptions.getBoolean(PhaseOptions.v().getPhaseOptions("db.deobfuscate"), "enabled");
         if (deobfuscate) {
           if (DEBUG) {
-            System.out.println("\nSTART CP Class:" + s.getName() + " Method: " + m.getName());
+            System.out.println("\nSTART CP Class:" + s.getPathPlusClassName() + " Method: " + m.getName());
           }
           AST.apply(
               new CPApplication((ASTMethodNode) AST, constantValueFields, finder.getClassNameFieldNameToSootFieldMapping()));

--- a/src/main/java/soot/dava/toolkits/base/AST/structuredAnalysis/CP.java
+++ b/src/main/java/soot/dava/toolkits/base/AST/structuredAnalysis/CP.java
@@ -114,7 +114,7 @@ public class CP extends StructuredAnalysis {
      * DEBUG = true; DEBUG_IF = true; DEBUG_WHILE = true; DEBUG_STATEMENTS = true;
      */
     this.methodNode = analyze;
-    localClassName = analyze.getDavaBody().getMethod().getDeclaringClass().getName();
+    localClassName = analyze.getDavaBody().getMethod().getDeclaringClass().getPathPlusClassName();
 
     // Create a list of VariableValueTuples for all the constantFields
     createConstantFieldsList(constantFields, classNameFieldNameToSootFieldMapping);
@@ -602,7 +602,7 @@ public class CP extends StructuredAnalysis {
       if (toCheck instanceof Local) {
         toCheckClassName = localClassName;
       } else {
-        toCheckClassName = ((FieldRef) toCheck).getField().getDeclaringClass().getName();
+        toCheckClassName = ((FieldRef) toCheck).getField().getDeclaringClass().getPathPlusClassName();
       }
 
       for (CPTuple tempTuple : set) {

--- a/src/main/java/soot/dava/toolkits/base/AST/transformations/CPApplication.java
+++ b/src/main/java/soot/dava/toolkits/base/AST/transformations/CPApplication.java
@@ -77,14 +77,14 @@ public class CPApplication extends DepthFirstAdapter {
 
   public CPApplication(ASTMethodNode AST, HashMap<String, Object> constantValueFields,
       HashMap<String, SootField> classNameFieldNameToSootFieldMapping) {
-    className = AST.getDavaBody().getMethod().getDeclaringClass().getName();
+    className = AST.getDavaBody().getMethod().getDeclaringClass().getPathPlusClassName();
     cp = new CP(AST, constantValueFields, classNameFieldNameToSootFieldMapping);
   }
 
   public CPApplication(boolean verbose, ASTMethodNode AST, HashMap<String, Object> constantValueFields,
       HashMap<String, SootField> classNameFieldNameToSootFieldMapping) {
     super(verbose);
-    className = AST.getDavaBody().getMethod().getDeclaringClass().getName();
+    className = AST.getDavaBody().getMethod().getDeclaringClass().getPathPlusClassName();
     cp = new CP(AST, constantValueFields, classNameFieldNameToSootFieldMapping);
   }
 
@@ -118,7 +118,8 @@ public class CPApplication extends DepthFirstAdapter {
       FieldRef useField = (FieldRef) key;
       // System.out.println("switch key is a FieldRef which is: "+useField);
       SootField usedSootField = useField.getField();
-      Object value = beforeSet.contains(usedSootField.getDeclaringClass().getName(), usedSootField.getName().toString());
+      Object value = beforeSet.contains(usedSootField.getDeclaringClass().getPathPlusClassName(),
+              usedSootField.getName().toString());
       if (value != null) {
         // System.out.println("FieldRef "+usedSootField+"is present in before set with value"+value);
         // create constant value for the value and replace this local
@@ -301,7 +302,8 @@ public class CPApplication extends DepthFirstAdapter {
       } else if (val instanceof FieldRef) {
         FieldRef useField = (FieldRef) val;
         SootField usedSootField = useField.getField();
-        Object value = set.contains(usedSootField.getDeclaringClass().getName(), usedSootField.getName().toString());
+        Object value = set.contains(usedSootField.getDeclaringClass().getPathPlusClassName(),
+                usedSootField.getName().toString());
         if (value != null) {
           // System.out.println("if condition FieldRef "+usedSootField+"is present in before set with value"+value);
           // create constant value for the value and replace this
@@ -382,7 +384,8 @@ public class CPApplication extends DepthFirstAdapter {
         FieldRef useField = (FieldRef) use;
         // System.out.println("FieldRef is: "+useField);
         SootField usedSootField = useField.getField();
-        Object value = beforeSet.contains(usedSootField.getDeclaringClass().getName(), usedSootField.getName().toString());
+        Object value = beforeSet.contains(usedSootField.getDeclaringClass().getPathPlusClassName(),
+                usedSootField.getName().toString());
         if (value != null) {
           // System.out.println("FieldRef "+usedSootField+"is present in before set with value"+value);
           // create constant value for the value and replace this

--- a/src/main/java/soot/dava/toolkits/base/AST/transformations/RemoveEmptyBodyDefaultConstructor.java
+++ b/src/main/java/soot/dava/toolkits/base/AST/transformations/RemoveEmptyBodyDefaultConstructor.java
@@ -51,7 +51,7 @@ public class RemoveEmptyBodyDefaultConstructor {
   public static boolean DEBUG = false;
 
   public static void checkAndRemoveDefault(SootClass s) {
-    debug("\n\nRemoveEmptyBodyDefaultConstructor----" + s.getName());
+    debug("\n\nRemoveEmptyBodyDefaultConstructor----" + s.getPathPlusClassName());
     List methods = s.getMethods();
     Iterator it = methods.iterator();
     List<SootMethod> constructors = new ArrayList<SootMethod>();

--- a/src/main/java/soot/dava/toolkits/base/finders/SynchronizedBlockFinder.java
+++ b/src/main/java/soot/dava/toolkits/base/finders/SynchronizedBlockFinder.java
@@ -873,7 +873,7 @@ public class SynchronizedBlockFinder implements FactFinder {
      * reason for doing this is that synchronized blocks get converted to a try catch block with the catch , catching the
      * throwable exception and this is the ONLY catch
      */
-    if (!en.get_Body().equals(synchBody) || !en.get_Exception().getName().equals(THROWABLE)
+    if (!en.get_Body().equals(synchBody) || !en.get_Exception().getPathPlusClassName().equals(THROWABLE)
         || (en.get_CatchList().size() > 1)) {
       // System.out.println("returning unverified here");
       return false;
@@ -967,7 +967,7 @@ public class SynchronizedBlockFinder implements FactFinder {
 
     // if not a caught exception of type throwable we have a problem
     if (!((asnFrom instanceof CaughtExceptionRef)
-        && (((RefType) ((CaughtExceptionRef) asnFrom).getType()).getSootClass().getName().equals(THROWABLE)))) {
+        && (((RefType) ((CaughtExceptionRef) asnFrom).getType()).getSootClass().getPathPlusClassName().equals(THROWABLE)))) {
       // System.out.println("here4");
       return false;
     }

--- a/src/main/java/soot/dava/toolkits/base/misc/PackageNamer.java
+++ b/src/main/java/soot/dava/toolkits/base/misc/PackageNamer.java
@@ -402,12 +402,12 @@ public class PackageNamer {
 
     Iterator classIt = Scene.v().getLibraryClasses().iterator();
     while (classIt.hasNext()) {
-      add_ClassName(((SootClass) classIt.next()).getName(), otherRoots);
+      add_ClassName(((SootClass) classIt.next()).getPathPlusClassName(), otherRoots);
     }
 
     classIt = Scene.v().getApplicationClasses().iterator();
     while (classIt.hasNext()) {
-      add_ClassName(((SootClass) classIt.next()).getName(), appRoots);
+      add_ClassName(((SootClass) classIt.next()).getPathPlusClassName(), appRoots);
     }
 
     Iterator<NameHolder> arit = appRoots.iterator();

--- a/src/main/java/soot/dava/toolkits/base/misc/ThrowFinder.java
+++ b/src/main/java/soot/dava/toolkits/base/misc/ThrowFinder.java
@@ -218,7 +218,7 @@ public class ThrowFinder {
                   exceptionSet.add(c);
                   changed = true;
                   if (DEBUG) {
-                    System.out.println("Added exception which is explicitly thrown" + c.getName());
+                    System.out.println("Added exception which is explicitly thrown" + c.getPathPlusClassName());
                   }
                 } else {
                   if (DEBUG) {

--- a/src/main/java/soot/dexpler/DexAnnotation.java
+++ b/src/main/java/soot/dexpler/DexAnnotation.java
@@ -489,7 +489,7 @@ public class DexAnnotation {
 
           // If this APK specifies an invalid outer class, we try to
           // repair it
-          if (outerClass.equals(clazz.getName())) {
+          if (outerClass.equals(clazz.getPathPlusClassName())) {
             if (outerClass.contains("$-")) {
               /*
                * This is a special case for generated lambda classes of jack and jill compiler. Generated lambda classes may
@@ -555,7 +555,7 @@ public class DexAnnotation {
           // If we have already set an outer class from some other
           // annotation, we use that
           // one.
-          outerClass = clazz.getOuterClass().getName();
+          outerClass = clazz.getOuterClass().getPathPlusClassName();
         } else if (classType.contains("$-")) {
           /*
            * This is a special case for generated lambda classes of jack and jill compiler. Generated lambda classes may

--- a/src/main/java/soot/dexpler/DexBody.java
+++ b/src/main/java/soot/dexpler/DexBody.java
@@ -949,7 +949,7 @@ public class DexBody {
           if (t instanceof RefType) {
             RefType rt = (RefType) t;
             if (rt.getSootClass().isPhantom() && !rt.getSootClass().hasSuperclass()
-                && !rt.getSootClass().getName().equals("java.lang.Throwable")) {
+                && !rt.getSootClass().getPathPlusClassName().equals("java.lang.Throwable")) {
               rt.getSootClass().setSuperclass(Scene.v().getSootClass("java.lang.Throwable"));
             }
           }

--- a/src/main/java/soot/dexpler/DexClassLoader.java
+++ b/src/main/java/soot/dexpler/DexClassLoader.java
@@ -151,14 +151,14 @@ public class DexClassLoader {
 
           // If the tag is already associated with the outer class,
           // we leave it as it is
-          if (outer.equals(sc.getName())) {
+          if (outer.equals(sc.getPathPlusClassName())) {
             continue;
           }
 
           // Check the inner class to make sure that this tag actually
           // refers to the current class as the inner class
           String inner = ict.getInnerClass().replaceAll("/", ".");
-          if (!inner.equals(sc.getName())) {
+          if (!inner.equals(sc.getPathPlusClassName())) {
             innerTagIt.remove();
             continue;
           }

--- a/src/main/java/soot/dexpler/TrapMinimizer.java
+++ b/src/main/java/soot/dexpler/TrapMinimizer.java
@@ -95,7 +95,7 @@ public class TrapMinimizer extends TrapTransformer {
 
         // If this is the catch-all block and the current unit has an,
         // active monitor, we need to keep the block
-        if (tr.getException().getName().equals("java.lang.Throwable") && unitsWithMonitor.contains(u)) {
+        if (tr.getException().getPathPlusClassName().equals("java.lang.Throwable") && unitsWithMonitor.contains(u)) {
           goesToHandler = true;
         }
 

--- a/src/main/java/soot/dotnet/DotnetClassSource.java
+++ b/src/main/java/soot/dotnet/DotnetClassSource.java
@@ -74,7 +74,7 @@ public class DotnetClassSource extends ClassSource {
   @Override
   public Dependencies resolve(SootClass sc) {
     // If Fake.LdFtn
-    if (sc.getName().equals(DotnetBasicTypes.FAKE_LDFTN)) {
+    if (sc.getPathPlusClassName().equals(DotnetBasicTypes.FAKE_LDFTN)) {
       return DotnetFakeLdFtnType.resolve(sc);
     }
 
@@ -85,7 +85,7 @@ public class DotnetClassSource extends ClassSource {
     // dependencies that might occur
     resolveSignatureDependencies();
 
-    ProtoAssemblyAllTypes.TypeDefinition typeDefinition = assemblyFile.getTypeDefinition(sc.getName());
+    ProtoAssemblyAllTypes.TypeDefinition typeDefinition = assemblyFile.getTypeDefinition(sc.getPathPlusClassName());
     DotnetType dotnetType = new DotnetType(typeDefinition, assemblyFile);
 
     return dotnetType.resolveSootClass(sc);

--- a/src/main/java/soot/dotnet/instructions/CilCallVirtInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilCallVirtInstruction.java
@@ -173,7 +173,7 @@ public class CilCallVirtInstruction extends AbstractCilnstruction {
     List<Type> methodParamTypes = new ArrayList<>();
     if (instruction.getArgumentsCount() == 0) {
       throw new RuntimeException("Opcode: " + instruction.getOpCode() + ": Given method " + method.getName()
-          + " of declared type " + method.getDeclaringClass().getName()
+          + " of declared type " + method.getDeclaringClass().getPathPlusClassName()
           + " has no arguments! This means there is no base variable for the virtual invoke!");
     }
 
@@ -232,7 +232,7 @@ public class CilCallVirtInstruction extends AbstractCilnstruction {
   private void checkMethodAvailable() {
     if (method.getName().trim().isEmpty()) {
       throw new RuntimeException("Opcode: " + instruction.getOpCode() + ": Given method " + method.getName()
-          + " of declared type " + method.getDeclaringClass().getName() + " has no method name!");
+          + " of declared type " + method.getDeclaringClass().getPathPlusClassName() + " has no method name!");
     }
   }
 
@@ -243,7 +243,7 @@ public class CilCallVirtInstruction extends AbstractCilnstruction {
     if (isBase) {
       err += "(base variable)";
     }
-    err += " of invoked method " + method.getName() + " declared in " + clazz.getName() + " is not a local! "
+    err += " of invoked method " + method.getName() + " declared in " + clazz.getPathPlusClassName() + " is not a local! "
         + "The value is: " + var.toString() + " of type " + var.getType() + "! " + "The resolving method body is: "
         + dotnetBody.getDotnetMethodSig().getSootMethodSignature().getSignature();
 

--- a/src/main/java/soot/dotnet/instructions/CilLdMemberTokenInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilLdMemberTokenInstruction.java
@@ -74,7 +74,7 @@ public class CilLdMemberTokenInstruction extends AbstractCilnstruction {
 
       if (method.getName().trim().isEmpty()) {
         throw new RuntimeException("Opcode: " + instruction.getOpCode() + ": Given method " + method.getName()
-            + " of declared type " + method.getDeclaringClass().getName() + " has no method name!");
+            + " of declared type " + method.getDeclaringClass().getPathPlusClassName() + " has no method name!");
       }
       String methodName = method.getUniqueName();
 

--- a/src/main/java/soot/dotnet/members/AbstractDotnetMember.java
+++ b/src/main/java/soot/dotnet/members/AbstractDotnetMember.java
@@ -46,14 +46,14 @@ public abstract class AbstractDotnetMember implements DotnetTypeMember {
      * Normally System.String.Empty == Reftype(System.String), because is string, lead to errors in validation With this
      * fix: System.String.Empty == StringConstant
      */
-    if (declaringClass.getName().equals(DotnetBasicTypes.SYSTEM_STRING) && fieldMethodName.equals("Empty")) {
+    if (declaringClass.getPathPlusClassName().equals(DotnetBasicTypes.SYSTEM_STRING) && fieldMethodName.equals("Empty")) {
       return StringConstant.v("");
     }
     /*
      * If System.Array.Empty, normal RefType(System.Array) Problem with System.Type[] = System.Array.Empty With this fix
      * null constant
      */
-    if (declaringClass.getName().equals(DotnetBasicTypes.SYSTEM_ARRAY) && fieldMethodName.equals("Empty")) {
+    if (declaringClass.getPathPlusClassName().equals(DotnetBasicTypes.SYSTEM_ARRAY) && fieldMethodName.equals("Empty")) {
       // return Jimple.v().newNewExpr(RefType.v(DotnetBasicTypes.SYSTEM_ARRAY));
       return NullConstant.v();
     }

--- a/src/main/java/soot/dotnet/members/DotnetEvent.java
+++ b/src/main/java/soot/dotnet/members/DotnetEvent.java
@@ -108,9 +108,10 @@ public class DotnetEvent extends AbstractDotnetMember {
   private MethodSource createMethodSource(EventDirective eventMethodType) {
     return (m, phaseName) -> {
       // Get body of method
-      AssemblyFile assemblyFile = (AssemblyFile) SourceLocator.v().dexClassIndex().get(declaringClass.getName());
+      AssemblyFile assemblyFile =
+              (AssemblyFile) SourceLocator.v().dexClassIndex().get(declaringClass.getPathPlusClassName());
       ProtoIlInstructions.IlFunctionMsg ilFunctionMsg
-          = assemblyFile.getMethodBodyOfEvent(declaringClass.getName(), protoEvent.getName(), eventMethodType);
+          = assemblyFile.getMethodBodyOfEvent(declaringClass.getPathPlusClassName(), protoEvent.getName(), eventMethodType);
 
       // add jimple body and jimplify
       DotnetMethod dotnetMethod;

--- a/src/main/java/soot/dotnet/members/DotnetMethod.java
+++ b/src/main/java/soot/dotnet/members/DotnetMethod.java
@@ -203,9 +203,10 @@ public class DotnetMethod extends AbstractDotnetMember {
   private MethodSource createMethodSource() {
     return (m, phaseName) -> {
       // Get body of method
-      AssemblyFile assemblyFile = (AssemblyFile) SourceLocator.v().dexClassIndex().get(declaringClass.getName());
+      AssemblyFile assemblyFile =
+              (AssemblyFile) SourceLocator.v().dexClassIndex().get(declaringClass.getPathPlusClassName());
       ProtoIlInstructions.IlFunctionMsg ilFunctionMsg
-          = assemblyFile.getMethodBody(declaringClass.getName(), m.getName(), protoMethod.getPeToken());
+          = assemblyFile.getMethodBody(declaringClass.getPathPlusClassName(), m.getName(), protoMethod.getPeToken());
 
       Body b = this.jimplifyMethodBody(ilFunctionMsg);
       m.setActiveBody(b);
@@ -226,7 +227,7 @@ public class DotnetMethod extends AbstractDotnetMember {
     try {
       if (ilFunctionMsg == null) {
         throw new RuntimeException("Could not resolve JimpleBody for " + dotnetMethodType.name() + " "
-            + sootMethod.getName() + " declared in class " + declaringClass.getName());
+            + sootMethod.getName() + " declared in class " + declaringClass.getPathPlusClassName());
       }
 
       // add the body of this code item
@@ -234,7 +235,7 @@ public class DotnetMethod extends AbstractDotnetMember {
       methodBody.jimplify(b);
     } catch (Exception e) {
       logger.warn("Error while generating jimple body of " + dotnetMethodType.name() + " " + sootMethod.getName()
-          + " declared in class " + declaringClass.getName() + "!");
+          + " declared in class " + declaringClass.getPathPlusClassName() + "!");
       logger.warn(e.getMessage());
       if (Options.v().ignore_methodsource_error()) {
         logger.warn("Ignore errors in generation due to the set parameter. Generate empty Jimple Body.");

--- a/src/main/java/soot/dotnet/members/DotnetProperty.java
+++ b/src/main/java/soot/dotnet/members/DotnetProperty.java
@@ -88,9 +88,10 @@ public class DotnetProperty extends AbstractDotnetMember {
   private MethodSource createPropertyMethodSource(boolean isSetter) {
     return (m, phaseName) -> {
       // Get body of method
-      AssemblyFile assemblyFile = (AssemblyFile) SourceLocator.v().dexClassIndex().get(declaringClass.getName());
+      AssemblyFile assemblyFile =
+              (AssemblyFile) SourceLocator.v().dexClassIndex().get(declaringClass.getPathPlusClassName());
       ProtoIlInstructions.IlFunctionMsg ilFunctionMsg
-          = assemblyFile.getMethodBodyOfProperty(declaringClass.getName(), protoProperty.getName(), isSetter);
+          = assemblyFile.getMethodBodyOfProperty(declaringClass.getPathPlusClassName(), protoProperty.getName(), isSetter);
 
       // add jimple body and jimplify
       DotnetMethod dotnetMethod = isSetter ? setterMethod : getterMethod;

--- a/src/main/java/soot/dotnet/types/DotnetType.java
+++ b/src/main/java/soot/dotnet/types/DotnetType.java
@@ -115,7 +115,7 @@ public class DotnetType {
       if (baseType.getTypeKind().equals(ProtoAssemblyAllTypes.TypeKindDef.INTERFACE)) {
         SootClass superClass = SootResolver.v().makeClassRef(baseType.getFullname());
         // Due to Generics, duplicates can occur - no duplicates
-        if (sootClass.getInterfaces().stream().noneMatch(x -> x.getName().equals(baseType.getFullname()))) {
+        if (sootClass.getInterfaces().stream().noneMatch(x -> x.getPathPlusClassName().equals(baseType.getFullname()))) {
           sootClass.addInterface(superClass);
           deps.typesToHierarchy.add(superClass.getType());
         }
@@ -155,7 +155,7 @@ public class DotnetType {
       // ignore unsafe or call-by-ref params methods if parameter is set
       if (!Options.v().resolve_all_dotnet_methods() && (method.getIsUnsafe()
           // getIsUnsafe is not working right, due to the "to do" in the Soot.Dotnet.Decompiler project
-          || method.getName().equals("InternalCopy") && declaringClass.getName().equals("System.String"))) {
+          || method.getName().equals("InternalCopy") && declaringClass.getPathPlusClassName().equals("System.String"))) {
         continue;
       }
 

--- a/src/main/java/soot/javaToJimple/ClassResolver.java
+++ b/src/main/java/soot/javaToJimple/ClassResolver.java
@@ -120,7 +120,7 @@ public class ClassResolver {
         polyglot.types.ClassType superType = (polyglot.types.ClassType) cDecl.superClass().type();
         // add inner clas tag
 
-        Util.addInnerClassTag(sootClass, sootClass.getName(),
+        Util.addInnerClassTag(sootClass, sootClass.getPathPlusClassName(),
             ((soot.RefType) Util.getSootType(superType.outer())).toString(), superType.name(),
             Util.getModifier(superType.flags()));
       }
@@ -227,7 +227,7 @@ public class ClassResolver {
         // this handles inner class tags for immediately enclosed
         // normal nested classes
         Util.addInnerClassTag(sootClass, Util.getSootType(((polyglot.ast.ClassDecl) next).type()).toString(),
-            sootClass.getName(), ((polyglot.ast.ClassDecl) next).name().toString(),
+            sootClass.getPathPlusClassName(), ((polyglot.ast.ClassDecl) next).name().toString(),
             Util.getModifier(((polyglot.ast.ClassDecl) next).flags()));
       } else if (next instanceof polyglot.ast.Initializer) {
         createInitializer((polyglot.ast.Initializer) next);
@@ -376,7 +376,7 @@ public class ClassResolver {
       if (((polyglot.types.ClassType) aNew.objectType().type()).isNested()) {
         polyglot.types.ClassType superType = (polyglot.types.ClassType) aNew.objectType().type();
         // add inner clas tag
-        Util.addInnerClassTag(sootClass, typeClass.getName(),
+        Util.addInnerClassTag(sootClass, typeClass.getPathPlusClassName(),
             ((soot.RefType) Util.getSootType(superType.outer())).toString(), superType.name(),
             Util.getModifier(superType.flags()));
 
@@ -485,15 +485,17 @@ public class ClassResolver {
     if ((InitialResolver.v().specialAnonMap() != null) && (InitialResolver.v().specialAnonMap().containsKey(addToClass))) {
       return InitialResolver.v().specialAnonMap().get(addToClass);
     } else {
-      String specialClassName = addToClass.getName() + "$" + InitialResolver.v().getNextAnonNum();
+      String specialClassName = addToClass.getPathPlusClassName() + "$" + InitialResolver.v().getNextAnonNum();
       // add class to scene and other maps and lists as needed
       soot.SootClass specialClass = new soot.SootClass(specialClassName);
       soot.Scene.v().addClass(specialClass);
       specialClass.setApplicationClass();
       specialClass.addTag(new SyntheticTag());
       specialClass.setSuperclass(soot.Scene.v().getSootClass(Scene.v().getObjectType().toString()));
-      Util.addInnerClassTag(addToClass, specialClass.getName(), addToClass.getName(), null, soot.Modifier.STATIC);
-      Util.addInnerClassTag(specialClass, specialClass.getName(), addToClass.getName(), null, soot.Modifier.STATIC);
+      Util.addInnerClassTag(addToClass, specialClass.getPathPlusClassName(), addToClass.getPathPlusClassName(),
+              null, soot.Modifier.STATIC);
+      Util.addInnerClassTag(specialClass, specialClass.getPathPlusClassName(), addToClass.getPathPlusClassName(),
+              null, soot.Modifier.STATIC);
       InitialResolver.v().addNameToAST(specialClassName);
       references.add(RefType.v(specialClassName));
       if (InitialResolver.v().specialAnonMap() == null) {
@@ -542,9 +544,9 @@ public class ClassResolver {
     // this field is named after the outer class even if the outer
     // class is an interface and will be actually added to the
     // special interface anon class
-    fieldName = "class$" + addToClass.getName().replaceAll(".", "$");
+    fieldName = "class$" + addToClass.getPathPlusClassName().replaceAll(".", "$");
     if ((InitialResolver.v().getInterfacesList() != null)
-        && (InitialResolver.v().getInterfacesList().contains(addToClass.getName()))) {
+        && (InitialResolver.v().getInterfacesList().contains(addToClass.getPathPlusClassName()))) {
       addToClass = getSpecialInterfaceAnonClass(addToClass);
     }
 
@@ -728,7 +730,7 @@ public class ClassResolver {
       sootClass.addTag(t);
     }
 
-    String simpleName = sootClass.getName();
+    String simpleName = sootClass.getPathPlusClassName();
 
     boolean found = false;
 
@@ -803,8 +805,8 @@ public class ClassResolver {
       // hasTag(OuterClassTag.NAME)){
 
       InnerClassInfo tag = InitialResolver.v().getInnerClassInfoMap().get(sootClass);
-      Util.addInnerClassTag(sootClass, sootClass.getName(),
-          tag.getInnerType() == InnerClassInfo.ANON ? null : tag.getOuterClass().getName(),
+      Util.addInnerClassTag(sootClass, sootClass.getPathPlusClassName(),
+          tag.getInnerType() == InnerClassInfo.ANON ? null : tag.getOuterClass().getPathPlusClassName(),
           tag.getInnerType() == InnerClassInfo.ANON ? null : tag.getSimpleName(),
           soot.Modifier.isInterface(tag.getOuterClass().getModifiers()) ? soot.Modifier.STATIC | soot.Modifier.PUBLIC
               : sootClass.getModifiers());
@@ -813,8 +815,8 @@ public class ClassResolver {
       SootClass outerClass = tag.getOuterClass();
       while (InitialResolver.v().getInnerClassInfoMap().containsKey(outerClass)) {
         InnerClassInfo tag2 = InitialResolver.v().getInnerClassInfoMap().get(outerClass);
-        Util.addInnerClassTag(sootClass, outerClass.getName(),
-            tag2.getInnerType() == InnerClassInfo.ANON ? null : tag2.getOuterClass().getName(),
+        Util.addInnerClassTag(sootClass, outerClass.getPathPlusClassName(),
+            tag2.getInnerType() == InnerClassInfo.ANON ? null : tag2.getOuterClass().getPathPlusClassName(),
             tag2.getInnerType() == InnerClassInfo.ANON ? null : tag2.getSimpleName(),
             tag2.getInnerType() == InnerClassInfo.ANON && soot.Modifier.isInterface(tag2.getOuterClass().getModifiers())
                 ? soot.Modifier.STATIC | soot.Modifier.PUBLIC

--- a/src/main/java/soot/javaToJimple/JimpleBodyBuilder.java
+++ b/src/main/java/soot/javaToJimple/JimpleBodyBuilder.java
@@ -113,7 +113,7 @@ public class JimpleBodyBuilder extends AbstractJimpleBodyBuilder {
 
     // create outer class this param ref for inner classes except for static
     // inner classes - this is not needed
-    int outerIndex = sootMethod.getDeclaringClass().getName().lastIndexOf("$");
+    int outerIndex = sootMethod.getDeclaringClass().getPathPlusClassName().lastIndexOf("$");
 
     if ((outerIndex != -1) && (sootMethod.getName().equals("<init>"))) {
       SootField this0Field = sootMethod.getDeclaringClass().getFieldByNameUnsafe("this$0");
@@ -523,8 +523,9 @@ public class JimpleBodyBuilder extends AbstractJimpleBodyBuilder {
       while (!fieldFound) {
         if (!currentClass.declaresFieldByName("this$0")) {
           throw new RuntimeException(
-              "Trying to get field val$" + li.name() + " from some outer class but can't access the outer class of: "
-                  + currentClass.getName() + "!" + " current class contains fields: " + currentClass.getFields());
+                  "Trying to get field val$" + li.name() + " from some outer class but can't access the outer class of: "
+                      + currentClass.getPathPlusClassName() + "!" + " current class contains fields: "
+                      + currentClass.getFields());
         }
         soot.SootClass outerClass = ((soot.RefType) currentClass.getFieldByName("this$0").getType()).getSootClass();
         // look for field of type li.type and name val$li.name in outer

--- a/src/main/java/soot/javaToJimple/PolyglotMethodSource.java
+++ b/src/main/java/soot/javaToJimple/PolyglotMethodSource.java
@@ -126,8 +126,8 @@ public class PolyglotMethodSource implements MethodSource {
       assertStatusClass = innerMap.get(assertStatusClass).getOuterClass();
     }
 
-    String paramName = assertStatusClass.getName();
-    String fieldName = "class$" + assertStatusClass.getName().replaceAll(".", "$");
+    String paramName = assertStatusClass.getPathPlusClassName();
+    String fieldName = "class$" + assertStatusClass.getPathPlusClassName().replaceAll(".", "$");
 
     if (assertStatusClass.isInterface()) {
       assertStatusClass = InitialResolver.v().specialAnonMap().get(assertStatusClass);

--- a/src/main/java/soot/javaToJimple/Util.java
+++ b/src/main/java/soot/javaToJimple/Util.java
@@ -132,7 +132,7 @@ public class Util {
   }
 
   public static String getSourceFileOfClass(soot.SootClass sootClass) {
-    String name = sootClass.getName();
+    String name = sootClass.getPathPlusClassName();
     int index = name.indexOf("$");
 
     // inner classes are found in the very outer class

--- a/src/main/java/soot/jbco/bafTransformations/ConstructorConfuser.java
+++ b/src/main/java/soot/jbco/bafTransformations/ConstructorConfuser.java
@@ -92,7 +92,8 @@ public class ConstructorConfuser extends BodyTransformer implements IJbcoTransfo
       if (u instanceof SpecialInvokeInst) {
         sii = (SpecialInvokeInst) u;
         SootMethodRef smr = sii.getMethodRef();
-        if (c == null || !smr.declaringClass().getName().equals(c.getName()) || !smr.name().equals("<init>")) {
+        if (c == null || !smr.declaringClass().getPathPlusClassName().equals(c.getPathPlusClassName()) ||
+                !smr.name().equals("<init>")) {
           sii = null;
         } else {
           break;
@@ -126,7 +127,8 @@ public class ConstructorConfuser extends BodyTransformer implements IJbcoTransfo
           Map<Local, Local> locals = soot.jbco.Main.methods2Baf2JLocals.get(b.getMethod());
           if (locals != null && locals.containsKey(bl)) {
             Type t = ((Local) locals.get(bl)).getType();
-            if (t instanceof RefType && ((RefType) t).getSootClass().getName().equals(origClass.getName())) {
+            if (t instanceof RefType && ((RefType) t).getSootClass().getPathPlusClassName()
+                    .equals(origClass.getPathPlusClassName())) {
               units.insertBefore(Baf.v().newDup1Inst(RefType.v()), sii);
               Unit ifinst = Baf.v().newIfNullInst(sii);
               units.insertBeforeNoRedirect(ifinst, sii);
@@ -162,7 +164,7 @@ public class ConstructorConfuser extends BodyTransformer implements IJbcoTransfo
         if (sii.getMethodRef().parameterTypes().size() == 0
             && !BodyBuilder.isExceptionCaughtAt(units, sii, b.getTraps().iterator())) {
           while (c != null) {
-            if (c.getName().equals("java.lang.Throwable")) {
+            if (c.getPathPlusClassName().equals("java.lang.Throwable")) {
               Unit throwThis = Baf.v().newThrowInst();
               units.insertBefore(throwThis, sii);
               b.getTraps().add(Baf.v().newTrap(origClass, throwThis, sii, sii));

--- a/src/main/java/soot/jbco/bafTransformations/TryCatchCombiner.java
+++ b/src/main/java/soot/jbco/bafTransformations/TryCatchCombiner.java
@@ -295,12 +295,12 @@ public class TryCatchCombiner extends BodyTransformer implements IJbcoTransform 
 
     // ignore runtime try blocks - these may have weird side-effects do to asynchronous exceptions
     SootClass exc = t.getException();
-    if (exc.getName().equals("java.lang.Throwable")) {
+    if (exc.getPathPlusClassName().equals("java.lang.Throwable")) {
       return false;
     }
 
     do {
-      if (exc.getName().equals("java.lang.RuntimeException")) {
+      if (exc.getPathPlusClassName().equals("java.lang.RuntimeException")) {
         return false;
       }
     } while (exc.hasSuperclass() && (exc = exc.getSuperclass()) != null);

--- a/src/main/java/soot/jbco/jimpleTransformations/BuildIntermediateAppClasses.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/BuildIntermediateAppClasses.java
@@ -110,7 +110,7 @@ public class BuildIntermediateAppClasses extends SceneTransformer implements IJb
       SootClass originalSuperclass = sc.getSuperclass();
 
       if (output) {
-        out.println("Processing " + sc.getName() + " with super " + originalSuperclass.getName());
+        out.println("Processing " + sc.getPathPlusClassName() + " with super " + originalSuperclass.getPathPlusClassName());
       }
 
       Iterator<SootMethod> methodIterator = sc.methodIterator();
@@ -146,7 +146,8 @@ public class BuildIntermediateAppClasses extends SceneTransformer implements IJb
       }
 
       if (methodsToAdd.size() > 0) {
-        final String fullName = ClassRenamer.v().getOrAddNewName(ClassRenamer.getPackageName(sc.getName()), null);
+        final String fullName = ClassRenamer.v().getOrAddNewName(
+                ClassRenamer.getPackageName(sc.getPathPlusClassName()), null);
 
         if (output) {
           out.println("\tBuilding " + fullName);
@@ -236,7 +237,8 @@ public class BuildIntermediateAppClasses extends SceneTransformer implements IJb
               if (v instanceof SpecialInvokeExpr) {
                 SpecialInvokeExpr sie = (SpecialInvokeExpr) v;
                 SootMethodRef smr = sie.getMethodRef();
-                if (sie.getBase().equivTo(thisLocal) && smr.declaringClass().getName().equals(originalSuperclass.getName())
+                if (sie.getBase().equivTo(thisLocal) &&
+                        smr.declaringClass().getPathPlusClassName().equals(originalSuperclass.getPathPlusClassName())
                     && smr.getSubSignature().getString().startsWith("void " + constructorName)) {
                   SootMethod newSuperInit;
                   if (!mediatingClass.declaresMethod(constructorName, smr.parameterTypes())) {

--- a/src/main/java/soot/jbco/jimpleTransformations/ClassRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/ClassRenamer.java
@@ -211,7 +211,7 @@ public class ClassRenamer extends SceneTransformer implements IJbcoTransform {
 
     for (SootClass applicationClass : Scene.v().getApplicationClasses()) {
 
-      final String fullyQualifiedName = applicationClass.getName();
+      final String fullyQualifiedName = applicationClass.getPathPlusClassName();
 
       if (applicationClass.equals(mainClass) || oldToNewClassNames.containsValue(fullyQualifiedName)
           || soot.jbco.Main.getWeight(phaseName, fullyQualifiedName) == 0) {

--- a/src/main/java/soot/jbco/jimpleTransformations/FieldRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/FieldRenamer.java
@@ -169,7 +169,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
     BodyBuilder.retrieveAllNames();
 
     for (SootClass applicationClass : Scene.v().getApplicationClasses()) {
-      String className = applicationClass.getName();
+      String className = applicationClass.getPathPlusClassName();
       if (className.contains(".")) {
         className = className.substring(className.lastIndexOf(".") + 1);
       }
@@ -178,7 +178,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
 
       if (renameFields) {
         if (isVerbose()) {
-          logger.info("Class [{}]", applicationClass.getName());
+          logger.info("Class [{}]", applicationClass.getPathPlusClassName());
         }
         // rename all the fields in the class
         for (SootField field : applicationClass.getFields()) {
@@ -248,7 +248,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
               }
 
               final String oldName = sootFieldRef.name();
-              final String fullyQualifiedName = sootFieldRef.declaringClass().getName() + '.' + oldName;
+              final String fullyQualifiedName = sootFieldRef.declaringClass().getPathPlusClassName() + '.' + oldName;
               if (skipFields.contains(fullyQualifiedName)) {
                 continue;
               }
@@ -272,7 +272,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
                 sootFieldRef.resolve();
               } catch (Exception exception) {
                 logger.error("Cannot rename field \"" + oldName + "\" to \"" + newName + "\" due to error.", exception);
-                logger.info("Fields of {}: {}", sootFieldRef.declaringClass().getName(),
+                logger.info("Fields of {}: {}", sootFieldRef.declaringClass().getPathPlusClassName(),
                     sootFieldRef.declaringClass().getFields());
                 throw new RuntimeException(exception);
               }
@@ -321,7 +321,7 @@ public class FieldRenamer extends SceneTransformer implements IJbcoTransform {
   }
 
   protected void renameField(SootClass sootClass, SootField field) {
-    final String fullyQualifiedName = sootClass.getName() + "." + field.getName();
+    final String fullyQualifiedName = sootClass.getPathPlusClassName() + "." + field.getName();
 
     final String newName = getOrAddNewName(field.getName());
     if (isVerbose()) {

--- a/src/main/java/soot/jbco/jimpleTransformations/LibraryMethodWrappersBuilder.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/LibraryMethodWrappersBuilder.java
@@ -120,7 +120,7 @@ public class LibraryMethodWrappersBuilder extends SceneTransformer implements IJ
       final SootClass applicationClass = applicationClassesIterator.next();
 
       if (isVerbose()) {
-        logger.info("\tProcessing class {}", applicationClass.getName());
+        logger.info("\tProcessing class {}", applicationClass.getPathPlusClassName());
       }
 
       // create local copy to prevent java.util.ConcurrentModificationException

--- a/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
+++ b/src/main/java/soot/jbco/jimpleTransformations/MethodRenamer.java
@@ -196,7 +196,7 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
    * @return the map where the key is old method name, the value - new method name. Never {@code null}
    */
   public Map<String, String> getRenamingMap(String className) {
-    return classToRenamingMap.entrySet().stream().filter(entry -> entry.getKey().getName().equals(className))
+    return classToRenamingMap.entrySet().stream().filter(entry -> entry.getKey().getPathPlusClassName().equals(className))
         .flatMap(entry -> entry.getValue().entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
@@ -236,7 +236,7 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
         if (libraryClass.isPresent()) {
           if (isVerbose()) {
             logger.info("Skipping renaming {} method as it overrides library one from {}.", method.getSignature(),
-                libraryClass.get().getName());
+                libraryClass.get().getPathPlusClassName());
           }
 
           continue;
@@ -326,7 +326,7 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
             if (declaringLibraryClass.isPresent()) {
               if (isVerbose()) {
                 logger.info("Skipping replacing method call \"{}\" in \"{}\" as it is overrides one " + " from library {}.",
-                    methodRef.getSignature(), method.getSignature(), declaringLibraryClass.get().getName());
+                    methodRef.getSignature(), method.getSignature(), declaringLibraryClass.get().getPathPlusClassName());
               }
               continue;
             }
@@ -481,7 +481,7 @@ public class MethodRenamer extends SceneTransformer implements IJbcoTransform {
 
   private Set<SootClass> getChildrenOfIncluding(Collection<SootClass> classes) {
     return Stream
-        .concat(classes.stream().filter(c -> !c.getName().equals("java.lang.Object"))
+        .concat(classes.stream().filter(c -> !c.getPathPlusClassName().equals("java.lang.Object"))
             .map(c -> c.isInterface() ? Scene.v().getActiveHierarchy().getImplementersOf(c)
                 : Scene.v().getActiveHierarchy().getSubclassesOf(c))
             .flatMap(Collection::stream), classes.stream())

--- a/src/main/java/soot/jbco/util/BodyBuilder.java
+++ b/src/main/java/soot/jbco/util/BodyBuilder.java
@@ -95,7 +95,7 @@ public class BodyBuilder {
     // iterate through application classes, rename fields with junk
 
     for (SootClass c : soot.Scene.v().getApplicationClasses()) {
-      nameList.add(c.getName());
+      nameList.add(c.getPathPlusClassName());
 
       for (SootMethod m : c.getMethods()) {
         nameList.add(m.getName());

--- a/src/main/java/soot/jimple/JasminClass.java
+++ b/src/main/java/soot/jimple/JasminClass.java
@@ -164,8 +164,9 @@ public class JasminClass extends AbstractJasminClass {
     // Emit the exceptions
     for (Trap trap : body.getTraps()) {
       if (trap.getBeginUnit() != trap.getEndUnit()) {
-        emit(".catch " + slashify(trap.getException().getName()) + " from " + unitToLabel.get(trap.getBeginUnit()) + " to "
-            + unitToLabel.get(trap.getEndUnit()) + " using " + unitToLabel.get(trap.getHandlerUnit()));
+        emit(".catch " + slashify(trap.getException().getPathPlusClassName()) + " from "
+                + unitToLabel.get(trap.getBeginUnit()) + " to "
+                + unitToLabel.get(trap.getEndUnit()) + " using " + unitToLabel.get(trap.getHandlerUnit()));
       }
     }
 
@@ -569,8 +570,9 @@ public class JasminClass extends AbstractJasminClass {
         emitValue(v.getBase());
         emitValue(rvalue);
 
-        emit("putfield " + slashify(v.getFieldRef().declaringClass().getName()) + '/' + v.getFieldRef().name() + ' '
-            + jasminDescriptorOf(v.getFieldRef().type()), -1 + -sizeOfType(v.getFieldRef().type()));
+        emit("putfield " + slashify(v.getFieldRef().declaringClass().getPathPlusClassName()) + '/'
+                        + v.getFieldRef().name() + ' ' + jasminDescriptorOf(v.getFieldRef().type()),
+                -1 + -sizeOfType(v.getFieldRef().type()));
       }
 
       @Override
@@ -693,7 +695,7 @@ public class JasminClass extends AbstractJasminClass {
         SootFieldRef field = v.getFieldRef();
 
         emitValue(rvalue);
-        emit("putstatic " + slashify(field.declaringClass().getName()) + '/' + field.name() + ' '
+        emit("putstatic " + slashify(field.declaringClass().getPathPlusClassName()) + '/' + field.name() + ' '
             + jasminDescriptorOf(field.type()), -sizeOfType(v.getFieldRef().type()));
       }
     });
@@ -1940,7 +1942,7 @@ public class JasminClass extends AbstractJasminClass {
       public void caseInstanceFieldRef(InstanceFieldRef v) {
         emitValue(v.getBase());
         SootFieldRef field = v.getFieldRef();
-        emit("getfield " + slashify(field.declaringClass().getName()) + '/' + field.name() + ' '
+        emit("getfield " + slashify(field.declaringClass().getPathPlusClassName()) + '/' + field.name() + ' '
             + jasminDescriptorOf(field.type()), -1 + sizeOfType(field.type()));
       }
 
@@ -1981,8 +1983,9 @@ public class JasminClass extends AbstractJasminClass {
           emitValue(v.getArg(i));
         }
 
-        emit("invokeinterface " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m) + " "
-            + (argCountOf(m) + 1), -(argCountOf(m) + 1) + sizeOfType(m.returnType()));
+        emit("invokeinterface " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name()
+                        + jasminDescriptorOf(m) + " " + (argCountOf(m) + 1),
+                -(argCountOf(m) + 1) + sizeOfType(m.returnType()));
       }
 
       @Override
@@ -2544,7 +2547,7 @@ public class JasminClass extends AbstractJasminClass {
           emitValue(v.getArg(i));
         }
 
-        emit("invokespecial " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m),
+        emit("invokespecial " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name() + jasminDescriptorOf(m),
             -(argCountOf(m) + 1) + sizeOfType(m.returnType()));
       }
 
@@ -2760,7 +2763,7 @@ public class JasminClass extends AbstractJasminClass {
           emitValue(v.getArg(i));
         }
 
-        emit("invokespecial " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m),
+        emit("invokespecial " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name() + jasminDescriptorOf(m),
             -(argCountOf(m) + 1) + sizeOfType(m.returnType()));
       }
 
@@ -2771,14 +2774,14 @@ public class JasminClass extends AbstractJasminClass {
           emitValue(v.getArg(i));
         }
 
-        emit("invokestatic " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m),
+        emit("invokestatic " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name() + jasminDescriptorOf(m),
             -(argCountOf(m)) + sizeOfType(m.returnType()));
       }
 
       @Override
       public void caseStaticFieldRef(StaticFieldRef v) {
         SootFieldRef field = v.getFieldRef();
-        emit("getstatic " + slashify(field.declaringClass().getName()) + "/" + field.name() + " "
+        emit("getstatic " + slashify(field.declaringClass().getPathPlusClassName()) + "/" + field.name() + " "
             + jasminDescriptorOf(field.type()), sizeOfType(field.type()));
       }
 
@@ -2905,7 +2908,7 @@ public class JasminClass extends AbstractJasminClass {
           emitValue(v.getArg(i));
         }
 
-        emit("invokevirtual " + slashify(m.declaringClass().getName()) + "/" + m.name() + jasminDescriptorOf(m),
+        emit("invokevirtual " + slashify(m.declaringClass().getPathPlusClassName()) + "/" + m.name() + jasminDescriptorOf(m),
             -(argCountOf(m) + 1) + sizeOfType(m.returnType()));
       }
 

--- a/src/main/java/soot/jimple/internal/AbstractBinopExpr.java
+++ b/src/main/java/soot/jimple/internal/AbstractBinopExpr.java
@@ -203,7 +203,7 @@ public abstract class AbstractBinopExpr implements Expr {
     if (superclass == null) {
       return false;
     }
-    if (superclass.getName().equals(DotnetBasicTypes.SYSTEM_ENUM)) {
+    if (superclass.getPathPlusClassName().equals(DotnetBasicTypes.SYSTEM_ENUM)) {
       return true;
     }
     return false;

--- a/src/main/java/soot/jimple/internal/JVirtualInvokeExpr.java
+++ b/src/main/java/soot/jimple/internal/JVirtualInvokeExpr.java
@@ -47,8 +47,9 @@ public class JVirtualInvokeExpr extends AbstractVirtualInvokeExpr {
       // now check if the class is valid
       if (sc.isInterface()) {
         SourceFileTag tag = (SourceFileTag) sc.getTag(SourceFileTag.NAME);
-        throw new RuntimeException("Trying to create virtual invoke expression for interface type (" + sc.getName()
-            + " in file " + (tag != null ? tag.getAbsolutePath() : "unknown") + "). Use JInterfaceInvokeExpr instead!");
+        throw new RuntimeException("Trying to create virtual invoke expression for interface type ("
+                + sc.getPathPlusClassName() + " in file " + (tag != null ? tag.getAbsolutePath() : "unknown")
+                + "). Use JInterfaceInvokeExpr instead!");
       }
     }
 

--- a/src/main/java/soot/jimple/parser/BodyExtractorWalker.java
+++ b/src/main/java/soot/jimple/parser/BodyExtractorWalker.java
@@ -80,8 +80,8 @@ public class BodyExtractorWalker extends Walker {
     }
 
     String className = (String) mProductions.removeLast();
-    if (!className.equals(mSootClass.getName())) {
-      throw new RuntimeException("expected:  " + className + ", but got: " + mSootClass.getName());
+    if (!className.equals(mSootClass.getPathPlusClassName())) {
+      throw new RuntimeException("expected:  " + className + ", but got: " + mSootClass.getPathPlusClassName());
     }
 
     if (node.getExtendsClause() != null) {

--- a/src/main/java/soot/jimple/parser/SkeletonExtractorWalker.java
+++ b/src/main/java/soot/jimple/parser/SkeletonExtractorWalker.java
@@ -72,8 +72,8 @@ public class SkeletonExtractorWalker extends Walker {
       mSootClass = new SootClass(className);
       mSootClass.setResolvingLevel(SootClass.SIGNATURES);
     } else {
-      if (!className.equals(mSootClass.getName())) {
-        throw new RuntimeException("expected:  " + className + ", but got: " + mSootClass.getName());
+      if (!className.equals(mSootClass.getPathPlusClassName())) {
+        throw new RuntimeException("expected:  " + className + ", but got: " + mSootClass.getPathPlusClassName());
       }
     }
 

--- a/src/main/java/soot/jimple/parser/Walker.java
+++ b/src/main/java/soot/jimple/parser/Walker.java
@@ -293,9 +293,9 @@ public class Walker extends DepthFirstAdapter {
       mSootClass = new SootClass(className);
       mSootClass.setResolvingLevel(SootClass.BODIES);
     } else {
-      if (!mSootClass.getName().equals(className)) {
+      if (!mSootClass.getPathPlusClassName().equals(className)) {
         throw new RuntimeException("Invalid SootClass for this JimpleAST. The SootClass provided is of type: >"
-            + mSootClass.getName() + "< whereas this parse tree is for type: >" + className + "<");
+            + mSootClass.getPathPlusClassName() + "< whereas this parse tree is for type: >" + className + "<");
       }
     }
 

--- a/src/main/java/soot/jimple/spark/builder/MethodNodeFactory.java
+++ b/src/main/java/soot/jimple/spark/builder/MethodNodeFactory.java
@@ -172,7 +172,7 @@ public class MethodNodeFactory extends AbstractShimpleValueSwitch {
           StaticFieldRef sfr = (StaticFieldRef) r;
           SootFieldRef s = sfr.getFieldRef();
           if (pag.getOpts().empties_as_allocs()) {
-            if (s.declaringClass().getName().equals("java.util.Collections")) {
+            if (s.declaringClass().getPathPlusClassName().equals("java.util.Collections")) {
               if (s.name().equals("EMPTY_SET")) {
                 src = pag.makeAllocNode(rtHashSet, rtHashSet, method);
               } else if (s.name().equals("EMPTY_MAP")) {
@@ -180,7 +180,7 @@ public class MethodNodeFactory extends AbstractShimpleValueSwitch {
               } else if (s.name().equals("EMPTY_LIST")) {
                 src = pag.makeAllocNode(rtLinkedList, rtLinkedList, method);
               }
-            } else if (s.declaringClass().getName().equals("java.util.Hashtable")) {
+            } else if (s.declaringClass().getPathPlusClassName().equals("java.util.Hashtable")) {
               if (s.name().equals("emptyIterator")) {
                 src = pag.makeAllocNode(rtHashtableEmptyIterator, rtHashtableEmptyIterator, method);
               } else if (s.name().equals("emptyEnumerator")) {
@@ -248,7 +248,7 @@ public class MethodNodeFactory extends AbstractShimpleValueSwitch {
       VirtualInvokeExpr vie = (VirtualInvokeExpr) iexpr;
       if (vie.getBase().getType() instanceof RefType) {
         RefType rt = (RefType) vie.getBase().getType();
-        if (rt.getSootClass().getName().equals("java.lang.Class")) {
+        if (rt.getSootClass().getPathPlusClassName().equals("java.lang.Class")) {
           SootMethodRef ref = vie.getMethodRef();
           if (ref.getName().equals("newInstance") && ref.getParameterTypes().size() == 0) {
             return true;
@@ -443,7 +443,7 @@ public class MethodNodeFactory extends AbstractShimpleValueSwitch {
   public void caseStaticInvokeExpr(StaticInvokeExpr v) {
     SootMethodRef ref = v.getMethodRef();
     if (v.getArgCount() == 1 && v.getArg(0) instanceof StringConstant && ref.name().equals("forName")
-        && ref.declaringClass().getName().equals("java.lang.Class") && ref.parameterTypes().size() == 1) {
+        && ref.declaringClass().getPathPlusClassName().equals("java.lang.Class") && ref.parameterTypes().size() == 1) {
       // This is a call to Class.forName
       StringConstant classNameConst = (StringConstant) v.getArg(0);
       caseClassConstant(ClassConstant.v("L" + classNameConst.value.replaceAll("\\.", "/") + ";"));

--- a/src/main/java/soot/jimple/spark/fieldrw/FieldRWTag.java
+++ b/src/main/java/soot/jimple/spark/fieldrw/FieldRWTag.java
@@ -41,7 +41,7 @@ public abstract class FieldRWTag implements Tag {
       } else {
         sb.append('%');
       }
-      sb.append(field.getDeclaringClass().getName());
+      sb.append(field.getDeclaringClass().getPathPlusClassName());
       sb.append(':');
       sb.append(field.getName());
     }

--- a/src/main/java/soot/jimple/spark/ondemand/pautil/DumpNumAppReachableMethods.java
+++ b/src/main/java/soot/jimple/spark/ondemand/pautil/DumpNumAppReachableMethods.java
@@ -53,7 +53,7 @@ public class DumpNumAppReachableMethods extends SceneTransformer {
   }
 
   private boolean isAppMethod(final SootMethod m) {
-    return !SootUtil.inLibrary(m.getDeclaringClass().getName());
+    return !SootUtil.inLibrary(m.getDeclaringClass().getPathPlusClassName());
   }
 
   /**

--- a/src/main/java/soot/jimple/spark/pag/MethodPAG.java
+++ b/src/main/java/soot/jimple/spark/pag/MethodPAG.java
@@ -298,7 +298,7 @@ public final class MethodPAG {
     if (isImplicit) {
       SootClass c = method.getDeclaringClass();
       outer: do {
-        while (!c.getName().equals("java.lang.ClassLoader")) {
+        while (!c.getPathPlusClassName().equals("java.lang.ClassLoader")) {
           if (!c.hasSuperclass()) {
             break outer;
           }

--- a/src/main/java/soot/jimple/spark/pag/PAG.java
+++ b/src/main/java/soot/jimple/spark/pag/PAG.java
@@ -610,7 +610,7 @@ public class PAG implements PointsToAnalysis {
       if (m == null) {
         tag = new StringTag(node.toString());
       } else {
-        tag = new LinkTag(node.toString(), m, m.getDeclaringClass().getName());
+        tag = new LinkTag(node.toString(), m, m.getDeclaringClass().getPathPlusClassName());
       }
       nodeToTag.put(node, tag);
     }

--- a/src/main/java/soot/jimple/spark/pag/PagToDotDumper.java
+++ b/src/main/java/soot/jimple/spark/pag/PagToDotDumper.java
@@ -116,9 +116,9 @@ public class PagToDotDumper {
     if (base1 instanceof LocalVarNode && base2 instanceof LocalVarNode) {
       LocalVarNode lvn1 = (LocalVarNode) base1;
       LocalVarNode lvn2 = (LocalVarNode) base2;
-      if (lvn1.getMethod().getDeclaringClass().getName().equals("java.util.Hashtable$ValueCollection")
+      if (lvn1.getMethod().getDeclaringClass().getPathPlusClassName().equals("java.util.Hashtable$ValueCollection")
           && lvn1.getMethod().getName().equals("contains")
-          && lvn2.getMethod().getDeclaringClass().getName().equals("java.util.Hashtable$ValueCollection")
+          && lvn2.getMethod().getDeclaringClass().getPathPlusClassName().equals("java.util.Hashtable$ValueCollection")
           && lvn2.getMethod().getName().equals("<init>")) {
         System.err.println("Method: " + lvn1.getMethod().getName());
         System.err.println(makeLabel(frn1));
@@ -197,7 +197,7 @@ public class PagToDotDumper {
    * @return
    */
   private boolean isDefinedIn(LocalVarNode lvNode, String cName, String mName) {
-    return lvNode.getMethod() != null && lvNode.getMethod().getDeclaringClass().getName().equals(cName)
+    return lvNode.getMethod() != null && lvNode.getMethod().getDeclaringClass().getPathPlusClassName().equals(cName)
         && lvNode.getMethod().getName().equals(mName);
   }
 

--- a/src/main/java/soot/jimple/spark/solver/PropAlias.java
+++ b/src/main/java/soot/jimple/spark/solver/PropAlias.java
@@ -225,7 +225,7 @@ public class PropAlias extends Propagator {
                 // we do this now
                 SootClass targetClass = ((RefType) ccnType).getSootClass();
                 if (targetClass.resolvingLevel() == SootClass.DANGLING) {
-                  Scene.v().forceResolve(targetClass.getName(), SootClass.SIGNATURES);
+                  Scene.v().forceResolve(targetClass.getPathPlusClassName(), SootClass.SIGNATURES);
                 }
 
                 edgeTgt.makeP2Set().add(pag.makeAllocNode(edgeSrc.getValue(), ccnType, ccn.getMethod()));

--- a/src/main/java/soot/jimple/spark/solver/PropIter.java
+++ b/src/main/java/soot/jimple/spark/solver/PropIter.java
@@ -208,7 +208,7 @@ public class PropIter extends Propagator {
             // this now
             SootClass targetClass = ((RefType) ccnType).getSootClass();
             if (targetClass.resolvingLevel() == SootClass.DANGLING) {
-              Scene.v().forceResolve(targetClass.getName(), SootClass.SIGNATURES);
+              Scene.v().forceResolve(targetClass.getPathPlusClassName(), SootClass.SIGNATURES);
             }
 
             instance.makeP2Set().add(pag.makeAllocNode(src.getValue(), ccnType, ccn.getMethod()));

--- a/src/main/java/soot/jimple/spark/solver/PropWorklist.java
+++ b/src/main/java/soot/jimple/spark/solver/PropWorklist.java
@@ -206,7 +206,7 @@ public class PropWorklist extends Propagator {
                 // we do this now
                 SootClass targetClass = ((RefType) ccnType).getSootClass();
                 if (targetClass.resolvingLevel() == SootClass.DANGLING) {
-                  Scene.v().forceResolve(targetClass.getName(), SootClass.SIGNATURES);
+                  Scene.v().forceResolve(targetClass.getPathPlusClassName(), SootClass.SIGNATURES);
                 }
 
                 // We can only create alloc nodes for types that

--- a/src/main/java/soot/jimple/toolkits/annotation/DominatorsTagger.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/DominatorsTagger.java
@@ -57,7 +57,7 @@ public class DominatorsTagger extends BodyTransformer {
       while (dIt.hasNext()) {
         Stmt ds = (Stmt) dIt.next();
         String info = ds + " dominates " + s;
-        s.addTag(new LinkTag(info, ds, b.getMethod().getDeclaringClass().getName(), "Dominators"));
+        s.addTag(new LinkTag(info, ds, b.getMethod().getDeclaringClass().getPathPlusClassName(), "Dominators"));
       }
     }
   }

--- a/src/main/java/soot/jimple/toolkits/annotation/arraycheck/ClassFieldAnalysis.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/arraycheck/ClassFieldAnalysis.java
@@ -87,7 +87,7 @@ public class ClassFieldAnalysis {
     /* Summerize class information here. */
     Date start = new Date();
     if (Options.v().verbose()) {
-      logger.debug("[] ClassFieldAnalysis started on : " + start + " for " + c.getPackageName() + c.getName());
+      logger.debug("[] ClassFieldAnalysis started on : " + start + " for " + c.getPackageName() + c.getPathPlusClassName());
     }
 
     Hashtable<SootField, IntValueContainer> fieldInfoTable = new Hashtable<SootField, IntValueContainer>();

--- a/src/main/java/soot/jimple/toolkits/annotation/callgraph/CallGraphTagger.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/callgraph/CallGraphTagger.java
@@ -69,7 +69,7 @@ public class CallGraphTagger extends BodyTransformer {
         Edge e = (Edge) edges.next();
         SootMethod m = e.tgt();
         s.addTag(new LinkTag("CallGraph: Type: " + e.kind() + " Target Method/Context: " + e.getTgt().toString(), m,
-            m.getDeclaringClass().getName(), "Call Graph"));
+            m.getDeclaringClass().getPathPlusClassName(), "Call Graph"));
 
       }
     }
@@ -87,7 +87,7 @@ public class CallGraphTagger extends BodyTransformer {
         }
         m.addTag(new LinkTag(
             "CallGraph: Source Type: " + callEdge.kind() + " Source Method/Context: " + callEdge.getSrc().toString(), src,
-            methodCaller.getDeclaringClass().getName(), "Call Graph"));
+            methodCaller.getDeclaringClass().getPathPlusClassName(), "Call Graph"));
       }
     }
   }

--- a/src/main/java/soot/jimple/toolkits/annotation/defs/ReachingDefsTagger.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/defs/ReachingDefsTagger.java
@@ -57,7 +57,7 @@ public class ReachingDefsTagger extends BodyTransformer {
           // System.out.println("local: "+l);
           for (Unit next : ld.getDefsOfAt(l, s)) {
             String info = l + " has reaching def: " + next;
-            String className = b.getMethod().getDeclaringClass().getName();
+            String className = b.getMethod().getDeclaringClass().getPathPlusClassName();
             s.addTag(new LinkTag(info, next, className, "Reaching Defs"));
           }
         }

--- a/src/main/java/soot/jimple/toolkits/annotation/qualifiers/TightestQualifiersTagger.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/qualifiers/TightestQualifiersTagger.java
@@ -118,7 +118,7 @@ public class TightestQualifiersTagger extends SceneTransformer {
 
       if (!sRes.equals(actual)) {
         if (meth.getName().equals("<init>")) {
-          meth.addTag(new StringTag("Constructor: " + meth.getDeclaringClass().getName() + " has " + actual
+          meth.addTag(new StringTag("Constructor: " + meth.getDeclaringClass().getPathPlusClassName() + " has " + actual
               + " level access, can have: " + sRes + " level access.", "Tightest Qualifiers"));
         } else {
           meth.addTag(new StringTag(

--- a/src/main/java/soot/jimple/toolkits/base/RenameDuplicatedClasses.java
+++ b/src/main/java/soot/jimple/toolkits/base/RenameDuplicatedClasses.java
@@ -86,7 +86,7 @@ public class RenameDuplicatedClasses extends SceneTransformer {
     Map<String, String> lowerCaseClassNameToReal = new HashMap<String, String>();
     for (Iterator<SootClass> iter = Scene.v().getClasses().snapshotIterator(); iter.hasNext();) {
       SootClass sootClass = iter.next();
-      String className = sootClass.getName();
+      String className = sootClass.getPathPlusClassName();
 
       if (lowerCaseClassNameToReal.containsKey(className.toLowerCase())) {
         if (fixedClassNames.contains(className)) {

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -967,7 +967,7 @@ public class OnFlyCallGraphBuilder {
       if (s.containsInvokeExpr()) {
         InvokeExpr ie = s.getInvokeExpr();
         SootMethodRef methodRef = ie.getMethodRef();
-        switch (methodRef.getDeclaringClass().getName()) {
+        switch (methodRef.getDeclaringClass().getPathPlusClassName()) {
           case "java.lang.reflect.Method":
             if ("java.lang.Object invoke(java.lang.Object,java.lang.Object[])"
                 .equals(methodRef.getSubSignature().getString())) {
@@ -1427,7 +1427,7 @@ public class OnFlyCallGraphBuilder {
             return;
           }
           SootClass superclass = currClass.getSuperclass();
-          if (superclass.isPhantom() || Scene.v().getObjectType().toString().equals(superclass.getName())) {
+          if (superclass.isPhantom() || Scene.v().getObjectType().toString().equals(superclass.getPathPlusClassName())) {
             methodIterator = null;
             return;
           } else {

--- a/src/main/java/soot/jimple/toolkits/callgraph/UnreachableMethodTransformer.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/UnreachableMethodTransformer.java
@@ -66,7 +66,7 @@ public class UnreachableMethodTransformer extends BodyTransformer {
     list.add(jimp.newInvokeStmt(
         jimp.newVirtualInvokeExpr(tmpRef, toCall.makeRef(), StringConstant.v("Executing supposedly unreachable method:"))));
     list.add(jimp.newInvokeStmt(jimp.newVirtualInvokeExpr(tmpRef, toCall.makeRef(),
-        StringConstant.v("\t" + method.getDeclaringClass().getName() + "." + method.getName()))));
+        StringConstant.v("\t" + method.getDeclaringClass().getPathPlusClassName() + "." + method.getName()))));
 
     toCall = scene.getMethod("<java.lang.System: void exit(int)>");
     list.add(jimp.newInvokeStmt(jimp.newStaticInvokeExpr(toCall.makeRef(), IntConstant.v(1))));

--- a/src/main/java/soot/jimple/toolkits/ide/icfg/OnTheFlyJimpleBasedICFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/OnTheFlyJimpleBasedICFG.java
@@ -172,7 +172,7 @@ public class OnTheFlyJimpleBasedICFG extends AbstractJimpleBasedICFG {
   private synchronized void ensureClassHasBodies(SootClass cl) {
     assert Scene.v().hasFastHierarchy();
     if (cl.resolvingLevel() < SootClass.BODIES) {
-      Scene.v().forceResolve(cl.getName(), SootClass.BODIES);
+      Scene.v().forceResolve(cl.getPathPlusClassName(), SootClass.BODIES);
       Scene.v().getOrMakeFastHierarchy();
     }
     assert Scene.v().hasFastHierarchy();

--- a/src/main/java/soot/jimple/toolkits/invoke/AccessManager.java
+++ b/src/main/java/soot/jimple/toolkits/invoke/AccessManager.java
@@ -73,7 +73,7 @@ public class AccessManager {
 
     final SootClass containerClass = container.getDeclaringClass();
     // Condition 1 above.
-    if (target.isPrivate() && !targetClass.getName().equals(containerClass.getName())) {
+    if (target.isPrivate() && !targetClass.getPathPlusClassName().equals(containerClass.getPathPlusClassName())) {
       return false;
     }
 

--- a/src/main/java/soot/jimple/toolkits/invoke/InlinerSafetyManager.java
+++ b/src/main/java/soot/jimple/toolkits/invoke/InlinerSafetyManager.java
@@ -218,7 +218,7 @@ public class InlinerSafetyManager {
     SootClass containerClass = container.getDeclaringClass();
 
     // Condition 1 above.
-    if (inlinee.isPrivate() && !inlineeClass.getName().equals(containerClass.getName())) {
+    if (inlinee.isPrivate() && !inlineeClass.getPathPlusClassName().equals(containerClass.getPathPlusClassName())) {
       return true;
     }
 

--- a/src/main/java/soot/jimple/toolkits/invoke/StaticMethodBinder.java
+++ b/src/main/java/soot/jimple/toolkits/invoke/StaticMethodBinder.java
@@ -135,7 +135,7 @@ public class StaticMethodBinder extends SceneTransformer {
 
           if (!instanceToStaticMap.containsKey(target)) {
             List<Type> newParameterTypes = new ArrayList<Type>();
-            newParameterTypes.add(RefType.v(targetDeclClass.getName()));
+            newParameterTypes.add(RefType.v(targetDeclClass.getPathPlusClassName()));
             newParameterTypes.addAll(target.getParameterTypes());
 
             // Check for signature conflicts.

--- a/src/main/java/soot/jimple/toolkits/invoke/SynchronizerManager.java
+++ b/src/main/java/soot/jimple/toolkits/invoke/SynchronizerManager.java
@@ -135,7 +135,7 @@ public class SynchronizerManager {
     SootField classCacher = classToClassField.get(sc);
     if (classCacher == null) {
       // Add a unique field named [__]class$name
-      String n = "class$" + sc.getName().replace('.', '$');
+      String n = "class$" + sc.getPathPlusClassName().replace('.', '$');
       while (sc.declaresFieldByName(n)) {
         n = '_' + n;
       }
@@ -172,7 +172,7 @@ public class SynchronizerManager {
     units.insertBefore(jimp.newIfStmt(jimp.newNeExpr(l, NullConstant.v()), target), target);
 
     units.insertBefore(jimp.newAssignStmt(l, jimp.newStaticInvokeExpr(getClassFetcherFor(sc, createNewAsShimple).makeRef(),
-        Collections.singletonList(StringConstant.v(sc.getName())))), target);
+        Collections.singletonList(StringConstant.v(sc.getPathPlusClassName())))), target);
     units.insertBefore(jimp.newAssignStmt(jimp.newStaticFieldRef(classCacher.makeRef()), l), target);
 
     return l;
@@ -192,7 +192,7 @@ public class SynchronizerManager {
    * Uses dumb matching to do search. Not worth doing symbolic analysis for this!
    */
   public SootMethod getClassFetcherFor(final SootClass c, boolean createNewAsShimple) {
-    final String prefix = '<' + c.getName().replace('.', '$') + ": java.lang.Class ";
+    final String prefix = '<' + c.getPathPlusClassName().replace('.', '$') + ": java.lang.Class ";
     for (String methodName = "class$"; true; methodName = '_' + methodName) {
       SootMethod m = c.getMethodByNameUnsafe(methodName);
       if (m == null) {

--- a/src/main/java/soot/jimple/toolkits/pointer/util/NativeMethodDriver.java
+++ b/src/main/java/soot/jimple/toolkits/pointer/util/NativeMethodDriver.java
@@ -144,7 +144,7 @@ public class NativeMethodDriver {
   public boolean process(SootMethod method, ReferenceVariable thisVar, ReferenceVariable returnVar,
       ReferenceVariable params[]) {
 
-    String cname = method.getDeclaringClass().getName();
+    String cname = method.getDeclaringClass().getPathPlusClassName();
     NativeMethodClass clsSim = cnameToSim.get(cname);
 
     // logger.debug(""+method.toString());

--- a/src/main/java/soot/jimple/toolkits/reflection/ReflectiveCallsInliner.java
+++ b/src/main/java/soot/jimple/toolkits/reflection/ReflectiveCallsInliner.java
@@ -401,7 +401,7 @@ public class ReflectiveCallsInliner extends SceneTransformer {
               .makeRef(), IntConstant.v(callSiteId), recv, methodLocal)));
         } else if (callKind == Kind.FieldSet) {
           SootMethod sootMethod = ie.getMethodRef().resolve();
-          if ("java.lang.reflect.Field".equals(sootMethod.getDeclaringClass().getName())
+          if ("java.lang.reflect.Field".equals(sootMethod.getDeclaringClass().getPathPlusClassName())
               && fieldSets.contains(sootMethod.getName())) {
             found = true;
             // assign type of 2nd parameter (1st is receiver object)
@@ -414,7 +414,7 @@ public class ReflectiveCallsInliner extends SceneTransformer {
           }
         } else if (callKind == Kind.FieldGet) {
           SootMethod sootMethod = ie.getMethodRef().resolve();
-          if ("java.lang.reflect.Field".equals(sootMethod.getDeclaringClass().getName())
+          if ("java.lang.reflect.Field".equals(sootMethod.getDeclaringClass().getPathPlusClassName())
               && fieldGets.contains(sootMethod.getName())) {
             found = true;
             // assign return type of get

--- a/src/main/java/soot/jimple/toolkits/thread/mhp/MethodExtentBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/thread/mhp/MethodExtentBuilder.java
@@ -107,7 +107,7 @@ public class MethodExtentBuilder {
           if (name.equals("wait") || name.equals("notify") || name.equals("notifyAll")
               || ((name.equals("start") || name.equals("join") || name.equals("suspend") || name.equals("resume")
                   || name.equals("destroy") || name.equals("stop"))
-                  && method.getDeclaringClass().getName().equals("java.lang.Thread"))) {
+                  && method.getDeclaringClass().getPathPlusClassName().equals("java.lang.Thread"))) {
             methodsNeedingInlining.add(targetMethod);
             return;
           } else {

--- a/src/main/java/soot/jimple/toolkits/thread/mhp/PegChain.java
+++ b/src/main/java/soot/jimple/toolkits/thread/mhp/PegChain.java
@@ -256,7 +256,7 @@ public class PegChain extends HashChain {
             SootClass sc = ((RefType) type).getSootClass();
 
             // sc = ((RefType)type).getSootClass();
-            objName = sc.getName();
+            objName = sc.getPathPlusClassName();
 
           }
         }
@@ -276,7 +276,7 @@ public class PegChain extends HashChain {
         Iterator<SootClass> it = superClasses.iterator();
 
         while (it.hasNext()) {
-          String className = it.next().getName();
+          String className = it.next().getPathPlusClassName();
           if (className.equals("java.lang.Thread")) {
             find = true;
             break;
@@ -286,7 +286,7 @@ public class PegChain extends HashChain {
       if (method.getName().equals("run")) {
         // System.out.println("method name: "+method.getName());
         // System.out.println("DeclaringClass name: "+method.getDeclaringClass().getName());
-        if ((method.getDeclaringClass().getName()).equals("java.lang.Runnable")) {
+        if ((method.getDeclaringClass().getPathPlusClassName()).equals("java.lang.Runnable")) {
           // System.out.println("find: "+find);
 
           find = true;
@@ -372,7 +372,7 @@ public class PegChain extends HashChain {
 
         } // end if (name.equals("start") )
         else {
-          if (name.equals("join") && method.getDeclaringClass().getName().equals("java.lang.Thread")) {
+          if (name.equals("join") && method.getDeclaringClass().getPathPlusClassName().equals("java.lang.Thread")) {
 
             // If the may-alias of "join" has more that one elements, we can NOT kill anything.
             PointsToSetInternal pts = (PointsToSetInternal) pag.reachingObjects((Local) value);
@@ -448,7 +448,7 @@ public class PegChain extends HashChain {
 
               // add Oct 8, for building pegs with inliner.
               if (name.equals("notify") && paras.size() == 0
-                  && method.getDeclaringClass().getName().equals("java.lang.Thread")) {
+                  && method.getDeclaringClass().getPathPlusClassName().equals("java.lang.Thread")) {
                 objName = makeObjName(value, type, unit);
                 JPegStmt pegStmt = new NotifyStmt(objName, threadName, unit, graph, sm);
                 addAndPutNonCompacted(unit, pegStmt);
@@ -630,7 +630,7 @@ public class PegChain extends HashChain {
     } else {
       String objName = null;
       if (targetMethod.isStatic()) {
-        objName = targetMethod.getDeclaringClass().getName();
+        objName = targetMethod.getDeclaringClass().getPathPlusClassName();
       } else {
         Iterator it = ((Chain) (targetMethod.getActiveBody()).getUnits()).iterator();
 

--- a/src/main/java/soot/jimple/toolkits/thread/mhp/StartJoinAnalysis.java
+++ b/src/main/java/soot/jimple/toolkits/thread/mhp/StartJoinAnalysis.java
@@ -267,7 +267,7 @@ public class StartJoinAnalysis extends ForwardFlowAnalysis {
             List<SootClass> superClasses = hierarchy.getSuperclassesOfIncluding(baseType.getSootClass());
             Iterator<SootClass> it = superClasses.iterator();
             while (it.hasNext()) {
-              if (it.next().getName().equals("java.lang.Thread")) {
+              if (it.next().getPathPlusClassName().equals("java.lang.Thread")) {
                 // This is a Thread.start()
                 if (!startStatements.contains(stmt)) {
                   startStatements.add(stmt);
@@ -288,7 +288,7 @@ public class StartJoinAnalysis extends ForwardFlowAnalysis {
             List<SootClass> superClasses = hierarchy.getSuperclassesOfIncluding(baseType.getSootClass());
             Iterator<SootClass> it = superClasses.iterator();
             while (it.hasNext()) {
-              if (it.next().getName().equals("java.lang.Thread")) {
+              if (it.next().getPathPlusClassName().equals("java.lang.Thread")) {
                 // This is a Thread.join()
                 if (!joinStatements.contains(stmt)) {
                   joinStatements.add(stmt);

--- a/src/main/java/soot/jimple/toolkits/typing/TypeNode.java
+++ b/src/main/java/soot/jimple/toolkits/typing/TypeNode.java
@@ -93,14 +93,14 @@ class TypeNode {
       List<TypeNode> plist = new LinkedList<TypeNode>();
 
       SootClass superclass = sClass.getSuperclassUnsafe();
-      if (superclass != null && !sClass.getName().equals(Scene.v().getObjectType().toString())) {
-        TypeNode parent = hierarchy.typeNode(RefType.v(sClass.getSuperclass().getName()));
+      if (superclass != null && !sClass.getPathPlusClassName().equals(Scene.v().getObjectType().toString())) {
+        TypeNode parent = hierarchy.typeNode(RefType.v(sClass.getSuperclass().getPathPlusClassName()));
         plist.add(parent);
         parentClass = parent;
       }
 
       for (Iterator<SootClass> i = sClass.getInterfaces().iterator(); i.hasNext();) {
-        TypeNode parent = hierarchy.typeNode(RefType.v((i.next()).getName()));
+        TypeNode parent = hierarchy.typeNode(RefType.v((i.next()).getPathPlusClassName()));
         plist.add(parent);
       }
 
@@ -146,8 +146,9 @@ class TypeNode {
         RefType baseType = (RefType) type.baseType;
         SootClass sClass = baseType.getSootClass();
         SootClass superClass = sClass.getSuperclassUnsafe();
-        if (superClass != null && !superClass.getName().equals(Scene.v().getObjectType().toString())) {
-          TypeNode parent = hierarchy.typeNode(ArrayType.v(RefType.v(sClass.getSuperclass().getName()), type.numDimensions));
+        if (superClass != null && !superClass.getPathPlusClassName().equals(Scene.v().getObjectType().toString())) {
+          TypeNode parent = hierarchy.typeNode(
+                  ArrayType.v(RefType.v(sClass.getSuperclass().getPathPlusClassName()), type.numDimensions));
           plist.add(parent);
           parentClass = parent;
         } else if (type.numDimensions == 1) {
@@ -173,7 +174,8 @@ class TypeNode {
         }
 
         for (Iterator<SootClass> i = sClass.getInterfaces().iterator(); i.hasNext();) {
-          TypeNode parent = hierarchy.typeNode(ArrayType.v(RefType.v((i.next()).getName()), type.numDimensions));
+          TypeNode parent = hierarchy.typeNode(
+                  ArrayType.v(RefType.v((i.next()).getPathPlusClassName()), type.numDimensions));
           plist.add(parent);
         }
       } else if (type.numDimensions == 1) {

--- a/src/main/java/soot/jimple/toolkits/typing/TypeResolver.java
+++ b/src/main/java/soot/jimple/toolkits/typing/TypeResolver.java
@@ -560,7 +560,8 @@ public class TypeResolver {
               if (lca == null) {
                 if (DEBUG) {
                   logger.debug(
-                      "==++==" + stmtBody.getMethod().getDeclaringClass().getName() + "." + stmtBody.getMethod().getName());
+                          "==++==" + stmtBody.getMethod().getDeclaringClass().getPathPlusClassName() + "."
+                                  + stmtBody.getMethod().getName());
                 }
 
                 continue multiple_children;

--- a/src/main/java/soot/jimple/toolkits/typing/TypeResolverBV.java
+++ b/src/main/java/soot/jimple/toolkits/typing/TypeResolverBV.java
@@ -578,7 +578,8 @@ public class TypeResolverBV {
               if (lca == null) {
                 if (DEBUG) {
                   logger.debug(
-                      "==++==" + stmtBody.getMethod().getDeclaringClass().getName() + "." + stmtBody.getMethod().getName());
+                          "==++==" + stmtBody.getMethod().getDeclaringClass().getPathPlusClassName() + "."
+                                  + stmtBody.getMethod().getName());
                 }
 
                 continue multiple_children;

--- a/src/main/java/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
@@ -185,7 +185,7 @@ public class AugEvalFunction implements IEvalFunction {
       } else if (at instanceof WeakObjectType) {
         return at;
       } else if (at instanceof RefType) {
-        String name = ((RefType) at).getSootClass().getName();
+        String name = ((RefType) at).getSootClass().getPathPlusClassName();
         if (name.equals(Scene.v().getObjectType().toString())) {
           return new WeakObjectType(name);
         }

--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -263,7 +263,7 @@ public class TypeResolver {
       if (rt instanceof WeakObjectType) {
         return true;
       } else {
-        final String name = rt.getSootClass().getName();
+        final String name = rt.getSootClass().getPathPlusClassName();
         return "java.lang.Object".equals(name) || "java.io.Serializable".equals(name) || "java.lang.Cloneable".equals(name);
       }
     }

--- a/src/main/java/soot/jimple/toolkits/typing/fast/UseChecker.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/UseChecker.java
@@ -286,7 +286,7 @@ public class UseChecker extends AbstractStmtSwitch {
         // this could lead to any kind of object, so we have to look at the uses.
         // For some fixed type T, we assume that we can fix the array to T[].
         if (bt instanceof RefType || bt instanceof NullType) {
-          String btName = bt instanceof NullType ? null : ((RefType) bt).getSootClass().getName();
+          String btName = bt instanceof NullType ? null : ((RefType) bt).getSootClass().getPathPlusClassName();
           if (btName == null || Scene.v().getObjectType().toString().equals(btName) || "java.io.Serializable".equals(btName)
               || "java.lang.Cloneable".equals(btName)) {
             if (defs == null) {

--- a/src/main/java/soot/sootify/TemplatePrinter.java
+++ b/src/main/java/soot/sootify/TemplatePrinter.java
@@ -61,7 +61,7 @@ public class TemplatePrinter {
 
     // open class
     print("public class ");
-    print(c.getName().replace('.', '_') + "_Maker");
+    print(c.getPathPlusClassName().replace('.', '_') + "_Maker");
     println(" {");
 
     println("private static Local localByName(Body b, String name) {");
@@ -77,7 +77,7 @@ public class TemplatePrinter {
     println("public void create() {");
     indent();
 
-    println("SootClass c = new SootClass(\"" + c.getName() + "\");");
+    println("SootClass c = new SootClass(\"" + c.getPathPlusClassName() + "\");");
     println("c.setApplicationClass();");
     // todo modifiers, extends etc.
     println("Scene.v().addClass(c);");

--- a/src/main/java/soot/sootify/ValueTemplatePrinter.java
+++ b/src/main/java/soot/sootify/ValueTemplatePrinter.java
@@ -356,7 +356,7 @@ public class ValueTemplatePrinter implements JimpleValueSwitch {
 
     p.print("SootMethodRef methodRef = ");
     p.printNoIndent("Scene.v().makeMethodRef(");
-    String className = m.getDeclaringClass().getName();
+    String className = m.getDeclaringClass().getPathPlusClassName();
     p.printNoIndent("Scene.v().getSootClass(\"" + className + "\"),");
     p.printNoIndent("\"" + m.getName() + "\",");
     p.printNoIndent("parameterTypes,");
@@ -551,7 +551,7 @@ public class ValueTemplatePrinter implements JimpleValueSwitch {
     f.getType().apply(ttp);
     p.print("SootFieldRef fieldRef = ");
     p.printNoIndent("Scene.v().makeFieldRef(");
-    String className = f.getDeclaringClass().getName();
+    String className = f.getDeclaringClass().getPathPlusClassName();
     p.printNoIndent("Scene.v().getSootClass(\"" + className + "\"),");
     p.printNoIndent("\"" + f.getName() + "\",");
     p.printNoIndent("type,");

--- a/src/main/java/soot/tagkit/OuterClassTag.java
+++ b/src/main/java/soot/tagkit/OuterClassTag.java
@@ -48,7 +48,7 @@ public class OuterClassTag implements Tag {
   @Override
   public byte[] getValue() {
     try {
-      return outerClass.getName().getBytes("UTF8");
+      return outerClass.getPathPlusClassName().getBytes("UTF8");
     } catch (UnsupportedEncodingException e) {
       return new byte[0];
     }
@@ -68,6 +68,6 @@ public class OuterClassTag implements Tag {
 
   @Override
   public String toString() {
-    return "[outer class=" + outerClass.getName() + "]";
+    return "[outer class=" + outerClass.getPathPlusClassName() + "]";
   }
 }

--- a/src/main/java/soot/toDex/DexPrinter.java
+++ b/src/main/java/soot/toDex/DexPrinter.java
@@ -260,14 +260,16 @@ public class DexPrinter {
   }
 
   protected static FieldReference toFieldReference(SootField f) {
-    FieldReference fieldRef = new ImmutableFieldReference(SootToDexUtils.getDexClassName(f.getDeclaringClass().getName()),
-        f.getName(), SootToDexUtils.getDexTypeDescriptor(f.getType()));
+    FieldReference fieldRef = new ImmutableFieldReference(
+            SootToDexUtils.getDexClassName(f.getDeclaringClass().getPathPlusClassName()),
+            f.getName(), SootToDexUtils.getDexTypeDescriptor(f.getType()));
     return fieldRef;
   }
 
   protected static FieldReference toFieldReference(SootFieldRef ref) {
-    FieldReference fieldRef = new ImmutableFieldReference(SootToDexUtils.getDexClassName(ref.declaringClass().getName()),
-        ref.name(), SootToDexUtils.getDexTypeDescriptor(ref.type()));
+    FieldReference fieldRef = new ImmutableFieldReference(
+            SootToDexUtils.getDexClassName(ref.declaringClass().getPathPlusClassName()),
+            ref.name(), SootToDexUtils.getDexTypeDescriptor(ref.type()));
     return fieldRef;
   }
 
@@ -276,8 +278,9 @@ public class DexPrinter {
     for (Type t : m.getParameterTypes()) {
       parameters.add(SootToDexUtils.getDexTypeDescriptor(t));
     }
-    return new ImmutableMethodReference(SootToDexUtils.getDexClassName(m.getDeclaringClass().getName()), m.getName(),
-        parameters, SootToDexUtils.getDexTypeDescriptor(m.getReturnType()));
+    return new ImmutableMethodReference(SootToDexUtils.getDexClassName(
+            m.getDeclaringClass().getPathPlusClassName()), m.getName(),
+            parameters, SootToDexUtils.getDexTypeDescriptor(m.getReturnType()));
   }
 
   public static TypeReference toTypeReference(Type t) {
@@ -687,7 +690,7 @@ public class DexPrinter {
       if (skipList.add("Ldalvik/annotation/EnclosingClass;")) {
         // EnclosingClass annotation
         ImmutableAnnotationElement enclosingElement = new ImmutableAnnotationElement("value",
-            new ImmutableTypeEncodedValue(SootToDexUtils.getDexClassName(c.getOuterClass().getName())));
+            new ImmutableTypeEncodedValue(SootToDexUtils.getDexClassName(c.getOuterClass().getPathPlusClassName())));
         annotations.add(new ImmutableAnnotation(AnnotationVisibility.SYSTEM, "Ldalvik/annotation/EnclosingClass;",
             Collections.singleton(enclosingElement)));
       }
@@ -729,7 +732,7 @@ public class DexPrinter {
       AnnotationTag a = new AnnotationTag("Ldalvik/annotation/AnnotationDefault;");
       defaultAnnotationTag.addAnnotation(a);
 
-      AnnotationTag at = new AnnotationTag(SootToDexUtils.getDexClassName(c.getName()));
+      AnnotationTag at = new AnnotationTag(SootToDexUtils.getDexClassName(c.getPathPlusClassName()));
       AnnotationAnnotationElem ae = new AnnotationAnnotationElem(at, '@', "value");
       a.addElem(ae);
 
@@ -779,7 +782,8 @@ public class DexPrinter {
     if (exceptionList != null && !exceptionList.isEmpty()) {
       List<ImmutableEncodedValue> valueList = new ArrayList<ImmutableEncodedValue>(exceptionList.size());
       for (SootClass exceptionClass : exceptionList) {
-        valueList.add(new ImmutableTypeEncodedValue(DexType.toDalvikICAT(exceptionClass.getName()).replace(".", "/")));
+        valueList.add(new ImmutableTypeEncodedValue(
+                DexType.toDalvikICAT(exceptionClass.getPathPlusClassName()).replace(".", "/")));
       }
       ImmutableArrayEncodedValue valueValue = new ImmutableArrayEncodedValue(valueList);
       ImmutableAnnotationElement valueElement = new ImmutableAnnotationElement("value", valueValue);
@@ -983,17 +987,17 @@ public class DexPrinter {
       // the other one. If the outer class points to our parent, but
       // this is simply the wrong inner class, we also continue with the
       // next tag.
-      if (!parentClass.hasOuterClass() || !innerClass.equals(parentClass.getName())) {
+      if (!parentClass.hasOuterClass() || !innerClass.equals(parentClass.getPathPlusClassName())) {
         continue;
       }
 
       // If the outer class points to the very same class, we null it
-      if (parentClass.getName().equals(outerClass) && icTag.getOuterClass() == null) {
+      if (parentClass.getPathPlusClassName().equals(outerClass) && icTag.getOuterClass() == null) {
         outerClass = null;
       }
 
       // Do not write garbage. Never.
-      if (parentClass.getName().equals(outerClass)) {
+      if (parentClass.getPathPlusClassName().equals(outerClass)) {
         continue;
       }
 
@@ -1035,7 +1039,7 @@ public class DexPrinter {
       String outerClass = DexInnerClassParser.getOuterClassNameFromTag(icTag);
 
       // Only classes with names are member classes
-      if (icTag.getOuterClass() != null && parentClass.getName().equals(outerClass)) {
+      if (icTag.getOuterClass() != null && parentClass.getPathPlusClassName().equals(outerClass)) {
         if (memberClasses == null) {
           memberClasses = new HashSet<String>();
         }
@@ -1693,7 +1697,7 @@ public class DexPrinter {
     if (dexClassIndex == null) {
       return; // no dex classes were loaded
     }
-    File sourceForClass = dexClassIndex.get(c.getName());
+    File sourceForClass = dexClassIndex.get(c.getPathPlusClassName());
     if (sourceForClass == null || sourceForClass.getName().endsWith(".dex")) {
       return; // a class was written that was not a dex class or the class
       // originates from a .dex file, not an APK

--- a/src/main/java/soot/toDex/ExprVisitor.java
+++ b/src/main/java/soot/toDex/ExprVisitor.java
@@ -230,7 +230,7 @@ public class ExprVisitor implements ExprSwitch {
         // arrive at java.lang.Object. In this case, we should not fail
         // the check
         if ((currentClass == classWithInvokation)
-            || (currentClass.isPhantom() && !currentClass.getName().equals("java.lang.Object"))) {
+            || (currentClass.isPhantom() && !currentClass.getPathPlusClassName().equals("java.lang.Object"))) {
           return true;
         }
       }

--- a/src/main/java/soot/toolkits/exceptions/DuplicateCatchAllTrapRemover.java
+++ b/src/main/java/soot/toolkits/exceptions/DuplicateCatchAllTrapRemover.java
@@ -66,16 +66,17 @@ public class DuplicateCatchAllTrapRemover extends BodyTransformer {
     // span the same code region
     for (Iterator<Trap> t1It = b.getTraps().snapshotIterator(); t1It.hasNext();) {
       Trap t1 = t1It.next();
-      if (t1.getException().getName().equals(Scene.v().getBaseExceptionType().toString())) {
+      if (t1.getException().getPathPlusClassName().equals(Scene.v().getBaseExceptionType().toString())) {
         for (Iterator<Trap> t2It = b.getTraps().snapshotIterator(); t2It.hasNext();) {
           Trap t2 = t2It.next();
           if (t1 != t2 && t1.getBeginUnit() == t2.getBeginUnit() && t1.getEndUnit() == t2.getEndUnit()
-              && t2.getException().getName().equals(Scene.v().getBaseExceptionType().toString())) {
+              && t2.getException().getPathPlusClassName().equals(Scene.v().getBaseExceptionType().toString())) {
             // Both traps (t1, t2) span the same code and catch java.lang.Throwable.
             // Check if one trap jumps to a target that then jumps to the target of
             // the other trap.
             for (Trap t3 : b.getTraps()) {
-              if (t3 != t1 && t3 != t2 && t3.getException().getName().equals(Scene.v().getBaseExceptionType().toString())) {
+              if (t3 != t1 && t3 != t2 &&
+                      t3.getException().getPathPlusClassName().equals(Scene.v().getBaseExceptionType().toString())) {
                 if (trapCoversUnit(b, t3, t1.getHandlerUnit()) && t3.getHandlerUnit() == t2.getHandlerUnit()) {
                   // c -> t1 -> t3 -> t2 && c -> t2
                   b.getTraps().remove(t2);

--- a/src/main/java/soot/toolkits/exceptions/TrapTightener.java
+++ b/src/main/java/soot/toolkits/exceptions/TrapTightener.java
@@ -86,7 +86,7 @@ public final class TrapTightener extends TrapTransformer {
 
       for (Iterator<Trap> trapIt = trapChain.iterator(); trapIt.hasNext();) {
         Trap trap = trapIt.next();
-        boolean isCatchAll = trap.getException().getName().equals(Scene.v().getBaseExceptionType().toString());
+        boolean isCatchAll = trap.getException().getPathPlusClassName().equals(Scene.v().getBaseExceptionType().toString());
         Unit firstTrappedUnit = trap.getBeginUnit();
         Unit firstTrappedThrower = null;
         Unit firstUntrappedUnit = trap.getEndUnit();

--- a/src/main/java/soot/tools/BadFields.java
+++ b/src/main/java/soot/tools/BadFields.java
@@ -113,7 +113,7 @@ public class BadFields extends SceneTransformer {
       }
       StaticFieldRef sfr = (StaticFieldRef) v;
       SootField f = sfr.getField();
-      if (!f.getDeclaringClass().getName().equals("java.lang.System")) {
+      if (!f.getDeclaringClass().getPathPlusClassName().equals("java.lang.System")) {
         continue;
       }
       if (f.getName().equals("err")) {
@@ -130,7 +130,7 @@ public class BadFields extends SceneTransformer {
       }
       InvokeExpr ie = s.getInvokeExpr();
       SootMethod target = ie.getMethod();
-      if (target.getDeclaringClass().getName().equals("java.lang.System") && target.getName().equals("exit")) {
+      if (target.getDeclaringClass().getPathPlusClassName().equals("java.lang.System") && target.getName().equals("exit")) {
         warn("" + m + " calls System.exit");
       }
     }
@@ -156,23 +156,23 @@ public class BadFields extends SceneTransformer {
 
   private void calls(SootMethod target) {
     if (target.getName().equals("<init>")) {
-      if (target.getDeclaringClass().getName().equals("java.io.PrintStream")
-          || target.getDeclaringClass().getName().equals("java.lang.Boolean")
-          || target.getDeclaringClass().getName().equals("java.lang.Integer")
-          || target.getDeclaringClass().getName().equals("java.lang.String")) {
+      if (target.getDeclaringClass().getPathPlusClassName().equals("java.io.PrintStream")
+          || target.getDeclaringClass().getPathPlusClassName().equals("java.lang.Boolean")
+          || target.getDeclaringClass().getPathPlusClassName().equals("java.lang.Integer")
+          || target.getDeclaringClass().getPathPlusClassName().equals("java.lang.String")) {
         return;
       }
-      if (target.getDeclaringClass().getName().equals(Scene.v().getObjectType().toString())) {
+      if (target.getDeclaringClass().getPathPlusClassName().equals(Scene.v().getObjectType().toString())) {
         return;
       }
     }
     if (target.getName().equals("getProperty")) {
-      if (target.getDeclaringClass().getName().equals("java.lang.System")) {
+      if (target.getDeclaringClass().getPathPlusClassName().equals("java.lang.System")) {
         return;
       }
     }
     if (target.getName().equals("charAt")) {
-      if (target.getDeclaringClass().getName().equals("java.lang.String")) {
+      if (target.getDeclaringClass().getPathPlusClassName().equals("java.lang.String")) {
         return;
       }
     }

--- a/src/main/java/soot/tools/CFGViewer.java
+++ b/src/main/java/soot/tools/CFGViewer.java
@@ -80,7 +80,8 @@ public class CFGViewer extends BodyTransformer {
     initialize(options);
     SootMethod meth = b.getMethod();
 
-    if ((methodsToPrint == null) || (meth.getDeclaringClass().getName() == methodsToPrint.get(meth.getName()))) {
+    if ((methodsToPrint == null) ||
+            (meth.getDeclaringClass().getPathPlusClassName() == methodsToPrint.get(meth.getName()))) {
       Body body = ir.getBody((JimpleBody) b);
       print_cfg(body);
     }
@@ -225,7 +226,7 @@ public class CFGViewer extends BodyTransformer {
       filename = filename + File.separator;
     }
     String methodname = body.getMethod().getSubSignature();
-    String classname = body.getMethod().getDeclaringClass().getName().replaceAll("\\$", "\\.");
+    String classname = body.getMethod().getDeclaringClass().getPathPlusClassName().replaceAll("\\$", "\\.");
     filename = filename + classname + " " + methodname.replace(File.separatorChar, '.') + DotGraph.DOT_EXTENSION;
     logger.debug("Generate dot file in " + filename);
 

--- a/src/main/java/soot/util/PhaseDumper.java
+++ b/src/main/java/soot/util/PhaseDumper.java
@@ -152,7 +152,7 @@ public class PhaseDumper {
   private static File makeDirectoryIfMissing(Body b) throws IOException {
     StringBuilder buf = new StringBuilder(soot.SourceLocator.v().getOutputDir());
     buf.append(File.separatorChar);
-    buf.append(b.getMethod().getDeclaringClass().getName());
+    buf.append(b.getMethod().getDeclaringClass().getPathPlusClassName());
     buf.append(File.separatorChar);
     buf.append(b.getMethod().getSubSignature().replace('<', '[').replace('>', ']'));
     File dir = new File(buf.toString());

--- a/src/main/java/soot/util/backend/ASMBackendUtils.java
+++ b/src/main/java/soot/util/backend/ASMBackendUtils.java
@@ -222,7 +222,7 @@ public class ASMBackendUtils {
   public static boolean acceptsStringInitialValue(SootField field) {
     if (field.getType() instanceof RefType) {
       SootClass fieldClass = ((RefType) field.getType()).getSootClass();
-      return fieldClass.getName().equals("java.lang.String");
+      return fieldClass.getPathPlusClassName().equals("java.lang.String");
     }
     return false;
   }

--- a/src/main/java/soot/validation/CheckEscapingValidator.java
+++ b/src/main/java/soot/validation/CheckEscapingValidator.java
@@ -46,7 +46,7 @@ public enum CheckEscapingValidator implements BodyValidator {
         if (stmt.containsInvokeExpr()) {
           InvokeExpr iexpr = stmt.getInvokeExpr();
           SootMethodRef ref = iexpr.getMethodRef();
-          if (ref.name().contains("'") || ref.declaringClass().getName().contains("'")) {
+          if (ref.name().contains("'") || ref.declaringClass().getPathPlusClassName().contains("'")) {
             exception.add(new ValidationException(stmt, "Escaped name found in signature"));
           }
           for (Type paramType : ref.parameterTypes()) {

--- a/src/main/java/soot/validation/CheckTypesValidator.java
+++ b/src/main/java/soot/validation/CheckTypesValidator.java
@@ -128,7 +128,7 @@ public enum CheckTypesValidator implements BodyValidator {
           }
 
           // if lefttype is base class, all right types are legal
-          if (((RefType) leftType).getSootClass().getName().equals(DotnetBasicTypes.SYSTEM_OBJECT)) {
+          if (((RefType) leftType).getSootClass().getPathPlusClassName().equals(DotnetBasicTypes.SYSTEM_OBJECT)) {
             return;
           }
 
@@ -187,7 +187,7 @@ public enum CheckTypesValidator implements BodyValidator {
 
       if (leftClass.isInterface()) {
         if (rightClass.isInterface()) {
-          if (!(leftClass.getName().equals(rightClass.getName())
+          if (!(leftClass.getPathPlusClassName().equals(rightClass.getPathPlusClassName())
               || Scene.v().getActiveHierarchy().isInterfaceSubinterfaceOf(rightClass, leftClass))) {
             exception.add(new ValidationException(stmt, "Warning: Bad use of interface type" + errorSuffix));
           }

--- a/src/main/java/soot/xml/XMLPrinter.java
+++ b/src/main/java/soot/xml/XMLPrinter.java
@@ -137,12 +137,13 @@ public class XMLPrinter {
           new String[] { Main.versionString, cmdlineStr.toString().trim(), dateStr });
 
       // add class root node
-      xmlClassNode = xmlRootNode.addChild("class", new String[] { "name" }, new String[] { sc.quotedNameOf(cl.getName()) });
+      xmlClassNode = xmlRootNode.addChild("class", new String[] { "name" }, new String[] {
+              sc.quotedNameOf(cl.getPathPlusClassName()) });
       if (!cl.getPackageName().isEmpty()) {
         xmlClassNode.addAttribute("package", cl.getPackageName());
       }
       if (cl.hasSuperclass()) {
-        xmlClassNode.addAttribute("extends", sc.quotedNameOf(cl.getSuperclass().getName()));
+        xmlClassNode.addAttribute("extends", sc.quotedNameOf(cl.getSuperclass().getPathPlusClassName()));
       }
 
       // add modifiers subnode
@@ -158,7 +159,8 @@ public class XMLPrinter {
       XMLNode xmlTempNode = xmlClassNode.addChild("interfaces", "", new String[] { "count" },
           new String[] { String.valueOf(cl.getInterfaceCount()) });
       for (SootClass next : cl.getInterfaces()) {
-        xmlTempNode.addChild("implements", "", new String[] { "class" }, new String[] { sc.quotedNameOf(next.getName()) });
+        xmlTempNode.addChild("implements", "", new String[] { "class" }, new String[] {
+                sc.quotedNameOf(next.getPathPlusClassName()) });
       }
     }
 
@@ -186,7 +188,8 @@ public class XMLPrinter {
     // Print methods
     {
       XMLNode methodsNode
-          = xmlClassNode.addChild("methods", new String[] { "count" }, new String[] { String.valueOf(cl.getMethodCount()) });
+          = xmlClassNode.addChild("methods", new String[] { "count" }, new String[] {
+                  String.valueOf(cl.getMethodCount()) });
 
       for (Iterator<SootMethod> methodIt = cl.methodIterator(); methodIt.hasNext();) {
         SootMethod method = methodIt.next();
@@ -231,8 +234,9 @@ public class XMLPrinter {
     final String cleanMethodName = cleanMethod(body.getMethod().getName());
 
     // add method node
-    XMLNode methodNode = methodsNode.addChild("method", new String[] { "name", "returntype", "class" }, new String[] {
-        cleanMethodName, body.getMethod().getReturnType().toString(), body.getMethod().getDeclaringClass().getName() });
+    XMLNode methodNode = methodsNode.addChild("method", new String[] { "name", "returntype", "class" },
+            new String[] {cleanMethodName, body.getMethod().getReturnType().toString(),
+                    body.getMethod().getDeclaringClass().getPathPlusClassName() });
     String declarationStr = body.getMethod().getDeclaration().trim();
     methodNode.addChild("declaration", toCDATA(declarationStr), new String[] { "length" },
         new String[] { String.valueOf(declarationStr.length()) });
@@ -587,7 +591,8 @@ public class XMLPrinter {
       for (Trap trap : body.getTraps()) {
         // catch java.io.IOException from label0 to label1 with label2;
         XMLNode catchNode = exceptionsNode.addChild("exception", new String[] { "id", "method", "type" },
-            new String[] { String.valueOf(j++), cleanMethodName, Scene.v().quotedNameOf(trap.getException().getName()) });
+                new String[] { String.valueOf(j++), cleanMethodName,
+                        Scene.v().quotedNameOf(trap.getException().getPathPlusClassName()) });
         catchNode.addChild("begin", new String[] { "label" }, new String[] { stmtToName.get(trap.getBeginUnit()) });
         catchNode.addChild("end", new String[] { "label" }, new String[] { stmtToName.get(trap.getEndUnit()) });
         catchNode.addChild("handler", new String[] { "label" }, new String[] { stmtToName.get(trap.getHandlerUnit()) });

--- a/src/systemTest/java/soot/testing/framework/AbstractTestingFramework.java
+++ b/src/systemTest/java/soot/testing/framework/AbstractTestingFramework.java
@@ -264,7 +264,7 @@ public abstract class AbstractTestingFramework {
       public Class findClass(String name) {
         return defineClass(name, classBytes, 0, classBytes.length);
       }
-    }.findClass(sc.getName());
+    }.findClass(sc.getPathPlusClassName());
   }
 
   /**

--- a/src/test/java/soot/java10/LoadingTest.java
+++ b/src/test/java/soot/java10/LoadingTest.java
@@ -56,13 +56,13 @@ public class LoadingTest {
     SootClass klass1
         = SootModuleResolver.v().resolveClass("java.lang.invoke.VarHandle", SootClass.BODIES, Optional.of("java.base"));
 
-    assertTrue(klass1.getName().equals("java.lang.invoke.VarHandle"));
+    assertTrue(klass1.getPathPlusClassName().equals("java.lang.invoke.VarHandle"));
     assertTrue(klass1.moduleName.equals("java.base"));
 
     SootClass klass2 = SootModuleResolver.v().resolveClass("java.lang.invoke.ConstantBootstraps", SootClass.BODIES,
         Optional.of("java.base"));
 
-    assertTrue(klass2.getName().equals("java.lang.invoke.ConstantBootstraps"));
+    assertTrue(klass2.getPathPlusClassName().equals("java.lang.invoke.ConstantBootstraps"));
     assertTrue(klass2.moduleName.equals("java.base"));
 
     Scene.v().loadNecessaryClasses();
@@ -78,7 +78,7 @@ public class LoadingTest {
         "java.lang.invoke.VarHandle" });
 
     SootClass klass = Scene.v().getSootClass("java.lang.invoke.VarHandle");
-    assertTrue(klass.getName().equals("java.lang.invoke.VarHandle"));
+    assertTrue(klass.getPathPlusClassName().equals("java.lang.invoke.VarHandle"));
     assertTrue(klass.moduleName.equals("java.base"));
 
   }
@@ -93,7 +93,7 @@ public class LoadingTest {
         "java.lang.invoke.ConstantBootstraps" });
 
     SootClass klass = Scene.v().getSootClass("java.lang.invoke.ConstantBootstraps");
-    assertTrue(klass.getName().equals("java.lang.invoke.ConstantBootstraps"));
+    assertTrue(klass.getPathPlusClassName().equals("java.lang.invoke.ConstantBootstraps"));
     assertTrue(klass.moduleName.equals("java.base"));
 
   }

--- a/src/test/java/soot/java9/LoadingTest.java
+++ b/src/test/java/soot/java9/LoadingTest.java
@@ -59,7 +59,7 @@ public class LoadingTest {
     SootClass klass
         = SootModuleResolver.v().resolveClass("java.lang.invoke.VarHandle", SootClass.BODIES, Optional.of("java.base"));
 
-    assertTrue(klass.getName().equals("java.lang.invoke.VarHandle"));
+    assertTrue(klass.getPathPlusClassName().equals("java.lang.invoke.VarHandle"));
     assertTrue(klass.moduleName.equals("java.base"));
 
   }
@@ -76,7 +76,7 @@ public class LoadingTest {
         "java.lang.invoke.VarHandle" });
 
     SootClass klass = Scene.v().getSootClass("java.lang.invoke.VarHandle");
-    assertTrue(klass.getName().equals("java.lang.invoke.VarHandle"));
+    assertTrue(klass.getPathPlusClassName().equals("java.lang.invoke.VarHandle"));
     assertTrue(klass.moduleName.equals("java.base"));
 
   }

--- a/src/test/java/soot/jimple/toolkit/callgraph/TypeBasedReflectionModelTest.java
+++ b/src/test/java/soot/jimple/toolkit/callgraph/TypeBasedReflectionModelTest.java
@@ -101,7 +101,7 @@ public class TypeBasedReflectionModelTest {
         tc.setApplicationClass();
         Scene.v().setMainClass(tc);
 
-        Scene.v().forceResolve(tc.getName(), BODIES);
+        Scene.v().forceResolve(tc.getPathPlusClassName(), BODIES);
         Scene.v().loadNecessaryClasses();
 
         Options.v().setPhaseOption("cg.spark", "on");

--- a/src/test/java/soot/util/backend/SootASMClassWriterTest.java
+++ b/src/test/java/soot/util/backend/SootASMClassWriterTest.java
@@ -172,7 +172,7 @@ public class SootASMClassWriterTest {
 		SootClass sc = mock(SootClass.class);
 		RefType type = mock(RefType.class);
 
-		when(sc.getName()).thenReturn(name);
+		when(sc.getPathPlusClassName()).thenReturn(name);
 		when(sc.getType()).thenReturn(type);
 		when(sc.hasSuperclass()).thenReturn(true);
 		when(sc.resolvingLevel()).thenReturn(SootClass.HIERARCHY);


### PR DESCRIPTION
In the SootClass class, the function getName() is not specific enough regarding what it is returning. I refactored the function name to getPathPlusClassName() as it is a better description of what the function is returning. 

The motivation behind making this change is in certain areas Soot assumes getName() is returning the fully qualified name of the class, package name + the class name. However, in some applications that is not always the case. For instance, in a SpringBoot application, all the application classes are put into the directories `BOOT-INF/classes`. It is important to note, the `BOOT-INF/classes` directories are not part of the class's package name. Which causes the path + class name to not equal the class's fully qualified name.  

This boils down to the file path of the class does not always equal the class's package name. According to the JDK 8 documentation, it states, "Many implementations of the Java platform rely on hierarchical file systems to manage source and class files, although The Java Language Specification does not require this."  

This pull request is merely to refactor the SootClass function, getName(), to describe the information it is returning accurately. 