### PR TITLE
Fix array type detection on fill-array-data DEX instructions - fixes #1806

### DIFF
--- a/src/main/java/soot/dexpler/DexBody.java
+++ b/src/main/java/soot/dexpler/DexBody.java
@@ -40,7 +40,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.jf.dexlib2.analysis.ClassPath;
 import org.jf.dexlib2.analysis.ClassPathResolver;
@@ -771,6 +770,7 @@ public class DexBody {
       DeadAssignmentEliminator.v().transform(jBody);
       UnconditionalBranchFolder.v().transform(jBody);
     }
+    DexFillArrayDataTransformer.v().transform(jBody);
 
     TypeAssigner.v().transform(jBody);
 

--- a/src/main/java/soot/dexpler/DexFillArrayDataTransformer.java
+++ b/src/main/java/soot/dexpler/DexFillArrayDataTransformer.java
@@ -1,0 +1,138 @@
+package soot.dexpler;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2012 Michael Markert, Frank Hartmann
+ *
+ * (c) 2012 University of Luxembourg - Interdisciplinary Centre for
+ * Security Reliability and Trust (SnT) - All rights reserved
+ * Alexandre Bartel
+ *
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import soot.ArrayType;
+import soot.Body;
+import soot.BodyTransformer;
+import soot.G;
+import soot.Local;
+import soot.Type;
+import soot.Unit;
+import soot.Value;
+import soot.dexpler.instructions.FillArrayDataInstruction;
+import soot.dexpler.typing.UntypedConstant;
+import soot.jimple.ArrayRef;
+import soot.jimple.AssignStmt;
+import soot.jimple.InvokeExpr;
+import soot.jimple.NewArrayExpr;
+import soot.toolkits.graph.ExceptionalUnitGraph;
+import soot.toolkits.graph.ExceptionalUnitGraphFactory;
+import soot.toolkits.scalar.LocalDefs;
+
+/**
+ * If Dalvik bytecode can contain <code>fill-array-data</code> instructions that can fill an array with data elements we only
+ * know the element size of.
+ * 
+ * Therefore when processing such instructions in {@link FillArrayDataInstruction} we don't know the exact type of the data
+ * that is loaded. Because of (conditional) branches in the code, identifying the type is not always possible at that stage.
+ * Instead {@link UntypedConstant} constants are used. These constants are processed by this transformer and get their final
+ * type.
+ * 
+ *
+ * @author Jan Peter Stotz
+ *
+ */
+public class DexFillArrayDataTransformer extends BodyTransformer {
+  private static final Logger logger = LoggerFactory.getLogger(DexFillArrayDataTransformer.class);
+
+  public static DexFillArrayDataTransformer v() {
+    return new DexFillArrayDataTransformer();
+  }
+
+  protected void internalTransform(final Body body, String phaseName, Map<String, String> options) {
+    final ExceptionalUnitGraph g = ExceptionalUnitGraphFactory.createExceptionalUnitGraph(body, DalvikThrowAnalysis.v());
+    final LocalDefs defs = G.v().soot_toolkits_scalar_LocalDefsFactory().newLocalDefs(g);
+
+    for (Iterator<Unit> unitIt = body.getUnits().snapshotIterator(); unitIt.hasNext();) {
+      Unit u = unitIt.next();
+      if (!(u instanceof AssignStmt)) {
+        continue;
+      }
+      AssignStmt ass = (AssignStmt) u;
+      Value rightOp = ass.getRightOp();
+      if (rightOp instanceof UntypedConstant) {
+        Value left = ass.getLeftOp();
+        if (left instanceof ArrayRef) {
+          ArrayRef leftArray = (ArrayRef) left;
+
+          Local l = (Local) leftArray.getBase();
+          List<Unit> assDefs = defs.getDefsOfAt(l, ass);
+          List<Type> arrayTypes = new LinkedList<>();
+          for (Unit d : assDefs) {
+            if (d instanceof AssignStmt) {
+              AssignStmt arrayAssign = (AssignStmt) d;
+              Value source = arrayAssign.getRightOp();
+              if (source instanceof NewArrayExpr) {
+                NewArrayExpr newArray = (NewArrayExpr) source;
+                arrayTypes.add(newArray.getBaseType());
+                continue;
+              }
+              if (source instanceof InvokeExpr) {
+                InvokeExpr invExpr = (InvokeExpr) source;
+                Type aType = invExpr.getMethodRef().getReturnType();
+                if (!(aType instanceof ArrayType)) {
+                  throw new InternalError("Failed to identify the array type. The identified method invocation "
+                      + "does not return an array type. Invocation: " + invExpr.getMethodRef());
+                }
+                arrayTypes.add(((ArrayType) aType).getArrayElementType());
+                continue;
+              }
+              throw new InternalError("Unsupported array definition statement: " + d);
+            }
+          }
+          if (arrayTypes.isEmpty()) {
+            throw new InternalError("Failed to determine the array type ");
+          }
+          if (arrayTypes.size() > 1) {
+            arrayTypes = arrayTypes.stream().distinct().collect(Collectors.toList());
+            if (arrayTypes.size() > 1) {
+              logger.warn("Found multiple possible array types, using first ignoreing the others: {}", arrayTypes);
+            }
+          }
+
+          // We found the array type, now convert the untyped constant value to it's final type
+          Type elementType = arrayTypes.get(0);
+          Value constant = ass.getRightOp();
+          UntypedConstant untyped = (UntypedConstant) constant;
+          ass.setRightOp(untyped.defineType(elementType));
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/java/soot/dexpler/DexFillArrayDataTransformer.java
+++ b/src/main/java/soot/dexpler/DexFillArrayDataTransformer.java
@@ -70,6 +70,8 @@ import soot.toolkits.scalar.LocalDefs;
 public class DexFillArrayDataTransformer extends BodyTransformer {
   private static final Logger logger = LoggerFactory.getLogger(DexFillArrayDataTransformer.class);
 
+  private static final int MAX_RECURSION_DEPTH = 5;
+
   public static DexFillArrayDataTransformer v() {
     return new DexFillArrayDataTransformer();
   }
@@ -92,7 +94,7 @@ public class DexFillArrayDataTransformer extends BodyTransformer {
 
           Local l = (Local) leftArray.getBase();
           List<Type> arrayTypes = new LinkedList<>();
-          checkArrayDefinitions(l, ass, defs, arrayTypes);
+          checkArrayDefinitions(l, ass, defs, arrayTypes, MAX_RECURSION_DEPTH);
           if (arrayTypes.isEmpty()) {
             throw new InternalError("Failed to determine the array type ");
           }
@@ -124,8 +126,14 @@ public class DexFillArrayDataTransformer extends BodyTransformer {
    * @param defs
    * @param arrayTypes
    *          result list containing the discovered array type(s)
+   * @param maxDepth
    */
-  private void checkArrayDefinitions(Local l, Unit u, LocalDefs defs, List<Type> arrayTypes) {
+  private void checkArrayDefinitions(Local l, Unit u, LocalDefs defs, List<Type> arrayTypes, int maxDepth) {
+    if (maxDepth <= 0) {
+      // Avoid infinite recursion
+      logger.warn("Recursion depth limit reached - aborting");
+      return;
+    }
     List<Unit> assDefs = defs.getDefsOfAt(l, u);
     for (Unit d : assDefs) {
       if (d instanceof AssignStmt) {
@@ -135,9 +143,7 @@ public class DexFillArrayDataTransformer extends BodyTransformer {
           // array is assigned from a newly created array
           NewArrayExpr newArray = (NewArrayExpr) source;
           arrayTypes.add(newArray.getBaseType());
-          continue;
-        }
-        if (source instanceof InvokeExpr) {
+        } else if (source instanceof InvokeExpr) {
           // array is assigned from the return value of a function
           InvokeExpr invExpr = (InvokeExpr) source;
           Type aType = invExpr.getMethodRef().getReturnType();
@@ -146,15 +152,13 @@ public class DexFillArrayDataTransformer extends BodyTransformer {
                 + "does not return an array type. Invocation: " + invExpr.getMethodRef());
           }
           arrayTypes.add(((ArrayType) aType).getArrayElementType());
-          continue;
-        }
-        if (source instanceof Local) {
+        } else if (source instanceof Local) {
           // our array is defined by an assignment from another array => check the definition of that other array.
           Local newLocal = (Local) source; // local of the "other array"
-          checkArrayDefinitions(newLocal, d, defs, arrayTypes);
-          continue;
+          checkArrayDefinitions(newLocal, d, defs, arrayTypes, maxDepth - 1);
+        } else {
+          throw new InternalError("Unsupported array definition statement: " + d);
         }
-        throw new InternalError("Unsupported array definition statement: " + d);
       }
     }
 

--- a/src/main/java/soot/dexpler/typing/UntypedIntOrFloatConstant.java
+++ b/src/main/java/soot/dexpler/typing/UntypedIntOrFloatConstant.java
@@ -70,6 +70,13 @@ public class UntypedIntOrFloatConstant extends UntypedConstant {
     return IntConstant.v(value);
   }
 
+  public IntConstant toBooleanConstant() {
+    if (value != 0) {
+      return IntConstant.v(1);
+    }
+    return IntConstant.v(value);
+  }
+
   @Override
   public Value defineType(Type t) {
     if (t instanceof FloatType) {
@@ -77,6 +84,8 @@ public class UntypedIntOrFloatConstant extends UntypedConstant {
     } else if (t instanceof IntType || t instanceof CharType || t instanceof BooleanType || t instanceof ByteType
         || t instanceof ShortType) {
       return this.toIntConstant();
+    } else if (t instanceof BooleanType) {
+      return toBooleanConstant();
     } else {
       if (value == 0 && t instanceof RefLikeType) {
         return NullConstant.v();


### PR DESCRIPTION
The previous `FillArrayDataInstruction` which converts DEX instructions to Jimpl instructions had two major problems:

1. The array type detection was only recognizing new-array instructions, not array that are created as a return value of a function
2. For detecting the array type it used a simple algorithm that inspected the DEX instructions before the fill-array-data instruction, not considering (conditional) branches of the control flow. This caused two problems: 
3. If the array type could not be detected a warning was logged and the fill-array-data instruction completely ignored
4. If multiple array were defined in a method with non-linear control flow the wrong array-new instruction could be assigned to the fill-array-data instruction causing various problems in the command itself or in a later phase.

The `FillArrayDataInstruction` implementation provided by this PR splits processing of fill-array-data instructions into two phases:

1. Command transforming to Jimple instructions, as the array type is not known the elements are stored as `UntypedConstant` 
2. In the second phase the new `DexFillArrayDataTransformer` checks AssignStatements that assign an `UntypedConstant` to an array element. It recovers the array data types and applies it to each value.

Note: The time to execute `DexFillArrayDataTransformer.v().transform(jBody);` was chosen as it is the latest possible point in time to execute it. The next transformer `TypeAssigner.v().transform(jBody);` can not handle `UntypedConstant` and thus throws an exception if it encounters one. 

In a test the new implementation was used to process ~350 recent Android apps. 
