### PR TITLE
Optimization and optional parallelization of typing minimization

### DIFF
--- a/src/main/java/soot/jimple/toolkits/typing/fast/DefaultTypingStrategy.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/DefaultTypingStrategy.java
@@ -1,5 +1,7 @@
 package soot.jimple.toolkits.typing.fast;
 
+import java.util.ArrayList;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -29,6 +31,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import soot.Local;
 import soot.RefType;
@@ -42,8 +49,12 @@ import soot.util.MultiMap;
  * The default typing strategy
  */
 public class DefaultTypingStrategy implements ITypingStrategy {
+  private static final Logger logger = LoggerFactory.getLogger(DefaultTypingStrategy.class);
 
   public static final ITypingStrategy INSTANCE = new DefaultTypingStrategy();
+
+  public static boolean MINIMIZING_ENABLED = true;
+  public static int USE_PARALLEL_MINIMIZE_IF_ENTRIES_MORE_THAN = 1000;
 
   @Override
   public Typing createTyping(Chain<Local> locals) {
@@ -81,18 +92,54 @@ public class DefaultTypingStrategy implements ITypingStrategy {
 
   @Override
   public void minimize(List<Typing> tgs, IHierarchy h) {
+    if (!MINIMIZING_ENABLED) {
+      return;
+    }
+
+    if (tgs.size() > USE_PARALLEL_MINIMIZE_IF_ENTRIES_MORE_THAN) {
+      minimizeParallel(tgs, h);
+      return;
+    }
+
+    minimizeSequential(tgs, h);
+  }
+
+  public void minimizeSequential(List<Typing> tgs, IHierarchy h) {
+    // int count = 0;
+    // int tgsSize = tgs.size();
     Set<Local> objectVars = getObjectLikeTypings(tgs);
     OUTER: for (ListIterator<Typing> i = tgs.listIterator(); i.hasNext();) {
       Typing tgi = i.next();
+      // count++;
+      // if (count % 500 == 0) {
+      // logger.info("{} of {} = {}%", count, tgsSize, 100f * count / tgsSize);
+      // }
+      if (tgi == null) {
+        // element is marked to be deleted, here we can finally remove it
+        i.remove();
+        continue;
+      }
 
       // Throw out duplicate typings
-      for (Typing tgj : tgs) {
-        // if compare = 1, then tgi is the more general typing
-        // We shouldn't pick that one as we would then end up
-        // with lots of locals typed to Serializable etc.
-        if (tgi != tgj && compare(tgi, tgj, h, objectVars) == 1) {
+      ListIterator<Typing> j = tgs.listIterator(i.nextIndex());
+      while (j.hasNext()) {
+        Typing tgj = j.next();
+        if (tgj == null) {
+          continue; // element is marked to be deleted
+        }
+        int comp = compare(tgi, tgj, h, objectVars);
+        if (comp == 1) {
+          // if compare = 1, then tgi is the more general typing
+          // We shouldn't pick that one as we would then end up
+          // with lots of locals typed to Serializable etc.
           i.remove();
           continue OUTER;
+        } else if (comp == -1) {
+          // if compare == -1, then tgj is the more general typing
+          // Set it to null as workaround for marking it as deleted.
+          // We can not remove the element here as this would cause a
+          // ConcurrentModificationException in the outer list iterator.
+          j.set(null);
         }
       }
     }
@@ -109,14 +156,16 @@ public class DefaultTypingStrategy implements ITypingStrategy {
           cmp = 0;
         } else if (h.ancestor(ta, tb)) {
           cmp = 1;
+          if (r == -1) {
+            return 2;
+          }
         } else if (h.ancestor(tb, ta)) {
           cmp = -1;
+          if (r == 1) {
+            return 2;
+          }
         } else {
           return -2;
-        }
-
-        if ((cmp == 1 && r == -1) || (cmp == -1 && r == 1)) {
-          return 2;
         }
         if (r == 0) {
           r = cmp;
@@ -124,6 +173,63 @@ public class DefaultTypingStrategy implements ITypingStrategy {
       }
     }
     return r;
+  }
+
+  public void minimizeParallel(List<Typing> tgs, IHierarchy h) {
+    logger.debug("Performing parallel minimization");
+    Set<Local> objectVars = getObjectLikeTypings(tgs);
+
+    // We don't know what type of list we get, we need a list that is thread safe for get/set
+    // values. (get could return stale values, but this would not cause harm)
+    ArrayList<Typing> workList = new ArrayList<>(tgs);
+    final AtomicInteger processed = new AtomicInteger();
+    final int tgsSize = tgs.size();
+
+    // We iterate over the list using the list item index.
+    // This way we have something like a parallel list iterator.
+    // The only disadvantage is that we can not delete items from the list.
+    // As workaround we replace those entries with a null value (mark them for deletion).
+    IntStream.range(0, tgsSize).parallel().forEach(i -> {
+      int count = processed.incrementAndGet();
+      if (count % 1000 == 0) {
+        logger.debug("minimizing {} = {}%", count, (100f * count) / tgsSize);
+      }
+      Typing tgi = workList.get(i);
+      if (tgi == null) {
+        return;
+      }
+      ListIterator<Typing> j = workList.listIterator(i + 1);
+      while (j.hasNext()) {
+        Typing tgj = j.next();
+        if (tgj == null) {
+          continue;
+        }
+        int comp = compare(tgi, tgj, h, objectVars);
+        if (comp == 1) {
+          // if compare = 1, then tgi is the more general typing
+          // We shouldn't pick that one as we would then end up
+          // with lots of locals typed to Serializable etc.
+          // Set it to null as workaround for marking it as deleted.
+          workList.set(i, null);
+          return;
+        } else if (comp == -1) {
+          // if compare == -1, then tgj is the more general typing
+          // Set it to null as workaround for marking it as deleted.
+          j.set(null);
+        }
+      }
+    });
+    // remove all null entries (entries marked for deletion)
+    for (int i = tgsSize - 1; i >= 0; i--) {
+      if (workList.get(i) == null) {
+        tgs.remove(i);
+      }
+    }
+
+    int diff = tgsSize - tgs.size();
+    if (diff > 0) {
+      logger.debug("Minimizing has removed {} of {} typing", diff, tgsSize);
+    }
   }
 
   @Override

--- a/src/test/java/soot/jimple/toolkits/typing/DefaultTypingStrategyMinimizeParallelTest.java
+++ b/src/test/java/soot/jimple/toolkits/typing/DefaultTypingStrategyMinimizeParallelTest.java
@@ -1,0 +1,47 @@
+package soot.jimple.toolkits.typing;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997 - 2018 Raja Vallée-Rai and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.List;
+
+import soot.jimple.toolkits.typing.fast.BytecodeHierarchy;
+import soot.jimple.toolkits.typing.fast.DefaultTypingStrategy;
+import soot.jimple.toolkits.typing.fast.Typing;
+
+/**
+ * JUnit-Tests for the {@link DefaultTypingStrategy#minimizeParallel(List, soot.jimple.toolkits.typing.fast.IHierarchy)}
+ * method.
+ * 
+ * For each test we generate a simple synthetic class hierarchy and some {@link Typing}s we minimize afterwards and check the
+ * result. The test are the same as in {@link DefaultTypingStrategyMinimizeSequentialTest}.
+ * 
+ * @author Jan Peter Stotz
+ */
+public class DefaultTypingStrategyMinimizeParallelTest extends DefaultTypingStrategyMinimizeSequentialTest {
+
+  @Override
+  protected void executeMinimize(List<Typing> typingList) {
+    new DefaultTypingStrategy().minimizeParallel(typingList, new BytecodeHierarchy());
+  }
+
+}

--- a/src/test/java/soot/jimple/toolkits/typing/DefaultTypingStrategyMinimizeSequentialTest.java
+++ b/src/test/java/soot/jimple/toolkits/typing/DefaultTypingStrategyMinimizeSequentialTest.java
@@ -22,9 +22,9 @@ package soot.jimple.toolkits.typing;
  * #L%
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,20 +44,18 @@ import soot.Type;
 import soot.jimple.internal.JimpleLocal;
 import soot.jimple.toolkits.typing.fast.BytecodeHierarchy;
 import soot.jimple.toolkits.typing.fast.DefaultTypingStrategy;
-import soot.jimple.toolkits.typing.fast.ITypingStrategy;
 import soot.jimple.toolkits.typing.fast.Typing;
 import soot.options.Options;
 
 /**
- * JUnit-Tests for the {@link Typing#minimize(List, soot.jimple.toolkits.typing.fast.IHierarchy)} method.
+ * JUnit-Tests for the {@link DefaultTypingStrategy#minimize(List, soot.jimple.toolkits.typing.fast.IHierarchy)} method.
  * 
  * For each test we generate a simple synthetic class hierarchy and some {@link Typing}s we minimize afterwards and check the
  * result.
  * 
  * @author Fabian Brenner, Jan Peter Stotz
  */
-
-public class TypingMinimizeTest {
+public class DefaultTypingStrategyMinimizeSequentialTest {
 
   /******************************************************
    * Analysis of 29 Android apps with multiple typings:
@@ -122,7 +120,7 @@ public class TypingMinimizeTest {
    *
    */
 
-  private static final Logger logger = LoggerFactory.getLogger(TypingMinimizeTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(DefaultTypingStrategyMinimizeSequentialTest.class);
 
   Type stringType;
   Type integerType;
@@ -155,7 +153,6 @@ public class TypingMinimizeTest {
 
   @Before
   public void init() {
-
     G.reset();
     Options o = Options.v();
     o.prepend_classpath();
@@ -166,11 +163,9 @@ public class TypingMinimizeTest {
     Scene.v().loadClassAndSupport("java.lang.Object");
 
     generateClasses();
-
   }
 
   private void generateClasses() {
-
     SootClass sClass = new SootClass("Interface", Modifier.INTERFACE);
     Scene.v().addClass(sClass);
 
@@ -238,12 +233,10 @@ public class TypingMinimizeTest {
     class_AbstractType = Scene.v().getType("Class_Abstract");
     fatherClassType = Scene.v().getType("FatherClass");
     childClassType = Scene.v().getType("ChildClass");
-
   }
 
   @Test
   public void testMostCommonTypingPairs_1() {
-
     logger.debug("Starting Object Random Minimize");
 
     List<Typing> typingList = new ArrayList<>();
@@ -261,19 +254,14 @@ public class TypingMinimizeTest {
     typing2.set(x1, Type2);
     typingList.add(typing2);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(2, typingList.size());
     assertEquals(resultTyping, typingList.get(0));
   }
 
-  private ITypingStrategy getTypingStrategy() {
-    return new DefaultTypingStrategy();
-  }
-
   @Test
   public void testMostCommonTypingPairs_2() {
-
     logger.debug("Starting Object Random Minimize");
 
     List<Typing> typingList = new ArrayList<>();
@@ -295,7 +283,7 @@ public class TypingMinimizeTest {
     typing3.set(x1, Type3);
     typingList.add(typing3);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(2, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing2, typing3));
@@ -327,7 +315,7 @@ public class TypingMinimizeTest {
     typing4.set(x1, Type4);
     typingList.add(typing4);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(2, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing1, typing3));
@@ -335,7 +323,6 @@ public class TypingMinimizeTest {
 
   @Test
   public void testMostCommonTypingPairs_4() {
-
     List<Typing> typingList = new ArrayList<>();
 
     Type Type1 = cloneableType;
@@ -356,7 +343,7 @@ public class TypingMinimizeTest {
     typing3.set(x1, Type3);
     typingList.add(typing3);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(3, typingList.size());
 
@@ -369,7 +356,6 @@ public class TypingMinimizeTest {
    */
   @Test
   public void testHugeCommonTypingPair() {
-
     List<Typing> typingList = new ArrayList<>();
 
     Type Type1 = serializableType;
@@ -426,7 +412,7 @@ public class TypingMinimizeTest {
     typing8.set(x3, Type2);
     typingList.add(typing8);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(8, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing1, typing2, typing3, typing4, typing5, typing6, typing7, typing8));
@@ -434,7 +420,6 @@ public class TypingMinimizeTest {
 
   @Test
   public void testAbstractInterfaceTyping() {
-
     List<Typing> typingList = new ArrayList<>();
 
     Local x1 = new JimpleLocal("$x1", null);
@@ -451,7 +436,7 @@ public class TypingMinimizeTest {
     typing3.set(x1, class_AbstractInterfaceClassType);
     typingList.add(typing3);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(1, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing3));
@@ -459,7 +444,6 @@ public class TypingMinimizeTest {
 
   @Test
   public void testAbstractAbstractTyping() {
-
     logger.debug("Starting Object Random Minimize");
 
     List<Typing> typingList = new ArrayList<>();
@@ -477,7 +461,7 @@ public class TypingMinimizeTest {
     typing3.set(x1, abstractClass_Interface2Type);
     typingList.add(typing3);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(1, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing3));
@@ -485,7 +469,6 @@ public class TypingMinimizeTest {
 
   @Test
   public void testJavaInterfaceTyping() {
-
     List<Typing> typingList = new ArrayList<>();
 
     Local x1 = new JimpleLocal("$x1", null);
@@ -502,7 +485,7 @@ public class TypingMinimizeTest {
     typing3.set(x1, numberType);
     typingList.add(typing3);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(2, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing2, typing1));
@@ -510,7 +493,6 @@ public class TypingMinimizeTest {
 
   @Test
   public void testInterfaceInterfaceTyping() {
-
     List<Typing> typingList = new ArrayList<>();
 
     Local x1 = new JimpleLocal("$x1", null);
@@ -527,7 +509,7 @@ public class TypingMinimizeTest {
     typing3.set(x1, numberType);
     typingList.add(typing3);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(2, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing2, typing3));
@@ -541,7 +523,6 @@ public class TypingMinimizeTest {
    */
   @Test
   public void testAllRelatedClassesTyping() {
-
     List<Typing> typingList = new ArrayList<>();
     Local x1 = new JimpleLocal("$x1", null);
 
@@ -589,7 +570,7 @@ public class TypingMinimizeTest {
     typing11.set(x1, childClassType);
     typingList.add(typing11);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(5, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing2, typing5, typing7, typing9, typing11));
@@ -600,7 +581,6 @@ public class TypingMinimizeTest {
    */
   @Test
   public void testAllNonRelatedClassesTyping() {
-
     List<Typing> typingList = new ArrayList<>();
     Local x1 = new JimpleLocal("$x1", null);
 
@@ -636,10 +616,14 @@ public class TypingMinimizeTest {
     typing8.set(x1, fatherClassType);
     typingList.add(typing8);
 
-    getTypingStrategy().minimize(typingList, new BytecodeHierarchy());
+    executeMinimize(typingList);
 
     assertEquals(7, typingList.size());
     assertThat(typingList, containsInAnyOrder(typing2, typing3, typing4, typing5, typing6, typing7, typing8));
+  }
+
+  protected void executeMinimize(List<Typing> typingList) {
+    new DefaultTypingStrategy().minimizeSequential(typingList, new BytecodeHierarchy());
   }
 
 }


### PR DESCRIPTION
I have implemented the optimization outlined in this post https://github.com/soot-oss/soot/issues/1053#issuecomment-2012823796 that reduces the minimization time by 50%.

Unfortunately, as the algorithm itself still has the complexity O(n<sup>2</sup>) certain large methods still can block method body generation for a long time.   

A second implemented improvement allows to parallelize minimization. As multi-core system are common nowadays this can reduce the time necessary to perform typing minimization. Parallelization is in this PR enabled if there are more than 1000 Typing available. 

In the end this is not a real solution but it can increase the number apps that can be analyzed within a certain time (e.g. 24 hours). 

Unit tests has been adapted to cover both sequential and parallel implementation.