### PR TITLE
New option: Ignore dex overflows

### DIFF
--- a/src/main/generated/options/soot/options/Options.java
+++ b/src/main/generated/options/soot/options/Options.java
@@ -1443,6 +1443,10 @@ public class Options extends OptionsBase {
                     || option.equals("no-writeout-body-releasing")
             )
                 no_writeout_body_releasing = true;
+            else if (false
+                    || option.equals("ignore-dex-overflow")
+            )
+                ignore_dex_overflow = true;
             else {
                 G.v().out.println("Invalid option -" + option);
                 return false;
@@ -1842,6 +1846,10 @@ public class Options extends OptionsBase {
     private boolean no_writeout_body_releasing = false;
     public void set_no_writeout_body_releasing(boolean setting) { no_writeout_body_releasing = setting; }
 
+    public boolean ignore_dex_overflow() { return ignore_dex_overflow; }
+    private boolean ignore_dex_overflow = false;
+    public void set_ignore_dex_overflow(boolean setting) { ignore_dex_overflow = setting; }
+
     public String getUsage() {
         return ""
                 + "\nGeneral Options:\n"
@@ -1996,7 +2004,8 @@ public class Options extends OptionsBase {
                 + "\nMiscellaneous Options:\n"
                 + padOpt("-time", "Report time required for transformations")
                 + padOpt("-subtract-gc", "Subtract gc from time")
-                + padOpt("-no-writeout-body-releasing", "Disables the release of method bodies after writeout. This flag is used internally.");
+                + padOpt("-no-writeout-body-releasing", "Disables the release of method bodies after writeout. This flag is used internally.")
+                + padOpt("-ignore-dex-overflow", "Ignore DEX overflows");
     }
 
 

--- a/src/main/java/soot/toDex/MultiDexBuilder.java
+++ b/src/main/java/soot/toDex/MultiDexBuilder.java
@@ -32,6 +32,7 @@ import org.jf.dexlib2.Opcodes;
 import org.jf.dexlib2.iface.ClassDef;
 import org.jf.dexlib2.writer.io.FileDataStore;
 import org.jf.dexlib2.writer.pool.DexPool;
+import soot.options.Options;
 
 /**
  * @author Manuel Benz created on 26.09.17
@@ -93,7 +94,9 @@ public class MultiDexBuilder {
     // (https://developer.android.com/studio/build/multidex.html,
     // http://www.fasteque.com/deep-dive-into-android-multidex/)
     if (!opcodes.isArt()) {
-      throw new RuntimeException("Dex file overflow. Splitting not support for pre Lollipop Android (Api 22).");
+      if (!Options.v().ignore_dex_overflow()) {
+        throw new RuntimeException("Dex file overflow. Splitting not support for pre Lollipop Android (Api 22).");
+      }
     }
 
     return true;


### PR DESCRIPTION
This pull request addresses the issue where Soot fails to build large Android applications with a `minSdkVersion` < 22 due to the absence of multi-dex support for API versions < 22, resulting in Soot throwing a `RuntimeException`. Given that Android API versions >= 22 come with built-in multi-dex support, these applications would theoretically work on devices running newer Android versions.

To allow Soot users to build such APKs, this pull request introduces an option to explicitly ignore dex overflows. The option can be enabled by calling `Options.v().set_ignore_dex_overflow(true)`.

An APK that results in such a `RuntimeException` is attached below. 
[Uploading com.mathgamesplayground.zip…]()

