### PR TITLE
Disallow null in QueueReader to handle concurrency correctly

### DIFF
--- a/src/main/java/soot/MethodToContexts.java
+++ b/src/main/java/soot/MethodToContexts.java
@@ -55,7 +55,9 @@ public final class MethodToContexts {
   public void add(Iterator<MethodOrMethodContext> it) {
     while (it.hasNext()) {
       MethodOrMethodContext momc = it.next();
-      add(momc);
+      if (momc != null) {
+        add(momc);
+      }
     }
   }
 

--- a/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
+++ b/src/main/java/soot/jimple/spark/builder/ContextInsensitiveBuilder.java
@@ -104,11 +104,14 @@ public class ContextInsensitiveBuilder {
     }
     while (callEdges.hasNext()) {
       Edge e = callEdges.next();
+      if (e == null) {
+        continue;
+      }
       if (!e.isInvalid()) {
         if (e.tgt().isConcrete() || e.tgt().isNative()) {
-	  MethodPAG mpag = MethodPAG.v(pag, e.tgt());
-	  mpag.build();
-	  mpag.addToPAG(null);
+          MethodPAG mpag = MethodPAG.v(pag, e.tgt());
+          mpag.build();
+          mpag.addToPAG(null);
         }
         pag.addCallTarget(e);
       }

--- a/src/main/java/soot/jimple/spark/geom/geomPA/GeomPointsTo.java
+++ b/src/main/java/soot/jimple/spark/geom/geomPA/GeomPointsTo.java
@@ -359,7 +359,11 @@ public class GeomPointsTo extends PAG {
     CallGraph soot_callgraph = Scene.v().getCallGraph();
 
     while (smList.hasNext()) {
-      final SootMethod func = smList.next().method();
+      MethodOrMethodContext n = smList.next();
+      if (n == null) {
+        continue;
+      }
+      final SootMethod func = n.method();
       func2int.put(func, id);
       int2func.put(id, func);
 
@@ -385,7 +389,7 @@ public class GeomPointsTo extends PAG {
     QueueReader<Edge> edgeList = Scene.v().getCallGraph().listener();
     while (edgeList.hasNext()) {
       Edge edge = edgeList.next();
-      if (edge.isClinit()) {
+      if (edge == null || edge.isClinit()) {
         continue;
       }
 

--- a/src/main/java/soot/jimple/spark/internal/TypeManager.java
+++ b/src/main/java/soot/jimple/spark/internal/TypeManager.java
@@ -115,6 +115,9 @@ public final class TypeManager {
     final Scene sc = Scene.v();
     while (allocNodeListener.hasNext()) {
       AllocNode n = allocNodeListener.next();
+      if (n == null) {
+        continue;
+      }
       Type nt = n.getType();
       Iterable<Type> types;
       if (nt instanceof NullType || nt instanceof AnySubType) {

--- a/src/main/java/soot/jimple/spark/solver/OnFlyCallGraph.java
+++ b/src/main/java/soot/jimple/spark/solver/OnFlyCallGraph.java
@@ -111,6 +111,9 @@ public class OnFlyCallGraph {
     reachableMethods.update();
     while (reachablesReader.hasNext()) {
       MethodOrMethodContext m = reachablesReader.next();
+      if (m == null) {
+        continue;
+      }
       MethodPAG mpag = MethodPAG.v(pag, m.method());
       try {
         mpag.build();
@@ -129,6 +132,9 @@ public class OnFlyCallGraph {
   private void processCallEdges() {
     while (callEdges.hasNext()) {
       Edge e = callEdges.next();
+      if (e == null) {
+        continue;
+      }
       MethodPAG amp = MethodPAG.v(pag, e.tgt());
       amp.build();
       amp.addToPAG(e.tgtCtxt());

--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import soot.Kind;
@@ -99,7 +100,7 @@ public class CallGraph implements Iterable<Edge> {
     Set<Edge> edgesToRemove = new HashSet<>();
     for (QueueReader<Edge> edgeRdr = listener(); edgeRdr.hasNext();) {
       Edge e = edgeRdr.next();
-      if (e.srcUnit() == u) {
+      if (e != null && e.srcUnit() == u) {
         e.remove();
         removeEdge(e, false);
         edgesToRemove.add(e);
@@ -395,7 +396,9 @@ public class CallGraph implements Iterable<Edge> {
     StringBuilder out = new StringBuilder();
     for (QueueReader<Edge> reader = listener(); reader.hasNext();) {
       Edge e = reader.next();
-      out.append(e.toString()).append('\n');
+      if (e != null) {
+        out.append(e.toString()).append('\n');
+      }
     }
     return out.toString();
   }

--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraphBuilder.java
@@ -111,7 +111,7 @@ public class CallGraphBuilder {
         break;
       }
       final MethodOrMethodContext momc = worklist.next();
-      if (!process(momc)) {
+      if (momc != null && !process(momc)) {
         break;
       }
     }

--- a/src/main/java/soot/jimple/toolkits/callgraph/Filter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/Filter.java
@@ -48,6 +48,9 @@ public class Filter implements Iterator<Edge> {
   private void advance() {
     while (source.hasNext()) {
       next = source.next();
+      if (next == null) {
+    	continue;
+      }
       if (pred.want(next)) {
         return;
       }

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -279,6 +279,9 @@ public class OnFlyCallGraphBuilder {
         }
       }
       MethodOrMethodContext momc = worklist.next();
+      if (momc == null) {
+        continue;
+      }
       SootMethod m = momc.method();
       if (appOnly && !m.getDeclaringClass().isApplicationClass()) {
         continue;

--- a/src/main/java/soot/jimple/toolkits/callgraph/ReachableMethods.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/ReachableMethods.java
@@ -25,6 +25,7 @@ package soot.jimple.toolkits.callgraph;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import soot.MethodOrMethodContext;
@@ -89,6 +90,9 @@ public class ReachableMethods {
     }
     while (unprocessedMethods.hasNext()) {
       MethodOrMethodContext m = unprocessedMethods.next();
+      if (m == null) {
+    	continue;
+      }
       Iterator<Edge> targets = cg.edgesOutOf(m);
       if (filter != null) {
         targets = filter.wrap(targets);

--- a/src/main/java/soot/jimple/toolkits/callgraph/SlowCallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/SlowCallGraph.java
@@ -134,7 +134,9 @@ public class SlowCallGraph extends CallGraph {
     StringBuilder out = new StringBuilder();
     for (QueueReader<Edge> rdr = listener(); rdr.hasNext();) {
       Edge e = rdr.next();
-      out.append(e.toString()).append('\n');
+      if (e != null) {
+        out.append(e.toString()).append('\n');
+      }
     }
     return out.toString();
   }

--- a/src/main/java/soot/util/queue/ChunkedQueue.java
+++ b/src/main/java/soot/util/queue/ChunkedQueue.java
@@ -33,7 +33,6 @@ package soot.util.queue;
 @SuppressWarnings("unchecked")
 public class ChunkedQueue<E> {
 
-  protected static final Object NULL_CONST = new Object();
   protected static final Object DELETED_CONST = new Object();
 
   protected static final int LENGTH = 60;
@@ -48,7 +47,7 @@ public class ChunkedQueue<E> {
   /** Add an object to the queue. */
   public void add(E o) {
     if (o == null) {
-      o = (E) NULL_CONST;
+      throw new IllegalArgumentException("Null is not allowed");
     }
     if (index == LENGTH - 1) {
       Object[] temp = new Object[LENGTH];

--- a/src/main/java/soot/util/queue/QueueReader.java
+++ b/src/main/java/soot/util/queue/QueueReader.java
@@ -35,6 +35,7 @@ import soot.util.Invalidable;
  * been read by all the QueueReader's are kept. A QueueReader only receives the Object's added to the queue <b>after</b> the
  * QueueReader was created.
  *
+ * This QueueReader does <emph>not</emph> accept <code>null</code> values. 
  * @author Ondrej Lhotak
  */
 public class QueueReader<E> implements java.util.Iterator<E> {
@@ -54,19 +55,20 @@ public class QueueReader<E> implements java.util.Iterator<E> {
     Object ret = null;
     do {
       if (q[index] == null) {
-        throw new NoSuchElementException();
+        //this is the case when someone concurrently invalidates 
+        //the rest of the elements
+        return null;
       }
       if (index == q.length - 1) {
         q = (E[]) q[index];
         index = 0;
         if (q[index] == null) {
-          throw new NoSuchElementException();
+          //this is the case when someone concurrently invalidates 
+          //the rest of the elements
+          return null;
         }
       }
       ret = q[index];
-      if (ret == ChunkedQueue.NULL_CONST) {
-        ret = null;
-      }
       index++;
     } while (skip(ret));
     return (E) ret;


### PR DESCRIPTION
Before that, it could happen that the QueueReader's hasNext method is called, and then the corresponding element gets invalidated by another thread. In that case, the next method throw a NoSuchElement exce> Instead (and conforming to to the JavaDoc), we allow null to be returned in these cases. This means that ChunkedQueues may not contain actual nulls anymore.