### PR TITLE
Fix throwable analysis problem with floating point divisions

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -174,6 +174,12 @@ import static org.objectweb.asm.tree.AbstractInsnNode.TABLESWITCH_INSN;
 import static org.objectweb.asm.tree.AbstractInsnNode.TYPE_INSN;
 import static org.objectweb.asm.tree.AbstractInsnNode.VAR_INSN;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -212,12 +218,6 @@ import org.objectweb.asm.tree.TypeInsnNode;
 import org.objectweb.asm.tree.VarInsnNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Table;
 
 import soot.ArrayType;
 import soot.Body;

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -174,12 +174,6 @@ import static org.objectweb.asm.tree.AbstractInsnNode.TABLESWITCH_INSN;
 import static org.objectweb.asm.tree.AbstractInsnNode.TYPE_INSN;
 import static org.objectweb.asm.tree.AbstractInsnNode.VAR_INSN;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Table;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -219,6 +213,12 @@ import org.objectweb.asm.tree.VarInsnNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
+
 import soot.ArrayType;
 import soot.Body;
 import soot.BooleanConstant;
@@ -253,6 +253,11 @@ import soot.UnknownType;
 import soot.Value;
 import soot.ValueBox;
 import soot.VoidType;
+import soot.asm.Operand.OperandType;
+import soot.dexpler.tags.DoubleOpTag;
+import soot.dexpler.tags.FloatOpTag;
+import soot.dexpler.tags.IntOpTag;
+import soot.dexpler.tags.LongOpTag;
 import soot.jimple.AddExpr;
 import soot.jimple.ArrayRef;
 import soot.jimple.AssignStmt;
@@ -461,7 +466,7 @@ public class AsmMethodSource implements MethodSource {
     Local l = o.stack;
     if (l == null && !(v instanceof Local)) {
       l = o.stack = newStackLocal();
-      setUnit(o.insn, Jimple.v().newAssignStmt(l, v));
+      setUnit(o, Jimple.v().newAssignStmt(l, v));
       o.updateBoxes();
     }
     return o;
@@ -472,7 +477,7 @@ public class AsmMethodSource implements MethodSource {
     Local l = o.stack;
     if (l == null && !(v instanceof Local) && !(v instanceof Constant)) {
       l = o.stack = newStackLocal();
-      setUnit(o.insn, Jimple.v().newAssignStmt(l, v));
+      setUnit(o, Jimple.v().newAssignStmt(l, v));
       o.updateBoxes();
     }
     return o;
@@ -483,7 +488,7 @@ public class AsmMethodSource implements MethodSource {
     Local l = o.stack;
     if (l == null && !(v instanceof Constant)) {
       l = o.stack = newStackLocal();
-      setUnit(o.insn, Jimple.v().newAssignStmt(l, v));
+      setUnit(o, Jimple.v().newAssignStmt(l, v));
       o.updateBoxes();
     }
     return o;
@@ -525,6 +530,13 @@ public class AsmMethodSource implements MethodSource {
   @SuppressWarnings("unused")
   private Operand popStackConst(Type t) {
     return AsmUtil.isDWord(t) ? popStackConstDual() : popStackConst();
+  }
+
+  protected void setUnit(Operand op, Unit u) {
+    setUnit(op.insn, u);
+    if (op.tag != null) {
+      u.addTag(op.tag);
+    }
   }
 
   protected void setUnit(AbstractInsnNode insn, Unit u) {
@@ -600,7 +612,7 @@ public class AsmMethodSource implements MethodSource {
       opr.stack = stack;
       AssignStmt as = Jimple.v().newAssignStmt(stack, opr.value);
       opr.updateBoxes();
-      setUnit(opr.insn, as);
+      setUnit(opr, as);
     }
   }
 
@@ -938,6 +950,28 @@ public class AsmMethodSource implements MethodSource {
       op1.addBox(binop.getOp1Box());
       op2.addBox(binop.getOp2Box());
       opr = new Operand(insn, binop);
+      if (op >= IADD && op <= DDIV) {
+        // The operations in this range always exists in four flavors: one for int, long, float, double
+        int flavor = op & 0x3;
+        switch (flavor) {
+          case 0b00:
+            opr.tag = IntOpTag.INSTANCE;
+            opr.type = OperandType.INT;
+            break;
+          case 0b01:
+            opr.tag = LongOpTag.INSTANCE;
+            opr.type = OperandType.LONG;
+            break;
+          case 0b10:
+            opr.tag = FloatOpTag.INSTANCE;
+            opr.type = OperandType.FLOAT;
+            break;
+          case 0b11:
+            opr.tag = DoubleOpTag.INSTANCE;
+            opr.type = OperandType.DOUBLE;
+            break;
+        }
+      }
       frame.in(op2, op1);
       frame.boxes(binop.getOp2Box(), binop.getOp1Box());
       frame.out(opr);
@@ -1116,7 +1150,7 @@ public class AsmMethodSource implements MethodSource {
         Operand o1 = pop();
         if (!units.containsKey(o1.insn)) {
           InvokeExpr iexpr = (InvokeExpr) getFrame(o1.insn).out()[0].value;
-          setUnit(o1.insn, Jimple.v().newInvokeStmt(iexpr));
+          setUnit(o1, Jimple.v().newInvokeStmt(iexpr));
         }
       }
       if (!units.containsKey(insn)) {
@@ -1894,7 +1928,7 @@ public class AsmMethodSource implements MethodSource {
         Local stack = secondOp.stack;
         firstOp.stack = stack;
         AssignStmt as = Jimple.v().newAssignStmt(stack, firstOp.stackOrValue());
-        setUnit(firstOp.insn, as);
+        setUnit(firstOp, as);
       } else {
         // Both operands have a stack local. We need to create an assignment to a temporary variable.
         Local stack = firstOp.stack;
@@ -1908,7 +1942,7 @@ public class AsmMethodSource implements MethodSource {
         Local stack = firstOp.stack;
         secondOp.stack = stack;
         AssignStmt as = Jimple.v().newAssignStmt(stack, secondOp.stackOrValue());
-        setUnit(secondOp.insn, as);
+        setUnit(secondOp, as);
       } else {
         throw new RuntimeException("Cannot merge operands, since neither has a stack local. Bummer.");
       }

--- a/src/main/java/soot/asm/Operand.java
+++ b/src/main/java/soot/asm/Operand.java
@@ -30,6 +30,7 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import soot.Local;
 import soot.Value;
 import soot.ValueBox;
+import soot.tagkit.Tag;
 
 /**
  * Stack operand.
@@ -38,8 +39,16 @@ import soot.ValueBox;
  */
 final class Operand {
 
+  public static enum OperandType {
+    INT, LONG, FLOAT, DOUBLE
+  }
+
   final AbstractInsnNode insn;
   final Value value;
+
+  OperandType type;
+  Tag tag;
+
   Local stack;
   private Object boxes;
 
@@ -54,6 +63,7 @@ final class Operand {
   Operand(AbstractInsnNode insn, Value value) {
     this.insn = insn;
     this.value = value;
+    this.type = null;
   }
 
   /**

--- a/src/main/java/soot/dexpler/DalvikThrowAnalysis.java
+++ b/src/main/java/soot/dexpler/DalvikThrowAnalysis.java
@@ -225,11 +225,10 @@ public class DalvikThrowAnalysis extends UnitThrowAnalysis {
 
       @Override
       public void caseAssignStmt(AssignStmt s) {
-        // Dalvik only throws ArrayIndexOutOfBounds and
-        // NullPointerException which are both handled through the
-        // ArrayRef expressions. There is no ArrayStoreException in
-        // Dalvik.
+        // Dalvik only throws ArrayIndexOutOfBounds and NullPointerException which are both handled 
+        // through the ArrayRef expressions. There is no ArrayStoreException in Dalvik.
         result = result.add(mightThrow(s.getLeftOp()));
+        
         Value rightOp = s.getRightOp();
         if (rightOp instanceof DivExpr && (s.hasTag(FloatOpTag.NAME) || s.hasTag(DoubleOpTag.NAME))) {
           // workaround for https://github.com/soot-oss/soot/issues/2188

--- a/src/main/java/soot/dexpler/DalvikThrowAnalysis.java
+++ b/src/main/java/soot/dexpler/DalvikThrowAnalysis.java
@@ -54,12 +54,16 @@ import soot.Singletons;
 import soot.SootMethod;
 import soot.Type;
 import soot.UnknownType;
+import soot.Value;
 import soot.baf.EnterMonitorInst;
 import soot.baf.ReturnInst;
 import soot.baf.ReturnVoidInst;
+import soot.dexpler.tags.DoubleOpTag;
+import soot.dexpler.tags.FloatOpTag;
 import soot.jimple.AssignStmt;
 import soot.jimple.CastExpr;
 import soot.jimple.ClassConstant;
+import soot.jimple.DivExpr;
 import soot.jimple.EnterMonitorStmt;
 import soot.jimple.StringConstant;
 import soot.toolkits.exceptions.ThrowableSet;
@@ -226,7 +230,15 @@ public class DalvikThrowAnalysis extends UnitThrowAnalysis {
         // ArrayRef expressions. There is no ArrayStoreException in
         // Dalvik.
         result = result.add(mightThrow(s.getLeftOp()));
-        result = result.add(mightThrow(s.getRightOp()));
+        Value rightOp = s.getRightOp();
+        if (rightOp instanceof DivExpr && (s.hasTag(FloatOpTag.NAME) || s.hasTag(DoubleOpTag.NAME))) {
+          // workaround for https://github.com/soot-oss/soot/issues/2188
+          // skip right op processing - float and double divisions don't throw any exceptions but when 
+          // building the Jimple body the value types are not yet known so we can not know from the expression 
+          // if it is an int or float/double division  
+        } else {
+          result = result.add(mightThrow(rightOp));
+        }
       }
 
     };

--- a/src/main/java/soot/dexpler/instructions/AgetInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/AgetInstruction.java
@@ -72,25 +72,25 @@ public class AgetInstruction extends DexlibAbstractInstruction {
     AssignStmt assign = Jimple.v().newAssignStmt(l, arrayRef);
     switch (aGetInstr.getOpcode()) {
       case AGET_OBJECT:
-        assign.addTag(new ObjectOpTag());
+        assign.addTag(ObjectOpTag.INSTANCE);
         break;
       case AGET:
-        assign.addTag(new IntOrFloatOpTag());
+        assign.addTag(IntOrFloatOpTag.INSTANCE);
         break;
       case AGET_WIDE:
-        assign.addTag(new LongOrDoubleOpTag());
+        assign.addTag(LongOrDoubleOpTag.INSTANCE);
         break;
       case AGET_BYTE:
-        assign.addTag(new ByteOpTag());
+        assign.addTag(ByteOpTag.INSTANCE);
         break;
       case AGET_CHAR:
-        assign.addTag(new CharOpTag());
+        assign.addTag(CharOpTag.INSTANCE);
         break;
       case AGET_SHORT:
-        assign.addTag(new ShortOpTag());
+        assign.addTag(ShortOpTag.INSTANCE);
         break;
       case AGET_BOOLEAN:
-        assign.addTag(new BooleanOpTag());
+        assign.addTag(BooleanOpTag.INSTANCE);
         break;
     }
 

--- a/src/main/java/soot/dexpler/instructions/Binop2addrInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/Binop2addrInstruction.java
@@ -80,110 +80,110 @@ public class Binop2addrInstruction extends TaggedInstruction {
     Opcode opcode = instruction.getOpcode();
     switch (opcode) {
       case ADD_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
       case ADD_FLOAT_2ADDR:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
       case ADD_DOUBLE_2ADDR:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
       case ADD_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
 
       case SUB_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
       case SUB_FLOAT_2ADDR:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
       case SUB_DOUBLE_2ADDR:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
       case SUB_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
 
       case MUL_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
       case MUL_FLOAT_2ADDR:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
       case MUL_DOUBLE_2ADDR:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
       case MUL_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
 
       case DIV_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
       case DIV_FLOAT_2ADDR:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
       case DIV_DOUBLE_2ADDR:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
       case DIV_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
 
       case REM_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
       case REM_FLOAT_2ADDR:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
       case REM_DOUBLE_2ADDR:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
       case REM_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
 
       case AND_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newAndExpr(source1, source2);
       case AND_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newAndExpr(source1, source2);
 
       case OR_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newOrExpr(source1, source2);
       case OR_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newOrExpr(source1, source2);
 
       case XOR_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newXorExpr(source1, source2);
       case XOR_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newXorExpr(source1, source2);
 
       case SHL_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newShlExpr(source1, source2);
       case SHL_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newShlExpr(source1, source2);
 
       case SHR_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newShrExpr(source1, source2);
       case SHR_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newShrExpr(source1, source2);
 
       case USHR_LONG_2ADDR:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newUshrExpr(source1, source2);
       case USHR_INT_2ADDR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newUshrExpr(source1, source2);
 
       default:

--- a/src/main/java/soot/dexpler/instructions/BinopInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/BinopInstruction.java
@@ -81,110 +81,110 @@ public class BinopInstruction extends TaggedInstruction {
     Opcode opcode = instruction.getOpcode();
     switch (opcode) {
       case ADD_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
       case ADD_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
       case ADD_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
       case ADD_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newAddExpr(source1, source2);
 
       case SUB_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
       case SUB_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
       case SUB_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
       case SUB_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newSubExpr(source1, source2);
 
       case MUL_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
       case MUL_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
       case MUL_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
       case MUL_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newMulExpr(source1, source2);
 
       case DIV_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
       case DIV_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
       case DIV_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
       case DIV_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newDivExpr(source1, source2);
 
       case REM_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
       case REM_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
       case REM_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
       case REM_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newRemExpr(source1, source2);
 
       case AND_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newAndExpr(source1, source2);
       case AND_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newAndExpr(source1, source2);
 
       case OR_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newOrExpr(source1, source2);
       case OR_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newOrExpr(source1, source2);
 
       case XOR_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newXorExpr(source1, source2);
       case XOR_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newXorExpr(source1, source2);
 
       case SHL_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newShlExpr(source1, source2);
       case SHL_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newShlExpr(source1, source2);
 
       case SHR_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newShrExpr(source1, source2);
       case SHR_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newShrExpr(source1, source2);
 
       case USHR_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newUshrExpr(source1, source2);
       case USHR_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newUshrExpr(source1, source2);
 
       default:

--- a/src/main/java/soot/dexpler/instructions/CastInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/CastInstruction.java
@@ -85,53 +85,53 @@ public class CastInstruction extends TaggedInstruction {
     Opcode opcode = instruction.getOpcode();
     switch (opcode) {
       case INT_TO_BYTE:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return ByteType.v();
       case INT_TO_CHAR:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return CharType.v();
       case INT_TO_SHORT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return ShortType.v();
 
       case LONG_TO_INT:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return IntType.v();
       case DOUBLE_TO_INT:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return IntType.v();
       case FLOAT_TO_INT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return IntType.v();
 
       case INT_TO_LONG:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return LongType.v();
       case DOUBLE_TO_LONG:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return LongType.v();
       case FLOAT_TO_LONG:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return LongType.v();
 
       case LONG_TO_FLOAT:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return FloatType.v();
       case DOUBLE_TO_FLOAT:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return FloatType.v();
       case INT_TO_FLOAT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return FloatType.v();
 
       case INT_TO_DOUBLE:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return DoubleType.v();
       case FLOAT_TO_DOUBLE:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return DoubleType.v();
       case LONG_TO_DOUBLE:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return DoubleType.v();
 
       default:

--- a/src/main/java/soot/dexpler/instructions/CmpInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/CmpInstruction.java
@@ -75,27 +75,27 @@ public class CmpInstruction extends TaggedInstruction {
     Type type = null;
     switch (opcode) {
       case CMPL_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         type = DoubleType.v();
         cmpExpr = Jimple.v().newCmplExpr(first, second);
         break;
       case CMPL_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         type = FloatType.v();
         cmpExpr = Jimple.v().newCmplExpr(first, second);
         break;
       case CMPG_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         type = DoubleType.v();
         cmpExpr = Jimple.v().newCmpgExpr(first, second);
         break;
       case CMPG_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         type = FloatType.v();
         cmpExpr = Jimple.v().newCmpgExpr(first, second);
         break;
       case CMP_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         type = LongType.v();
         cmpExpr = Jimple.v().newCmpExpr(first, second);
         break;

--- a/src/main/java/soot/dexpler/instructions/UnopInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/UnopInstruction.java
@@ -87,22 +87,22 @@ public class UnopInstruction extends TaggedInstruction {
     Opcode opcode = instruction.getOpcode();
     switch (opcode) {
       case NEG_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return Jimple.v().newNegExpr(source);
       case NEG_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return Jimple.v().newNegExpr(source);
       case NEG_FLOAT:
-        setTag(new FloatOpTag());
+        setTag(FloatOpTag.INSTANCE);
         return Jimple.v().newNegExpr(source);
       case NEG_DOUBLE:
-        setTag(new DoubleOpTag());
+        setTag(DoubleOpTag.INSTANCE);
         return Jimple.v().newNegExpr(source);
       case NOT_LONG:
-        setTag(new LongOpTag());
+        setTag(LongOpTag.INSTANCE);
         return getNotLongExpr(source);
       case NOT_INT:
-        setTag(new IntOpTag());
+        setTag(IntOpTag.INSTANCE);
         return getNotIntExpr(source);
       default:
         throw new RuntimeException("Invalid Opcode: " + opcode);

--- a/src/main/java/soot/dexpler/tags/BooleanOpTag.java
+++ b/src/main/java/soot/dexpler/tags/BooleanOpTag.java
@@ -28,7 +28,14 @@ import soot.tagkit.Tag;
 
 public class BooleanOpTag implements Tag, DexplerTag {
 
+  public static final BooleanOpTag INSTANCE = new BooleanOpTag();
+
   public static final String NAME = "BooleanOpTag";
+
+  @Deprecated
+  public BooleanOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/ByteOpTag.java
+++ b/src/main/java/soot/dexpler/tags/ByteOpTag.java
@@ -28,7 +28,14 @@ import soot.tagkit.Tag;
 
 public class ByteOpTag implements Tag, DexplerTag {
 
+  public static final ByteOpTag INSTANCE = new ByteOpTag();
+
   public static final String NAME = "ByteOpTag";
+
+  @Deprecated
+  public ByteOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/CharOpTag.java
+++ b/src/main/java/soot/dexpler/tags/CharOpTag.java
@@ -27,8 +27,15 @@ import soot.Type;
 import soot.tagkit.Tag;
 
 public class CharOpTag implements Tag, DexplerTag {
+  
+  public static final CharOpTag INSTANCE = new CharOpTag();
 
   public static final String NAME = "CharOpTag";
+
+  @Deprecated
+  public CharOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/DoubleOpTag.java
+++ b/src/main/java/soot/dexpler/tags/DoubleOpTag.java
@@ -48,7 +48,14 @@ import soot.tagkit.Tag;
 
 public class DoubleOpTag implements Tag, DexplerTag {
 
+  public static final DoubleOpTag INSTANCE = new DoubleOpTag();  
+  
   public static final String NAME = "DoubleOpTag";
+
+  @Deprecated
+  public DoubleOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/FloatOpTag.java
+++ b/src/main/java/soot/dexpler/tags/FloatOpTag.java
@@ -47,8 +47,15 @@ import soot.Type;
 import soot.tagkit.Tag;
 
 public class FloatOpTag implements Tag, DexplerTag {
-
+  
+  public static final FloatOpTag INSTANCE = new FloatOpTag();
+  
   public static final String NAME = "FloatOpTag";
+
+  @Deprecated
+  public FloatOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/IntOpTag.java
+++ b/src/main/java/soot/dexpler/tags/IntOpTag.java
@@ -48,7 +48,14 @@ import soot.tagkit.Tag;
 
 public class IntOpTag implements Tag, DexplerTag {
 
+  public static final IntOpTag INSTANCE = new IntOpTag();
+
   public static final String NAME = "IntOpTag";
+
+  @Deprecated
+  public IntOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/IntOrFloatOpTag.java
+++ b/src/main/java/soot/dexpler/tags/IntOrFloatOpTag.java
@@ -26,7 +26,14 @@ import soot.tagkit.Tag;
 
 public class IntOrFloatOpTag implements Tag, DexplerTag {
 
+  public static final IntOrFloatOpTag INSTANCE = new IntOrFloatOpTag();
+
   public static final String NAME = "IntOrFloatOpTag";
+
+  @Deprecated
+  public IntOrFloatOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/LongOpTag.java
+++ b/src/main/java/soot/dexpler/tags/LongOpTag.java
@@ -48,7 +48,14 @@ import soot.tagkit.Tag;
 
 public class LongOpTag implements Tag, DexplerTag {
 
+  public static final LongOpTag INSTANCE = new LongOpTag();
+
   public static final String NAME = "LongOpTag";
+
+  @Deprecated
+  public LongOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/LongOrDoubleOpTag.java
+++ b/src/main/java/soot/dexpler/tags/LongOrDoubleOpTag.java
@@ -26,7 +26,14 @@ import soot.tagkit.Tag;
 
 public class LongOrDoubleOpTag implements Tag, DexplerTag {
 
+  public static final LongOrDoubleOpTag INSTANCE = new LongOrDoubleOpTag();
+
   public static final String NAME = "LongOrDoubleOpTag";
+
+  @Deprecated
+  public LongOrDoubleOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/NumOpTag.java
+++ b/src/main/java/soot/dexpler/tags/NumOpTag.java
@@ -46,7 +46,14 @@ import soot.tagkit.Tag;
 
 public class NumOpTag implements Tag, DexplerTag {
 
+  public static final NumOpTag INSTANCE = new NumOpTag();
+
   public static final String NAME = "NumOpTag";
+
+  @Deprecated
+  public NumOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/ObjectOpTag.java
+++ b/src/main/java/soot/dexpler/tags/ObjectOpTag.java
@@ -46,7 +46,14 @@ import soot.tagkit.Tag;
 
 public class ObjectOpTag implements Tag, DexplerTag {
 
+  public static final ObjectOpTag INSTANCE = new ObjectOpTag();
+
   public static final String NAME = "ObjectOpTag";
+
+  @Deprecated
+  public ObjectOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/dexpler/tags/ShortOpTag.java
+++ b/src/main/java/soot/dexpler/tags/ShortOpTag.java
@@ -28,7 +28,14 @@ import soot.tagkit.Tag;
 
 public class ShortOpTag implements Tag, DexplerTag {
 
+  public static final ShortOpTag INSTANCE = new ShortOpTag();
+
   public static final String NAME = "ShortOpTag";
+
+  @Deprecated
+  public ShortOpTag() {
+    super();
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/soot/toolkits/exceptions/UnitThrowAnalysis.java
+++ b/src/main/java/soot/toolkits/exceptions/UnitThrowAnalysis.java
@@ -1,13 +1,5 @@
 package soot.toolkits.exceptions;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -34,6 +26,15 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 import heros.solver.IDESolver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
 import soot.Body;
 import soot.DecimalConstant;
 import soot.FastHierarchy;

--- a/src/main/java/soot/toolkits/exceptions/UnitThrowAnalysis.java
+++ b/src/main/java/soot/toolkits/exceptions/UnitThrowAnalysis.java
@@ -1,5 +1,13 @@
 package soot.toolkits.exceptions;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -26,15 +34,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 import heros.solver.IDESolver;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-
 import soot.Body;
 import soot.DecimalConstant;
 import soot.FastHierarchy;
@@ -131,6 +130,8 @@ import soot.baf.ThrowInst;
 import soot.baf.UshrInst;
 import soot.baf.VirtualInvokeInst;
 import soot.baf.XorInst;
+import soot.dexpler.tags.DoubleOpTag;
+import soot.dexpler.tags.FloatOpTag;
 import soot.grimp.GrimpValueSwitch;
 import soot.grimp.NewInvokeExpr;
 import soot.jimple.AddExpr;
@@ -823,7 +824,16 @@ public class UnitThrowAnalysis extends AbstractThrowAnalysis {
         result = result.add(mgr.ARRAY_STORE_EXCEPTION);
       }
       result = result.add(mightThrow(s.getLeftOp()));
-      result = result.add(mightThrow(s.getRightOp()));
+
+      Value rightOp = s.getRightOp();
+      if (rightOp instanceof DivExpr && (s.hasTag(FloatOpTag.NAME) || s.hasTag(DoubleOpTag.NAME))) {
+        // workaround for https://github.com/soot-oss/soot/issues/2188
+        // skip right op processing - float and double divisions don't throw any exceptions but when
+        // building the Jimple body the value types are not yet known so we can not know from the expression
+        // if it is an int or float/double division
+      } else {
+        result = result.add(mightThrow(rightOp));
+      }
     }
 
     @Override


### PR DESCRIPTION
Workaround for #2188 which fixes the throwable analysis problem with floating point divisions.
The 

Fixed for Dex and Java class source files.

The used Tags like `DoubleOpTag` have been converted to singletons as they don't contain any individual data and thus having multiple instances of them would just waste memory.