### PR TITLE
Spark: Do not abort with an exception when encountering weird code

### DIFF
--- a/src/main/java/soot/jimple/spark/builder/MethodNodeFactory.java
+++ b/src/main/java/soot/jimple/spark/builder/MethodNodeFactory.java
@@ -469,4 +469,13 @@ public class MethodNodeFactory extends AbstractShimpleValueSwitch {
   protected final MethodPAG mpag;
   protected SootMethod method;
   protected ClientAccessibilityOracle accessibilityOracle = Scene.v().getClientAccessibilityOracle();
+
+  /**
+   * Returns the method
+   * 
+   * @return the method
+   */
+  public SootMethod getMethod() {
+    return method;
+  }
 }

--- a/src/main/java/soot/jimple/spark/pag/PAG.java
+++ b/src/main/java/soot/jimple/spark/pag/PAG.java
@@ -25,7 +25,6 @@ package soot.jimple.spark.pag;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/soot/jimple/spark/pag/PAG.java
+++ b/src/main/java/soot/jimple/spark/pag/PAG.java
@@ -1,16 +1,5 @@
 package soot.jimple.spark.pag;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -35,6 +24,18 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import soot.Context;
 import soot.FastHierarchy;


### PR DESCRIPTION
Previously, when we see that the returned value of a method call to a void method is used, we would throw an exception and abort