### PR TITLE
Fix ASM generating invalid references for static methods in interface

### DIFF
--- a/src/main/java/soot/baf/BafASMBackend.java
+++ b/src/main/java/soot/baf/BafASMBackend.java
@@ -1388,7 +1388,7 @@ public class BafASMBackend extends AbstractASMBackend {
       public void caseStaticInvokeInst(StaticInvokeInst i) {
         SootMethodRef m = i.getMethodRef();
         mv.visitMethodInsn(Opcodes.INVOKESTATIC, slashify(m.declaringClass().getName()), m.name(), toTypeDesc(m),
-            m.declaringClass().isInterface() && !m.isStatic());
+            m.declaringClass().isInterface());
       }
 
       @Override


### PR DESCRIPTION
Static calls to interface methods should use InterfaceMethodRefs instead of MethodRefs. Otherwise, newer JVM versions will throw an IncompatibleClassChangeError.

See https://github.com/openjdk/jdk/commit/c36295e947397cf70ccc1e976a0f866a94b3ab2b#diff-2e49825df1451e2d44694826a70e86bf1a511371482e4de50f7ef09c300bd9bbR780 and https://bugs.openjdk.org/browse/JDK-8145148?focusedCommentId=13958798&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13958798 for more details.