### PR TITLE
prevent TypeResolver.typePromotion from running in an endless loop

### DIFF
--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -383,8 +383,10 @@ public class TypeResolver {
   final ShortType shortType = ShortType.v();
 
   private ITyping typePromotion(ITyping tg) {
-    boolean conversionsPending;
+    int conversionsPending = Integer.MAX_VALUE;
+    int lastConversionsPending;
     do {
+      lastConversionsPending = conversionsPending;
       AugEvalFunction ef = createAugEvalFunction(this.jb);
       AugHierarchy h = new AugHierarchy();
       UseChecker uc = createUseChecker(this.jb);
@@ -403,16 +405,19 @@ public class TypeResolver {
 
       } while (uv.typingChanged);
 
-      conversionsPending = false;
+      conversionsPending = 0;
       for (Local v : this.jb.getLocals()) {
         Type t = tg.get(v);
         Type r = convert(t);
         if (r != null) {
           tg.set(v, r);
-          conversionsPending = true;
+          conversionsPending++;
         }
       }
-    } while (conversionsPending);
+      if (lastConversionsPending <= conversionsPending) {
+        throw new RuntimeException("typePromotion failed: conversionsPending was not reduced " + jb.getMethod());
+      }
+    } while (conversionsPending > 0);
 
     return tg;
   }


### PR DESCRIPTION
Prevent soot.jimple.toolkits.typing.fast.TypeResolver typePromotion from running in an endless loop.

In each loop run we count the number of conversionsPending. We expect that between two loop runs the number of conversionsPending have to change (get smaller), otherwise the algorithm is stuck and will never come to an end. 

If the current loop run has the same conversionsPending count as the last run we throw a RuntimeException to prevent the endless loop.

I have tested a lot of apps using this PR and the excepction was only thrown in those two apps that ended up in the endless loop before.