### PR TITLE
Use Linux line endings on all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+*       text=auto eol=lf
+
+*.java  text eol=lf diff=java
+
+*.bat   text eol=crlf
+
+*.jpg   binary
+*.pdf   binary
+*.jar   binary
+*.zip   binary


### PR DESCRIPTION
When building soot on Windows you have to manually configure git to check-out soot using Linux line endings, otherwise Maven will always create Option classes that just differ regarding their line ending. But those files are still considered as modified by git. 

The `.gitattributes` file from this PR automatically tells GIT how to handle files regarding their line-ending which is helpful especially on Windows.