### PR TITLE
Update ScopeFinderTarget.java

### DIFF
--- a/src/systemTest/targets/soot/asm/ScopeFinderTarget.java
+++ b/src/systemTest/targets/soot/asm/ScopeFinderTarget.java
@@ -43,7 +43,6 @@ public class ScopeFinderTarget {
     field = new Object();
   }
 
-  @Nullable
   public void method() {
     System.out.println("in method");
   }


### PR DESCRIPTION
The key issue here is the use of @Nullable with void. This is problematic because:

1. The @Nullable annotation is meant to indicate that a method can return null
2. However, void means the method doesn't return anything at all
3. Therefore, @Nullable on a void method is meaningless and incorrect

In most IDEs, this would likely trigger a warning because it's a nonsensical combination. The method itself (printing "in method") would work fine, but the annotation serves no purpose and is technically incorrect.