### PR TITLE
Remove getParameterRefs()

### DIFF
--- a/src/main/java/soot/Body.java
+++ b/src/main/java/soot/Body.java
@@ -445,37 +445,6 @@ public abstract class Body extends AbstractHost implements Serializable {
   }
 
   /**
-   * Returns the list of parameter references used in this body. The list is as long as the number of parameters declared in
-   * the associated method's signature. The list may have <code>null</code> entries for parameters not referenced in the
-   * body. The returned list is of fixed size.
-   *
-   * @return
-   */
-  public List<Value> getParameterRefs() {
-    final int numParams = getMethod().getParameterCount();
-    Value[] res = new Value[numParams];
-    int numFound = 0;
-    for (Unit u : getUnits()) {
-      if (u instanceof IdentityStmt) {
-        Value rightOp = ((IdentityStmt) u).getRightOp();
-        if (rightOp instanceof ParameterRef) {
-          ParameterRef pr = (ParameterRef) rightOp;
-          int idx = pr.getIndex();
-          if (res[idx] != null) {
-            throw new RuntimeException("duplicate parameterref" + idx + " in " + getMethod());
-          }
-          res[idx] = pr;
-          numFound++;
-          if (numFound >= numParams) {
-            break;
-          }
-        }
-      }
-    }
-    return Arrays.asList(res);
-  }
-
-  /**
    * Returns the Chain of Units that make up this body. The units are returned as a PatchingChain. The client can then
    * manipulate the chain, adding and removing units, and the changes will be reflected in the body. Since a PatchingChain is
    * returned the client need <i>not</i> worry about removing exception boundary units or otherwise corrupting the chain.

--- a/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
@@ -42,7 +42,6 @@ import soot.PatchingChain;
 import soot.SootMethod;
 import soot.Unit;
 import soot.UnitBox;
-import soot.Value;
 import soot.jimple.Stmt;
 import soot.toolkits.graph.BriefUnitGraph;
 import soot.toolkits.graph.DirectedGraph;
@@ -61,15 +60,6 @@ public abstract class AbstractJimpleBasedICFG implements BiDiInterproceduralCFG<
         @Override
         public DirectedGraph<Unit> load(Body body) throws Exception {
           return makeGraph(body);
-        }
-      });
-
-  @SynchronizedBy("by use of synchronized LoadingCache class")
-  protected LoadingCache<SootMethod, List<Value>> methodToParameterRefs
-      = IDESolver.DEFAULT_CACHE_BUILDER.build(new CacheLoader<SootMethod, List<Value>>() {
-        @Override
-        public List<Value> load(SootMethod m) throws Exception {
-          return m.getActiveBody().getParameterRefs();
         }
       });
 
@@ -183,11 +173,6 @@ public abstract class AbstractJimpleBasedICFG implements BiDiInterproceduralCFG<
       }
     }
     return false;
-  }
-
-  @Override
-  public List<Value> getParameterRefs(SootMethod m) {
-    return methodToParameterRefs.getUnchecked(m);
   }
 
   @Override

--- a/src/main/java/soot/jimple/toolkits/ide/icfg/BackwardsInterproceduralCFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/BackwardsInterproceduralCFG.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import soot.SootMethod;
 import soot.Unit;
-import soot.Value;
 import soot.toolkits.graph.DirectedGraph;
 
 /**
@@ -137,12 +136,6 @@ public class BackwardsInterproceduralCFG implements BiDiInterproceduralCFG<Unit,
   @Override
   public DirectedGraph<Unit> getOrCreateUnitGraph(SootMethod m) {
     return delegate.getOrCreateUnitGraph(m);
-  }
-
-  // same
-  @Override
-  public List<Value> getParameterRefs(SootMethod m) {
-    return delegate.getParameterRefs(m);
   }
 
   @Override

--- a/src/main/java/soot/jimple/toolkits/ide/icfg/BiDiInterproceduralCFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/BiDiInterproceduralCFG.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import soot.Value;
 import soot.toolkits.graph.DirectedGraph;
 
 /**
@@ -46,8 +45,6 @@ public interface BiDiInterproceduralCFG<N, M> extends InterproceduralCFG<N, M> {
 
   // also exposed to some clients who need it
   public DirectedGraph<N> getOrCreateUnitGraph(M body);
-
-  public List<Value> getParameterRefs(M m);
 
   /**
    * Gets whether the given statement is a return site of at least one call


### PR DESCRIPTION
For most use cases, getting the parameter refs is pointless. The only information the parameter refs offer is parameter type information that can be obtained by other means.