### PR TITLE
Bypass singleton pattern for commonly used types

### DIFF
--- a/src/main/generated/singletons/soot/Singletons.java
+++ b/src/main/generated/singletons/soot/Singletons.java
@@ -356,20 +356,6 @@ public class Singletons {
     	instance_soot_baf_Baf = null;
     }
 
-    private soot.BooleanType instance_soot_BooleanType;
-    public soot.BooleanType soot_BooleanType() {
-        if (instance_soot_BooleanType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_BooleanType == null)
-	        		instance_soot_BooleanType = new soot.BooleanType(g);
-	       	}
-       	}
-        return instance_soot_BooleanType;
-    }
-    protected void release_soot_BooleanType() {
-    	instance_soot_BooleanType = null;
-    }
-
     private soot.jimple.toolkits.scalar.pre.BusyCodeMotion instance_soot_jimple_toolkits_scalar_pre_BusyCodeMotion;
     public soot.jimple.toolkits.scalar.pre.BusyCodeMotion soot_jimple_toolkits_scalar_pre_BusyCodeMotion() {
         if (instance_soot_jimple_toolkits_scalar_pre_BusyCodeMotion == null) {
@@ -384,34 +370,6 @@ public class Singletons {
     	instance_soot_jimple_toolkits_scalar_pre_BusyCodeMotion = null;
     }
 
-    private soot.ByteType instance_soot_ByteType;
-    public soot.ByteType soot_ByteType() {
-        if (instance_soot_ByteType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_ByteType == null)
-	        		instance_soot_ByteType = new soot.ByteType(g);
-	       	}
-       	}
-        return instance_soot_ByteType;
-    }
-    protected void release_soot_ByteType() {
-    	instance_soot_ByteType = null;
-    }
-
-    private soot.UByteType instance_soot_UByteType;
-    public soot.UByteType soot_UByteType() {
-        if (instance_soot_UByteType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_UByteType == null)
-	        		instance_soot_UByteType = new soot.UByteType(g);
-	       	}
-       	}
-        return instance_soot_UByteType;
-    }
-    protected void release_soot_UByteType() {
-    	instance_soot_UByteType = null;
-    }
-
     private soot.jimple.toolkits.pointer.CastCheckEliminatorDumper instance_soot_jimple_toolkits_pointer_CastCheckEliminatorDumper;
     public soot.jimple.toolkits.pointer.CastCheckEliminatorDumper soot_jimple_toolkits_pointer_CastCheckEliminatorDumper() {
         if (instance_soot_jimple_toolkits_pointer_CastCheckEliminatorDumper == null) {
@@ -424,20 +382,6 @@ public class Singletons {
     }
     protected void release_soot_jimple_toolkits_pointer_CastCheckEliminatorDumper() {
     	instance_soot_jimple_toolkits_pointer_CastCheckEliminatorDumper = null;
-    }
-
-    private soot.CharType instance_soot_CharType;
-    public soot.CharType soot_CharType() {
-        if (instance_soot_CharType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_CharType == null)
-	        		instance_soot_CharType = new soot.CharType(g);
-	       	}
-       	}
-        return instance_soot_CharType;
-    }
-    protected void release_soot_CharType() {
-    	instance_soot_CharType = null;
     }
 
     private soot.jimple.toolkits.annotation.arraycheck.ClassFieldAnalysis instance_soot_jimple_toolkits_annotation_arraycheck_ClassFieldAnalysis;
@@ -650,20 +594,6 @@ public class Singletons {
     	instance_soot_jimple_toolkits_pointer_DependenceTagAggregator = null;
     }
 
-    private soot.DoubleType instance_soot_DoubleType;
-    public soot.DoubleType soot_DoubleType() {
-        if (instance_soot_DoubleType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_DoubleType == null)
-	        		instance_soot_DoubleType = new soot.DoubleType(g);
-	       	}
-       	}
-        return instance_soot_DoubleType;
-    }
-    protected void release_soot_DoubleType() {
-    	instance_soot_DoubleType = null;
-    }
-
     private soot.baf.DoubleWordType instance_soot_baf_DoubleWordType;
     public soot.baf.DoubleWordType soot_baf_DoubleWordType() {
         if (instance_soot_baf_DoubleWordType == null) {
@@ -748,20 +678,6 @@ public class Singletons {
     	instance_soot_jimple_toolkits_pointer_FieldRWTagger = null;
     }
 
-    private soot.FloatType instance_soot_FloatType;
-    public soot.FloatType soot_FloatType() {
-        if (instance_soot_FloatType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_FloatType == null)
-	        		instance_soot_FloatType = new soot.FloatType(g);
-	       	}
-       	}
-        return instance_soot_FloatType;
-    }
-    protected void release_soot_FloatType() {
-    	instance_soot_FloatType = null;
-    }
-
     private soot.jimple.toolkits.pointer.FullObjectSet instance_soot_jimple_toolkits_pointer_FullObjectSet;
     public soot.jimple.toolkits.pointer.FullObjectSet soot_jimple_toolkits_pointer_FullObjectSet() {
         if (instance_soot_jimple_toolkits_pointer_FullObjectSet == null) {
@@ -802,34 +718,6 @@ public class Singletons {
     }
     protected void release_soot_dava_toolkits_base_finders_IfFinder() {
     	instance_soot_dava_toolkits_base_finders_IfFinder = null;
-    }
-
-    private soot.IntType instance_soot_IntType;
-    public soot.IntType soot_IntType() {
-        if (instance_soot_IntType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_IntType == null)
-	        		instance_soot_IntType = new soot.IntType(g);
-	       	}
-       	}
-        return instance_soot_IntType;
-    }
-    protected void release_soot_IntType() {
-    	instance_soot_IntType = null;
-    }
-
-    private soot.UIntType instance_soot_UIntType;
-    public soot.UIntType soot_UIntType() {
-        if (instance_soot_UIntType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_UIntType == null)
-	        		instance_soot_UIntType = new soot.UIntType(g);
-	       	}
-       	}
-        return instance_soot_UIntType;
-    }
-    protected void release_soot_UIntType() {
-    	instance_soot_UIntType = null;
     }
 
     private soot.jimple.Jimple instance_soot_jimple_Jimple;
@@ -1014,34 +902,6 @@ public class Singletons {
     	instance_soot_toolkits_scalar_FlowSensitiveConstantPropagator = null;
     }
 
-    private soot.LongType instance_soot_LongType;
-    public soot.LongType soot_LongType() {
-        if (instance_soot_LongType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_LongType == null)
-	        		instance_soot_LongType = new soot.LongType(g);
-	       	}
-       	}
-        return instance_soot_LongType;
-    }
-    protected void release_soot_LongType() {
-    	instance_soot_LongType = null;
-    }
-
-    private soot.ULongType instance_soot_ULongType;
-    public soot.ULongType soot_ULongType() {
-        if (instance_soot_ULongType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_ULongType == null)
-	        		instance_soot_ULongType = new soot.ULongType(g);
-	       	}
-       	}
-        return instance_soot_ULongType;
-    }
-    protected void release_soot_ULongType() {
-    	instance_soot_ULongType = null;
-    }
-
     private soot.dava.toolkits.base.misc.MonitorConverter instance_soot_dava_toolkits_base_misc_MonitorConverter;
     public soot.dava.toolkits.base.misc.MonitorConverter soot_dava_toolkits_base_misc_MonitorConverter() {
         if (instance_soot_dava_toolkits_base_misc_MonitorConverter == null) {
@@ -1096,20 +956,6 @@ public class Singletons {
     }
     protected void release_soot_jimple_toolkits_annotation_nullcheck_NullPointerChecker() {
     	instance_soot_jimple_toolkits_annotation_nullcheck_NullPointerChecker = null;
-    }
-
-    private soot.NullType instance_soot_NullType;
-    public soot.NullType soot_NullType() {
-        if (instance_soot_NullType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_NullType == null)
-	        		instance_soot_NullType = new soot.NullType(g);
-	       	}
-       	}
-        return instance_soot_NullType;
-    }
-    protected void release_soot_NullType() {
-    	instance_soot_NullType = null;
     }
 
     private soot.dava.toolkits.base.misc.PackageNamer instance_soot_dava_toolkits_base_misc_PackageNamer;
@@ -1306,48 +1152,6 @@ public class Singletons {
     }
     protected void release_soot_shimple_toolkits_scalar_SConstantPropagatorAndFolder() {
     	instance_soot_shimple_toolkits_scalar_SConstantPropagatorAndFolder = null;
-    }
-
-    private soot.ShortType instance_soot_ShortType;
-    public soot.ShortType soot_ShortType() {
-        if (instance_soot_ShortType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_ShortType == null)
-	        		instance_soot_ShortType = new soot.ShortType(g);
-	       	}
-       	}
-        return instance_soot_ShortType;
-    }
-    protected void release_soot_ShortType() {
-    	instance_soot_ShortType = null;
-    }
-
-    private soot.UShortType instance_soot_UShortType;
-    public soot.UShortType soot_UShortType() {
-        if (instance_soot_UShortType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_UShortType == null)
-	        		instance_soot_UShortType = new soot.UShortType(g);
-	       	}
-       	}
-        return instance_soot_UShortType;
-    }
-    protected void release_soot_UShortType() {
-    	instance_soot_UShortType = null;
-    }
-
-    private soot.DecimalType instance_soot_DecimalType;
-    public soot.DecimalType soot_DecimalType() {
-        if (instance_soot_DecimalType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_DecimalType == null)
-	        		instance_soot_DecimalType = new soot.DecimalType(g);
-	       	}
-       	}
-        return instance_soot_DecimalType;
-    }
-    protected void release_soot_DecimalType() {
-    	instance_soot_DecimalType = null;
     }
 
     private soot.jimple.toolkits.pointer.SideEffectTagger instance_soot_jimple_toolkits_pointer_SideEffectTagger;
@@ -1602,20 +1406,6 @@ public class Singletons {
     	instance_soot_jimple_toolkits_scalar_IdentityOperationEliminator = null;
     }
 
-    private soot.UnknownType instance_soot_UnknownType;
-    public soot.UnknownType soot_UnknownType() {
-        if (instance_soot_UnknownType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_UnknownType == null)
-	        		instance_soot_UnknownType = new soot.UnknownType(g);
-	       	}
-       	}
-        return instance_soot_UnknownType;
-    }
-    protected void release_soot_UnknownType() {
-    	instance_soot_UnknownType = null;
-    }
-
     private soot.jimple.toolkits.scalar.UnreachableCodeEliminator instance_soot_jimple_toolkits_scalar_UnreachableCodeEliminator;
     public soot.jimple.toolkits.scalar.UnreachableCodeEliminator soot_jimple_toolkits_scalar_UnreachableCodeEliminator() {
         if (instance_soot_jimple_toolkits_scalar_UnreachableCodeEliminator == null) {
@@ -1656,20 +1446,6 @@ public class Singletons {
     }
     protected void release_soot_dava_toolkits_base_AST_UselessTryRemover() {
     	instance_soot_dava_toolkits_base_AST_UselessTryRemover = null;
-    }
-
-    private soot.VoidType instance_soot_VoidType;
-    public soot.VoidType soot_VoidType() {
-        if (instance_soot_VoidType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_VoidType == null)
-	        		instance_soot_VoidType = new soot.VoidType(g);
-	       	}
-       	}
-        return instance_soot_VoidType;
-    }
-    protected void release_soot_VoidType() {
-    	instance_soot_VoidType = null;
     }
 
     private soot.baf.WordType instance_soot_baf_WordType;
@@ -2384,62 +2160,6 @@ public class Singletons {
     }
     protected void release_soot_jimple_toolkits_base_RenameDuplicatedClasses() {
     	instance_soot_jimple_toolkits_base_RenameDuplicatedClasses = null;
-    }
-
-    private soot.jimple.toolkits.typing.fast.Integer127Type instance_soot_jimple_toolkits_typing_fast_Integer127Type;
-    public soot.jimple.toolkits.typing.fast.Integer127Type soot_jimple_toolkits_typing_fast_Integer127Type() {
-        if (instance_soot_jimple_toolkits_typing_fast_Integer127Type == null) {
-	       	synchronized (this) {
-		        if (instance_soot_jimple_toolkits_typing_fast_Integer127Type == null)
-	        		instance_soot_jimple_toolkits_typing_fast_Integer127Type = new soot.jimple.toolkits.typing.fast.Integer127Type(g);
-	       	}
-       	}
-        return instance_soot_jimple_toolkits_typing_fast_Integer127Type;
-    }
-    protected void release_soot_jimple_toolkits_typing_fast_Integer127Type() {
-    	instance_soot_jimple_toolkits_typing_fast_Integer127Type = null;
-    }
-
-    private soot.jimple.toolkits.typing.fast.Integer1Type instance_soot_jimple_toolkits_typing_fast_Integer1Type;
-    public soot.jimple.toolkits.typing.fast.Integer1Type soot_jimple_toolkits_typing_fast_Integer1Type() {
-        if (instance_soot_jimple_toolkits_typing_fast_Integer1Type == null) {
-	       	synchronized (this) {
-		        if (instance_soot_jimple_toolkits_typing_fast_Integer1Type == null)
-	        		instance_soot_jimple_toolkits_typing_fast_Integer1Type = new soot.jimple.toolkits.typing.fast.Integer1Type(g);
-	       	}
-       	}
-        return instance_soot_jimple_toolkits_typing_fast_Integer1Type;
-    }
-    protected void release_soot_jimple_toolkits_typing_fast_Integer1Type() {
-    	instance_soot_jimple_toolkits_typing_fast_Integer1Type = null;
-    }
-
-    private soot.jimple.toolkits.typing.fast.Integer32767Type instance_soot_jimple_toolkits_typing_fast_Integer32767Type;
-    public soot.jimple.toolkits.typing.fast.Integer32767Type soot_jimple_toolkits_typing_fast_Integer32767Type() {
-        if (instance_soot_jimple_toolkits_typing_fast_Integer32767Type == null) {
-	       	synchronized (this) {
-		        if (instance_soot_jimple_toolkits_typing_fast_Integer32767Type == null)
-	        		instance_soot_jimple_toolkits_typing_fast_Integer32767Type = new soot.jimple.toolkits.typing.fast.Integer32767Type(g);
-	       	}
-       	}
-        return instance_soot_jimple_toolkits_typing_fast_Integer32767Type;
-    }
-    protected void release_soot_jimple_toolkits_typing_fast_Integer32767Type() {
-    	instance_soot_jimple_toolkits_typing_fast_Integer32767Type = null;
-    }
-
-    private soot.jimple.toolkits.typing.fast.BottomType instance_soot_jimple_toolkits_typing_fast_BottomType;
-    public soot.jimple.toolkits.typing.fast.BottomType soot_jimple_toolkits_typing_fast_BottomType() {
-        if (instance_soot_jimple_toolkits_typing_fast_BottomType == null) {
-	       	synchronized (this) {
-		        if (instance_soot_jimple_toolkits_typing_fast_BottomType == null)
-	        		instance_soot_jimple_toolkits_typing_fast_BottomType = new soot.jimple.toolkits.typing.fast.BottomType(g);
-	       	}
-       	}
-        return instance_soot_jimple_toolkits_typing_fast_BottomType;
-    }
-    protected void release_soot_jimple_toolkits_typing_fast_BottomType() {
-    	instance_soot_jimple_toolkits_typing_fast_BottomType = null;
     }
 
     private soot.dexpler.TrapMinimizer instance_soot_dexpler_TrapMinimizer;

--- a/src/main/java/soot/BooleanType.java
+++ b/src/main/java/soot/BooleanType.java
@@ -35,12 +35,13 @@ import soot.util.Switch;
 public class BooleanType extends PrimType implements IntegerType, IJavaType, DotNetINumber, IIntLikeType {
 
   public static final int HASHCODE = 0x1C4585DA;
+  public static final BooleanType INSTANCE = new BooleanType();
 
-  public BooleanType(Singletons.Global g) {
+  private BooleanType() {
   }
 
   public static BooleanType v() {
-    return G.v().soot_BooleanType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/BooleanType.java
+++ b/src/main/java/soot/BooleanType.java
@@ -38,6 +38,7 @@ public class BooleanType extends PrimType implements IntegerType, IJavaType, Dot
   public static final BooleanType INSTANCE = new BooleanType();
 
   private BooleanType() {
+    super(false);
   }
 
   public static BooleanType v() {

--- a/src/main/java/soot/ByteType.java
+++ b/src/main/java/soot/ByteType.java
@@ -35,12 +35,10 @@ import soot.util.Switch;
 public class ByteType extends PrimType implements IntegerType, IJavaType, DotNetINumber, IIntLikeType {
 
   public static final int HASHCODE = 0x813D1329;
-
-  public ByteType(Singletons.Global g) {
-  }
+  public static final ByteType INSTANCE = new ByteType();
 
   public static ByteType v() {
-    return G.v().soot_ByteType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/ByteType.java
+++ b/src/main/java/soot/ByteType.java
@@ -37,6 +37,10 @@ public class ByteType extends PrimType implements IntegerType, IJavaType, DotNet
   public static final int HASHCODE = 0x813D1329;
   public static final ByteType INSTANCE = new ByteType();
 
+  private ByteType() {
+    super(false);
+  }
+
   public static ByteType v() {
     return INSTANCE;
   }

--- a/src/main/java/soot/CharType.java
+++ b/src/main/java/soot/CharType.java
@@ -38,6 +38,7 @@ public class CharType extends PrimType implements IntegerType, IJavaType, DotNet
   public static final CharType INSTANCE = new CharType();
 
   private CharType() {
+    super(false);
   }
 
   public static CharType v() {

--- a/src/main/java/soot/CharType.java
+++ b/src/main/java/soot/CharType.java
@@ -35,12 +35,13 @@ import soot.util.Switch;
 public class CharType extends PrimType implements IntegerType, IJavaType, DotNetINumber, IIntLikeType {
 
   public static final int HASHCODE = 0x739EA474;
+  public static final CharType INSTANCE = new CharType();
 
-  public CharType(Singletons.Global g) {
+  private CharType() {
   }
 
   public static CharType v() {
-    return G.v().soot_CharType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/DecimalType.java
+++ b/src/main/java/soot/DecimalType.java
@@ -34,12 +34,13 @@ import soot.util.Switch;
 public class DecimalType extends PrimType implements DotNetINumber {
 
   public static final int HASHCODE = 0x2B9D7242;
+  public static final DecimalType INSTANCE = new DecimalType();
 
-  public DecimalType(Singletons.Global g) {
+  private DecimalType() {
   }
 
   public static DecimalType v() {
-    return G.v().soot_DecimalType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/DecimalType.java
+++ b/src/main/java/soot/DecimalType.java
@@ -37,6 +37,7 @@ public class DecimalType extends PrimType implements DotNetINumber {
   public static final DecimalType INSTANCE = new DecimalType();
 
   private DecimalType() {
+    super(false);
   }
 
   public static DecimalType v() {

--- a/src/main/java/soot/DoubleType.java
+++ b/src/main/java/soot/DoubleType.java
@@ -37,6 +37,7 @@ public class DoubleType extends PrimType implements DotNetINumber, IJavaType {
   public static final DoubleType INSTANCE = new DoubleType();
 
   private DoubleType() {
+    super(false);
   }
 
   public static DoubleType v() {

--- a/src/main/java/soot/DoubleType.java
+++ b/src/main/java/soot/DoubleType.java
@@ -34,12 +34,13 @@ import soot.util.Switch;
 public class DoubleType extends PrimType implements DotNetINumber, IJavaType {
 
   public static final int HASHCODE = 0x4B9D7242;
+  public static final DoubleType INSTANCE = new DoubleType();
 
-  public DoubleType(Singletons.Global g) {
+  private DoubleType() {
   }
 
   public static DoubleType v() {
-    return G.v().soot_DoubleType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/FloatType.java
+++ b/src/main/java/soot/FloatType.java
@@ -34,12 +34,13 @@ import soot.util.Switch;
 public class FloatType extends PrimType implements DotNetINumber, IJavaType {
 
   public static final int HASHCODE = 0xA84373FA;
+  public static final FloatType INSTANCE = new FloatType();
 
-  public FloatType(Singletons.Global g) {
+  private FloatType() {
   }
 
   public static FloatType v() {
-    return G.v().soot_FloatType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/FloatType.java
+++ b/src/main/java/soot/FloatType.java
@@ -37,6 +37,7 @@ public class FloatType extends PrimType implements DotNetINumber, IJavaType {
   public static final FloatType INSTANCE = new FloatType();
 
   private FloatType() {
+    super(false);
   }
 
   public static FloatType v() {

--- a/src/main/java/soot/IntType.java
+++ b/src/main/java/soot/IntType.java
@@ -35,12 +35,13 @@ import soot.util.Switch;
 public class IntType extends PrimType implements IntegerType, IJavaType, DotNetINumber, IIntLikeType {
 
   public static final int HASHCODE = 0xB747239F;
+  public static final IntType INSTANCE = new IntType();
 
-  public IntType(Singletons.Global g) {
+  private IntType() {
   }
 
   public static IntType v() {
-    return G.v().soot_IntType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/IntType.java
+++ b/src/main/java/soot/IntType.java
@@ -38,6 +38,7 @@ public class IntType extends PrimType implements IntegerType, IJavaType, DotNetI
   public static final IntType INSTANCE = new IntType();
 
   private IntType() {
+    super(false);
   }
 
   public static IntType v() {

--- a/src/main/java/soot/LongType.java
+++ b/src/main/java/soot/LongType.java
@@ -34,12 +34,13 @@ import soot.util.Switch;
 public class LongType extends PrimType implements IJavaType, DotNetINumber {
 
   public static final int HASHCODE = 0x023DA077;
+  public static final LongType INSTANCE = new LongType();
 
-  public LongType(Singletons.Global g) {
+  private LongType() {
   }
 
   public static LongType v() {
-    return G.v().soot_LongType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/LongType.java
+++ b/src/main/java/soot/LongType.java
@@ -37,6 +37,7 @@ public class LongType extends PrimType implements IJavaType, DotNetINumber {
   public static final LongType INSTANCE = new LongType();
 
   private LongType() {
+    super(false);
   }
 
   public static LongType v() {

--- a/src/main/java/soot/NullType.java
+++ b/src/main/java/soot/NullType.java
@@ -32,6 +32,7 @@ public class NullType extends RefLikeType {
   public static final NullType INSTANCE = new NullType();
 
   private NullType() {
+    super(false);
   }
 
   public static NullType v() {

--- a/src/main/java/soot/NullType.java
+++ b/src/main/java/soot/NullType.java
@@ -29,12 +29,13 @@ import soot.util.Switch;
  */
 @SuppressWarnings("serial")
 public class NullType extends RefLikeType {
+  public static final NullType INSTANCE = new NullType();
 
-  public NullType(Singletons.Global g) {
+  private NullType() {
   }
 
   public static NullType v() {
-    return G.v().soot_NullType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/PrimType.java
+++ b/src/main/java/soot/PrimType.java
@@ -31,6 +31,13 @@ package soot;
 @SuppressWarnings("serial")
 public abstract class PrimType extends Type {
 
+  public PrimType(boolean b) {
+    super(b);
+  }
+
+  public PrimType() {
+  }
+
   public RefType boxedType() {
     return RefType.v(getTypeAsString());
   }

--- a/src/main/java/soot/RefLikeType.java
+++ b/src/main/java/soot/RefLikeType.java
@@ -30,6 +30,14 @@ package soot;
 @SuppressWarnings("serial")
 public abstract class RefLikeType extends Type {
 
+  public RefLikeType(boolean b) {
+    super(b);
+  }
+
+  public RefLikeType() {
+    super();
+  }
+
   /**
    * If I have a variable x of declared type t, what is a good declared type for the expression ((Object[]) x)[i]? The
    * getArrayElementType() method in RefLikeType was introduced even later to answer this question for all classes

--- a/src/main/java/soot/Scene.java
+++ b/src/main/java/soot/Scene.java
@@ -56,7 +56,6 @@ import org.slf4j.LoggerFactory;
 import pxb.android.axml.AxmlReader;
 import pxb.android.axml.AxmlVisitor;
 import pxb.android.axml.NodeVisitor;
-
 import soot.dexpler.DalvikThrowAnalysis;
 import soot.dotnet.exceptiontoolkits.DotnetThrowAnalysis;
 import soot.dotnet.members.DotnetMethod;
@@ -137,6 +136,25 @@ public class Scene {
   protected List<ISootClassAddedListener> classAddedListeners = new ArrayList<>(4);
 
   public Scene(Singletons.Global g) {
+
+    IterableNumberer<Type> tn = getTypeNumberer();
+    tn.add(BooleanType.INSTANCE);
+    tn.add(ByteType.INSTANCE);
+    tn.add(CharType.INSTANCE);
+    tn.add(DecimalType.INSTANCE);
+    tn.add(DoubleType.INSTANCE);
+    tn.add(FloatType.INSTANCE);
+    tn.add(IntType.INSTANCE);
+    tn.add(LongType.INSTANCE);
+    tn.add(NullType.INSTANCE);
+    tn.add(ShortType.INSTANCE);
+    tn.add(UByteType.INSTANCE);
+    tn.add(UIntType.INSTANCE);
+    tn.add(ULongType.INSTANCE);
+    tn.add(UShortType.INSTANCE);
+    tn.add(UnknownType.INSTANCE);
+    tn.add(VoidType.INSTANCE);
+
     setReservedNames();
 
     // load soot.class.path system property, if defined
@@ -1087,8 +1105,18 @@ public class Scene {
         case "float":
           result = FloatType.v();
           break;
-        case "byte":
+        case "sbyte":
           result = ByteType.v();
+          break;
+        case "ubyte":
+          result = UByteType.v();
+          break;
+        case "byte":
+          if (Options.v().src_prec() == Options.src_prec_dotnet) {
+            result = UByteType.v();
+          } else {
+            result = ByteType.v();
+          }
           break;
         case "char":
           result = CharType.v();

--- a/src/main/java/soot/ShortType.java
+++ b/src/main/java/soot/ShortType.java
@@ -38,6 +38,7 @@ public class ShortType extends PrimType implements IJavaType, IntegerType, DotNe
   public static final ShortType INSTANCE = new ShortType();
 
   private ShortType() {
+    super(false);
   }
 
   public static ShortType v() {

--- a/src/main/java/soot/ShortType.java
+++ b/src/main/java/soot/ShortType.java
@@ -35,12 +35,13 @@ import soot.util.Switch;
 public class ShortType extends PrimType implements IJavaType, IntegerType, DotNetINumber, IIntLikeType {
 
   public static final int HASHCODE = 0x8B817DD3;
+  public static final ShortType INSTANCE = new ShortType();
 
-  public ShortType(Singletons.Global g) {
+  private ShortType() {
   }
 
   public static ShortType v() {
-    return G.v().soot_ShortType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/Type.java
+++ b/src/main/java/soot/Type.java
@@ -38,7 +38,13 @@ public abstract class Type implements Switchable, Serializable, Numberable {
   private int number = 0;
 
   public Type() {
-    Scene.v().getTypeNumberer().add(this);
+    this(true);
+  }
+
+  public Type(boolean doNumber) {
+    if (doNumber) {
+      Scene.v().getTypeNumberer().add(this);
+    }
   }
 
   /**

--- a/src/main/java/soot/UByteType.java
+++ b/src/main/java/soot/UByteType.java
@@ -40,6 +40,7 @@ public class UByteType extends PrimType implements DotNetINumber, IIntLikeType {
   public static final UByteType INSTANCE = new UByteType();
 
   private UByteType() {
+    super(false);
   }
 
   public static UByteType v() {

--- a/src/main/java/soot/UByteType.java
+++ b/src/main/java/soot/UByteType.java
@@ -37,12 +37,13 @@ public class UByteType extends PrimType implements DotNetINumber, IIntLikeType {
   public static final int HASHCODE = 0x213D1329;
   public static final int MIN_VALUE = 0;
   public static final int MAX_VALUE = 255;
+  public static final UByteType INSTANCE = new UByteType();
 
-  public UByteType(Singletons.Global g) {
+  private UByteType() {
   }
 
   public static UByteType v() {
-    return G.v().soot_UByteType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/UIntType.java
+++ b/src/main/java/soot/UIntType.java
@@ -37,12 +37,13 @@ public class UIntType extends PrimType implements DotNetINumber, IIntLikeType {
   public static final int HASHCODE = 0xB347239F;
   public static final long MAX_VALUE = 4294967295L;
   public static final int MIN_VALUE = 0;
+  public static final UIntType INSTANCE = new UIntType();
 
-  public UIntType(Singletons.Global g) {
+  private UIntType() {
   }
 
   public static UIntType v() {
-    return G.v().soot_UIntType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/UIntType.java
+++ b/src/main/java/soot/UIntType.java
@@ -40,6 +40,7 @@ public class UIntType extends PrimType implements DotNetINumber, IIntLikeType {
   public static final UIntType INSTANCE = new UIntType();
 
   private UIntType() {
+    super(false);
   }
 
   public static UIntType v() {

--- a/src/main/java/soot/ULongType.java
+++ b/src/main/java/soot/ULongType.java
@@ -34,12 +34,13 @@ import soot.util.Switch;
 public class ULongType extends PrimType implements DotNetINumber {
 
   public static final int HASHCODE = 0x013DA077;
+  public static final ULongType INSTANCE = new ULongType();
 
-  public ULongType(Singletons.Global g) {
+  private ULongType() {
   }
 
   public static ULongType v() {
-    return G.v().soot_ULongType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/ULongType.java
+++ b/src/main/java/soot/ULongType.java
@@ -37,6 +37,7 @@ public class ULongType extends PrimType implements DotNetINumber {
   public static final ULongType INSTANCE = new ULongType();
 
   private ULongType() {
+    super(false);
   }
 
   public static ULongType v() {

--- a/src/main/java/soot/UShortType.java
+++ b/src/main/java/soot/UShortType.java
@@ -39,6 +39,7 @@ public class UShortType extends PrimType implements DotNetINumber {
   public static final UShortType INSTANCE = new UShortType();
 
   private UShortType() {
+    super(false);
   }
 
   public static UShortType v() {

--- a/src/main/java/soot/UShortType.java
+++ b/src/main/java/soot/UShortType.java
@@ -36,12 +36,13 @@ public class UShortType extends PrimType implements DotNetINumber {
   public static final int HASHCODE = 0x5B817DD3;
   public static final int MAX_VALUE = 65535;
   public static final int MIN_VALUE = 0;
+  public static final UShortType INSTANCE = new UShortType();
 
-  public UShortType(Singletons.Global g) {
+  private UShortType() {
   }
 
   public static UShortType v() {
-    return G.v().soot_UShortType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/UnknownType.java
+++ b/src/main/java/soot/UnknownType.java
@@ -32,6 +32,7 @@ public class UnknownType extends Type {
   public static final UnknownType INSTANCE = new UnknownType();
 
   private UnknownType() {
+    super(false);
   }
 
   public static UnknownType v() {

--- a/src/main/java/soot/UnknownType.java
+++ b/src/main/java/soot/UnknownType.java
@@ -29,12 +29,13 @@ import soot.util.Switch;
  */
 @SuppressWarnings("serial")
 public class UnknownType extends Type {
+  public static final UnknownType INSTANCE = new UnknownType();
 
-  public UnknownType(Singletons.Global g) {
+  private UnknownType() {
   }
 
   public static UnknownType v() {
-    return G.v().soot_UnknownType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/VoidType.java
+++ b/src/main/java/soot/VoidType.java
@@ -29,12 +29,13 @@ import soot.util.Switch;
  */
 @SuppressWarnings("serial")
 public class VoidType extends Type {
+  public static final VoidType INSTANCE = new VoidType();
 
-  public VoidType(Singletons.Global g) {
+  private VoidType() {
   }
 
   public static VoidType v() {
-    return G.v().soot_VoidType();
+    return INSTANCE;
   }
 
   @Override

--- a/src/main/java/soot/VoidType.java
+++ b/src/main/java/soot/VoidType.java
@@ -32,6 +32,7 @@ public class VoidType extends Type {
   public static final VoidType INSTANCE = new VoidType();
 
   private VoidType() {
+    super(false);
   }
 
   public static VoidType v() {

--- a/src/main/java/soot/jimple/toolkits/typing/fast/BottomType.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/BottomType.java
@@ -1,5 +1,29 @@
 package soot.jimple.toolkits.typing.fast;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2008 Ben Bellamy
+ *
+ * All rights reserved.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.Type;
 
 /**

--- a/src/main/java/soot/jimple/toolkits/typing/fast/BottomType.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/BottomType.java
@@ -1,43 +1,18 @@
 package soot.jimple.toolkits.typing.fast;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2008 Ben Bellamy 
- * 
- * All rights reserved.
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import soot.G;
-import soot.Singletons;
 import soot.Type;
 
 /**
  * @author Ben Bellamy
  */
 public class BottomType extends Type {
+  public static final BottomType INSTANCE = new BottomType();
 
   public static BottomType v() {
-    return G.v().soot_jimple_toolkits_typing_fast_BottomType();
+    return INSTANCE;
   }
 
-  public BottomType(Singletons.Global g) {
+  private BottomType() {
   }
 
   @Override

--- a/src/main/java/soot/jimple/toolkits/typing/fast/BottomType.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/BottomType.java
@@ -4,7 +4,7 @@ package soot.jimple.toolkits.typing.fast;
  * #%L
  * Soot - a J*va Optimization Framework
  * %%
- * Copyright (C) 2008 Ben Bellamy
+ * Copyright (C) Soot contributers
  *
  * All rights reserved.
  * %%

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer127Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer127Type.java
@@ -1,5 +1,29 @@
 package soot.jimple.toolkits.typing.fast;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2008 Ben Bellamy
+ *
+ * All rights reserved.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.ByteType;
 import soot.IntegerType;
 import soot.PrimType;

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer127Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer127Type.java
@@ -4,7 +4,7 @@ package soot.jimple.toolkits.typing.fast;
  * #%L
  * Soot - a J*va Optimization Framework
  * %%
- * Copyright (C) 2008 Ben Bellamy
+ * Copyright (C) Soot contributers
  *
  * All rights reserved.
  * %%

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer127Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer127Type.java
@@ -1,47 +1,21 @@
 package soot.jimple.toolkits.typing.fast;
 
 import soot.ByteType;
-
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2008 Ben Bellamy 
- * 
- * All rights reserved.
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import soot.G;
 import soot.IntegerType;
 import soot.PrimType;
-import soot.Singletons;
 import soot.Type;
 
 /**
  * @author Ben Bellamy
  */
 public class Integer127Type extends PrimType implements IntegerType {
+  public static final Integer127Type INSTANCE = new Integer127Type();
 
   public static Integer127Type v() {
-    return G.v().soot_jimple_toolkits_typing_fast_Integer127Type();
+    return INSTANCE;
   }
 
-  public Integer127Type(Singletons.Global g) {
+  private Integer127Type() {
   }
 
   @Override

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer1Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer1Type.java
@@ -1,47 +1,21 @@
 package soot.jimple.toolkits.typing.fast;
 
 import soot.BooleanType;
-
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2008 Ben Bellamy 
- * 
- * All rights reserved.
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import soot.G;
 import soot.IntegerType;
 import soot.PrimType;
-import soot.Singletons;
 import soot.Type;
 
 /**
  * @author Ben Bellamy
  */
 public class Integer1Type extends PrimType implements IntegerType {
+  public static final Integer1Type INSTANCE = new Integer1Type();
 
   public static Integer1Type v() {
-    return G.v().soot_jimple_toolkits_typing_fast_Integer1Type();
+    return INSTANCE;
   }
 
-  public Integer1Type(Singletons.Global g) {
+  private Integer1Type() {
   }
 
   @Override

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer1Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer1Type.java
@@ -1,5 +1,29 @@
 package soot.jimple.toolkits.typing.fast;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2008 Ben Bellamy
+ *
+ * All rights reserved.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.BooleanType;
 import soot.IntegerType;
 import soot.PrimType;

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer1Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer1Type.java
@@ -4,7 +4,7 @@ package soot.jimple.toolkits.typing.fast;
  * #%L
  * Soot - a J*va Optimization Framework
  * %%
- * Copyright (C) 2008 Ben Bellamy
+ * Copyright (C) Soot contributers
  *
  * All rights reserved.
  * %%

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer32767Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer32767Type.java
@@ -1,5 +1,29 @@
 package soot.jimple.toolkits.typing.fast;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2008 Ben Bellamy
+ *
+ * All rights reserved.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.IntegerType;
 import soot.PrimType;
 import soot.ShortType;

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer32767Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer32767Type.java
@@ -1,46 +1,21 @@
 package soot.jimple.toolkits.typing.fast;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2008 Ben Bellamy 
- * 
- * All rights reserved.
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import soot.G;
 import soot.IntegerType;
 import soot.PrimType;
 import soot.ShortType;
-import soot.Singletons;
 import soot.Type;
 
 /**
  * @author Ben Bellamy
  */
 public class Integer32767Type extends PrimType implements IntegerType {
+  public static final Integer32767Type INSTANCE = new Integer32767Type();
 
   public static Integer32767Type v() {
-    return G.v().soot_jimple_toolkits_typing_fast_Integer32767Type();
+    return INSTANCE;
   }
 
-  public Integer32767Type(Singletons.Global g) {
+  private Integer32767Type() {
   }
 
   @Override

--- a/src/main/java/soot/jimple/toolkits/typing/fast/Integer32767Type.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/Integer32767Type.java
@@ -4,7 +4,7 @@ package soot.jimple.toolkits.typing.fast;
  * #%L
  * Soot - a J*va Optimization Framework
  * %%
- * Copyright (C) 2008 Ben Bellamy
+ * Copyright (C) Soot contributers
  *
  * All rights reserved.
  * %%

--- a/src/main/xml/singletons/singletons.xml
+++ b/src/main/xml/singletons/singletons.xml
@@ -23,12 +23,8 @@
   <class>soot.jimple.toolkits.annotation.tags.ArrayNullTagAggregator</class>
   <class>soot.dava.toolkits.base.AST.ASTWalker</class>
   <class>soot.baf.Baf</class>
-  <class>soot.BooleanType</class>
   <class>soot.jimple.toolkits.scalar.pre.BusyCodeMotion</class>
-  <class>soot.ByteType</class>
-  <class>soot.UByteType</class>
   <class>soot.jimple.toolkits.pointer.CastCheckEliminatorDumper</class>
-  <class>soot.CharType</class>
   <class>soot.jimple.toolkits.annotation.arraycheck.ClassFieldAnalysis</class>
   <class>soot.jimple.toolkits.scalar.CommonSubexpressionEliminator</class>
   <class>soot.jimple.toolkits.scalar.ConditionalBranchFolder</class>
@@ -44,19 +40,15 @@
   <class>soot.Printer</class>
   <class>soot.jimple.toolkits.scalar.DeadAssignmentEliminator</class>
   <class>soot.jimple.toolkits.pointer.DependenceTagAggregator</class>
-  <class>soot.DoubleType</class>
   <class>soot.baf.DoubleWordType</class>
   <class>soot.jimple.toolkits.pointer.DumbPointerAnalysis</class>
   <class>soot.jimple.spark.sets.EmptyPointsToSet</class>
   <class>soot.ErroneousType</class>
   <class>soot.dava.toolkits.base.finders.ExceptionFinder</class>
   <class>soot.jimple.toolkits.pointer.FieldRWTagger</class>
-  <class>soot.FloatType</class>
   <class>soot.jimple.toolkits.pointer.FullObjectSet</class>
   <class>soot.grimp.Grimp</class>
   <class>soot.dava.toolkits.base.finders.IfFinder</class>
-  <class>soot.IntType</class>
-  <class>soot.UIntType</class>
   <class>soot.jimple.Jimple</class>
   <class>soot.dava.toolkits.base.finders.LabeledBlockFinder</class>
   <class>soot.jimple.toolkits.scalar.pre.LazyCodeMotion</class>
@@ -70,13 +62,10 @@
   <class>soot.toolkits.scalar.LocalSplitter</class>
   <class>soot.toolkits.scalar.SharedInitializationLocalSplitter</class>
   <class>soot.toolkits.scalar.FlowSensitiveConstantPropagator</class>
-  <class>soot.LongType</class>
-  <class>soot.ULongType</class>
   <class>soot.dava.toolkits.base.misc.MonitorConverter</class>
   <class>soot.jimple.toolkits.scalar.NopEliminator</class>
   <class>soot.jimple.NullConstant</class>
   <class>soot.jimple.toolkits.annotation.nullcheck.NullPointerChecker</class>
-  <class>soot.NullType</class>
   <class>soot.dava.toolkits.base.misc.PackageNamer</class>
   <class>soot.PackManager</class>
   <class>soot.baf.toolkits.base.PeepholeOptimizer</class>
@@ -91,9 +80,6 @@
   <class>soot.shimple.Shimple</class>
   <class>soot.shimple.ShimpleTransformer</class>
   <class>soot.shimple.toolkits.scalar.SConstantPropagatorAndFolder</class>
-  <class>soot.ShortType</class>
-  <class>soot.UShortType</class>
-  <class>soot.DecimalType</class>
   <class>soot.jimple.toolkits.pointer.SideEffectTagger</class>
   <class>soot.jimple.spark.SparkTransformer</class>
   <class>soot.jimple.toolkits.invoke.StaticInliner</class>
@@ -112,11 +98,9 @@
   <class>soot.jimple.toolkits.scalar.FieldStaticnessCorrector</class>
   <class>soot.jimple.toolkits.scalar.MethodStaticnessCorrector</class>
   <class>soot.jimple.toolkits.scalar.IdentityOperationEliminator</class>
-  <class>soot.UnknownType</class>
   <class>soot.jimple.toolkits.scalar.UnreachableCodeEliminator</class>
   <class>soot.toolkits.scalar.UnusedLocalEliminator</class>
   <class>soot.dava.toolkits.base.AST.UselessTryRemover</class>
-  <class>soot.VoidType</class>
   <class>soot.baf.WordType</class>
   <class>soot.jimple.spark.fieldrw.FieldReadTagAggregator</class>
   <class>soot.jimple.spark.fieldrw.FieldWriteTagAggregator</class>
@@ -168,10 +152,6 @@
   <class>soot.toDex.TrapSplitter</class>
   <class>soot.toDex.FastDexTrapTightener</class>
   <class>soot.jimple.toolkits.base.RenameDuplicatedClasses</class>
-  <class>soot.jimple.toolkits.typing.fast.Integer127Type</class>
-  <class>soot.jimple.toolkits.typing.fast.Integer1Type</class>
-  <class>soot.jimple.toolkits.typing.fast.Integer32767Type</class>
-  <class>soot.jimple.toolkits.typing.fast.BottomType</class>
   <class>soot.dexpler.TrapMinimizer</class>
   <class>soot.toolkits.scalar.SmartLocalDefsPool</class>
   <class>soot.jimple.spark.internal.PublicAndProtectedAccessibility</class>

--- a/src/test/java/soot/util/backend/SootASMClassWriterTest.java
+++ b/src/test/java/soot/util/backend/SootASMClassWriterTest.java
@@ -40,7 +40,7 @@ import soot.Scene;
 import soot.SootClass;
 import soot.UnknownType;
 
-@PrepareForTest({ Scene.class, UnknownType.class, RefType.class })
+@PrepareForTest({ Scene.class, RefType.class })
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"javax.management.", "com.sun.org.apache.xerces.",
 		"javax.xml.", "org.xml.", "org.w3c.dom.",
@@ -65,13 +65,11 @@ public class SootASMClassWriterTest {
 			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 		mockStatic(Scene.class);
 		mockStatic(RefType.class);
-		mockStatic(UnknownType.class);
 
 		scene = mock(Scene.class);
 		when(Scene.v()).thenReturn(scene);
+		when(Scene.v().getTypeNumberer()).thenReturn(new soot.util.ArrayNumberer());
 
-		UnknownType unknown = mock(UnknownType.class);
-		when(UnknownType.v()).thenReturn(unknown);
 
 		sc1 = mockClass("A");
 		sc2 = mockClass("B");


### PR DESCRIPTION
Types such as IntType are used very often. Since these types can be reused even after G.reset(), using the singleton instance is relatively slow.