### PR TITLE
Move Tag.getValue() to Attribute

### DIFF
--- a/src/main/java/soot/dexpler/tags/BooleanOpTag.java
+++ b/src/main/java/soot/dexpler/tags/BooleanOpTag.java
@@ -43,11 +43,6 @@ public class BooleanOpTag implements Tag, DexplerTag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
-
-  @Override
   public Type getDefiniteType() {
     return BooleanType.v();
   }

--- a/src/main/java/soot/dexpler/tags/ByteOpTag.java
+++ b/src/main/java/soot/dexpler/tags/ByteOpTag.java
@@ -43,11 +43,6 @@ public class ByteOpTag implements Tag, DexplerTag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
-
-  @Override
   public Type getDefiniteType() {
     return ByteType.v();
   }

--- a/src/main/java/soot/dexpler/tags/CharOpTag.java
+++ b/src/main/java/soot/dexpler/tags/CharOpTag.java
@@ -27,7 +27,7 @@ import soot.Type;
 import soot.tagkit.Tag;
 
 public class CharOpTag implements Tag, DexplerTag {
-  
+
   public static final CharOpTag INSTANCE = new CharOpTag();
 
   public static final String NAME = "CharOpTag";
@@ -40,11 +40,6 @@ public class CharOpTag implements Tag, DexplerTag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
   }
 
   @Override

--- a/src/main/java/soot/dexpler/tags/DoubleOpTag.java
+++ b/src/main/java/soot/dexpler/tags/DoubleOpTag.java
@@ -48,8 +48,8 @@ import soot.tagkit.Tag;
 
 public class DoubleOpTag implements Tag, DexplerTag {
 
-  public static final DoubleOpTag INSTANCE = new DoubleOpTag();  
-  
+  public static final DoubleOpTag INSTANCE = new DoubleOpTag();
+
   public static final String NAME = "DoubleOpTag";
 
   @Deprecated
@@ -60,11 +60,6 @@ public class DoubleOpTag implements Tag, DexplerTag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
   }
 
   @Override

--- a/src/main/java/soot/dexpler/tags/FloatOpTag.java
+++ b/src/main/java/soot/dexpler/tags/FloatOpTag.java
@@ -47,9 +47,9 @@ import soot.Type;
 import soot.tagkit.Tag;
 
 public class FloatOpTag implements Tag, DexplerTag {
-  
+
   public static final FloatOpTag INSTANCE = new FloatOpTag();
-  
+
   public static final String NAME = "FloatOpTag";
 
   @Deprecated
@@ -60,11 +60,6 @@ public class FloatOpTag implements Tag, DexplerTag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
   }
 
   @Override

--- a/src/main/java/soot/dexpler/tags/IntOpTag.java
+++ b/src/main/java/soot/dexpler/tags/IntOpTag.java
@@ -63,11 +63,6 @@ public class IntOpTag implements Tag, DexplerTag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
-
-  @Override
   public Type getDefiniteType() {
     return IntType.v();
   }

--- a/src/main/java/soot/dexpler/tags/IntOrFloatOpTag.java
+++ b/src/main/java/soot/dexpler/tags/IntOrFloatOpTag.java
@@ -39,9 +39,4 @@ public class IntOrFloatOpTag implements Tag, DexplerTag {
   public String getName() {
     return NAME;
   }
-
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
 }

--- a/src/main/java/soot/dexpler/tags/LongOpTag.java
+++ b/src/main/java/soot/dexpler/tags/LongOpTag.java
@@ -63,11 +63,6 @@ public class LongOpTag implements Tag, DexplerTag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
-
-  @Override
   public Type getDefiniteType() {
     return LongType.v();
   }

--- a/src/main/java/soot/dexpler/tags/LongOrDoubleOpTag.java
+++ b/src/main/java/soot/dexpler/tags/LongOrDoubleOpTag.java
@@ -40,8 +40,4 @@ public class LongOrDoubleOpTag implements Tag, DexplerTag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
 }

--- a/src/main/java/soot/dexpler/tags/NumOpTag.java
+++ b/src/main/java/soot/dexpler/tags/NumOpTag.java
@@ -60,8 +60,4 @@ public class NumOpTag implements Tag, DexplerTag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
 }

--- a/src/main/java/soot/dexpler/tags/ObjectOpTag.java
+++ b/src/main/java/soot/dexpler/tags/ObjectOpTag.java
@@ -60,8 +60,4 @@ public class ObjectOpTag implements Tag, DexplerTag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
 }

--- a/src/main/java/soot/dexpler/tags/ShortOpTag.java
+++ b/src/main/java/soot/dexpler/tags/ShortOpTag.java
@@ -43,11 +43,6 @@ public class ShortOpTag implements Tag, DexplerTag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
-
-  @Override
   public Type getDefiniteType() {
     return ShortType.v();
   }

--- a/src/main/java/soot/dexpler/tags/SpecialInvokeTypeTag.java
+++ b/src/main/java/soot/dexpler/tags/SpecialInvokeTypeTag.java
@@ -77,9 +77,4 @@ public class SpecialInvokeTypeTag implements Tag, DexplerTag {
   public String getName() {
     return NAME;
   }
-
-  @Override
-  public byte[] getValue() {
-    return new byte[1];
-  }
 }

--- a/src/main/java/soot/dotnet/AssemblyTag.java
+++ b/src/main/java/soot/dotnet/AssemblyTag.java
@@ -1,5 +1,27 @@
 package soot.dotnet;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2022 Fraunhofer SIT
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.tagkit.Tag;
 
 /**

--- a/src/main/java/soot/dotnet/AssemblyTag.java
+++ b/src/main/java/soot/dotnet/AssemblyTag.java
@@ -1,28 +1,5 @@
 package soot.dotnet;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2022 Fraunhofer SIT
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import soot.tagkit.AttributeValueException;
 import soot.tagkit.Tag;
 
 /**
@@ -44,11 +21,6 @@ public class AssemblyTag implements Tag {
   @Override
   public String getName() {
     return ASSEMBLY;
-  }
-
-  @Override
-  public byte[] getValue() throws AttributeValueException {
-    return null;
   }
 
 }

--- a/src/main/java/soot/dotnet/members/InitialFieldTagValue.java
+++ b/src/main/java/soot/dotnet/members/InitialFieldTagValue.java
@@ -39,7 +39,6 @@ public class InitialFieldTagValue implements Tag {
     return NAME;
   }
 
-  @Override
   public byte[] getValue() throws AttributeValueException {
     return content;
   }

--- a/src/main/java/soot/dotnet/members/method/DelegateHandler.java
+++ b/src/main/java/soot/dotnet/members/method/DelegateHandler.java
@@ -65,7 +65,6 @@ import soot.jimple.StaticInvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.StringConstant;
 import soot.jimple.internal.JTableSwitchStmt;
-import soot.tagkit.AttributeValueException;
 import soot.tagkit.Tag;
 
 public class DelegateHandler {
@@ -104,11 +103,6 @@ public class DelegateHandler {
     @Override
     public String getName() {
       return DELEGATE_NAME;
-    }
-
-    @Override
-    public byte[] getValue() throws AttributeValueException {
-      return null;
     }
 
     public SootMethodRef getListMethod(Type retType, String methodName, Type... paramTypes) {

--- a/src/main/java/soot/dotnet/types/StructTag.java
+++ b/src/main/java/soot/dotnet/types/StructTag.java
@@ -1,27 +1,5 @@
 package soot.dotnet.types;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2015 Steven Arzt
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-import soot.tagkit.AttributeValueException;
 import soot.tagkit.Tag;
 
 /**
@@ -34,11 +12,6 @@ public class StructTag implements Tag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public byte[] getValue() throws AttributeValueException {
-    return null;
   }
 
 }

--- a/src/main/java/soot/dotnet/types/StructTag.java
+++ b/src/main/java/soot/dotnet/types/StructTag.java
@@ -1,5 +1,26 @@
 package soot.dotnet.types;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2015 Steven Arzt
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
 import soot.tagkit.Tag;
 
 /**

--- a/src/main/java/soot/jimple/spark/fieldrw/FieldRWTag.java
+++ b/src/main/java/soot/jimple/spark/fieldrw/FieldRWTag.java
@@ -49,16 +49,6 @@ public abstract class FieldRWTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    byte[] bytes = fieldNames.getBytes();
-    byte[] ret = new byte[bytes.length + 2];
-    ret[0] = (byte) (bytes.length / 256);
-    ret[1] = (byte) (bytes.length % 256);
-    System.arraycopy(bytes, 0, ret, 2, bytes.length);
-    return ret;
-  }
-
-  @Override
   public String toString() {
     return getName() + fieldNames;
   }

--- a/src/main/java/soot/jimple/toolkits/annotation/tags/ArrayCheckTag.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/tags/ArrayCheckTag.java
@@ -41,21 +41,6 @@ public class ArrayCheckTag implements OneByteCodeTag {
   }
 
   /**
-   * Returns back the check information in binary form, which will be written into the class file.
-   */
-  @Override
-  public byte[] getValue() {
-    byte b = 0;
-    if (lowerCheck) {
-      b |= 0x01;
-    }
-    if (upperCheck) {
-      b |= 0x02;
-    }
-    return new byte[] { b };
-  }
-
-  /**
    * Needs upper bound check?
    */
   public boolean isCheckUpper() {

--- a/src/main/java/soot/jimple/toolkits/annotation/tags/ArrayNullCheckTag.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/tags/ArrayNullCheckTag.java
@@ -53,11 +53,6 @@ public class ArrayNullCheckTag implements OneByteCodeTag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[] { value };
-  }
-
-  @Override
   public String toString() {
     return Byte.toString(value);
   }

--- a/src/main/java/soot/jimple/toolkits/annotation/tags/NullCheckTag.java
+++ b/src/main/java/soot/jimple/toolkits/annotation/tags/NullCheckTag.java
@@ -45,11 +45,6 @@ public class NullCheckTag implements OneByteCodeTag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    return new byte[] { value };
-  }
-
   public boolean needCheck() {
     return (value != 0);
   }

--- a/src/main/java/soot/jimple/toolkits/callgraph/ReachableMethods.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/ReachableMethods.java
@@ -38,7 +38,7 @@ import soot.util.queue.QueueReader;
  */
 public class ReachableMethods {
 
-  protected final ChunkedQueue<MethodOrMethodContext> reachables = new ChunkedQueue<>();
+  protected final ChunkedQueue<MethodOrMethodContext> reachables = createChunkedQueue();
   protected final Set<MethodOrMethodContext> set = new HashSet<>();
   protected final QueueReader<MethodOrMethodContext> allReachables = reachables.reader();
   protected QueueReader<MethodOrMethodContext> unprocessedMethods;
@@ -49,6 +49,10 @@ public class ReachableMethods {
 
   public ReachableMethods(CallGraph graph, Iterator<? extends MethodOrMethodContext> entryPoints, Filter filter) {
     this(graph, entryPoints, filter, false);
+  }
+
+  protected ChunkedQueue<MethodOrMethodContext> createChunkedQueue() {
+    return new ChunkedQueue<>();
   }
 
   public ReachableMethods(CallGraph graph, Iterator<? extends MethodOrMethodContext> entryPoints, Filter filter,

--- a/src/main/java/soot/jimple/toolkits/pointer/CastCheckTag.java
+++ b/src/main/java/soot/jimple/toolkits/pointer/CastCheckTag.java
@@ -43,11 +43,6 @@ public class CastCheckTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[] { (byte) (eliminateCheck ? 1 : 0) };
-  }
-
-  @Override
   public String toString() {
     if (eliminateCheck) {
       return "This cast check can be eliminated.";

--- a/src/main/java/soot/jimple/toolkits/pointer/DependenceTag.java
+++ b/src/main/java/soot/jimple/toolkits/pointer/DependenceTag.java
@@ -52,17 +52,6 @@ public class DependenceTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    byte[] ret = new byte[5];
-    ret[0] = (byte) ((read >> 8) & 0xff);
-    ret[1] = (byte) (read & 0xff);
-    ret[2] = (byte) ((write >> 8) & 0xff);
-    ret[3] = (byte) (write & 0xff);
-    ret[4] = (byte) (callsNative ? 1 : 0);
-    return ret;
-  }
-
-  @Override
   public String toString() {
     StringBuilder buf = new StringBuilder();
     if (callsNative) {

--- a/src/main/java/soot/tagkit/AnnotationDefaultTag.java
+++ b/src/main/java/soot/tagkit/AnnotationDefaultTag.java
@@ -52,9 +52,4 @@ public class AnnotationDefaultTag implements Tag {
   public AnnotationElem getDefaultVal() {
     return defaultVal;
   }
-
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("AnnotationDefaultTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/AnnotationTag.java
+++ b/src/main/java/soot/tagkit/AnnotationTag.java
@@ -120,11 +120,6 @@ public class AnnotationTag implements Tag {
     return type;
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("AnnotationTag has no value for bytecode");
-  }
-
   /**
    * Adds one element to the list
    *

--- a/src/main/java/soot/tagkit/ArtificialEntityTag.java
+++ b/src/main/java/soot/tagkit/ArtificialEntityTag.java
@@ -38,8 +38,4 @@ public class ArtificialEntityTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() throws AttributeValueException {
-    throw new RuntimeException("ArtificialEntityTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/Attribute.java
+++ b/src/main/java/soot/tagkit/Attribute.java
@@ -31,4 +31,9 @@ public interface Attribute extends Tag {
    * Sets the value of the attribute from a byte[].
    */
   public void setValue(byte[] v);
+
+  /**
+   * Returns the tag raw data.
+   */
+  public byte[] getValue() throws AttributeValueException;
 }

--- a/src/main/java/soot/tagkit/BytecodeOffsetTag.java
+++ b/src/main/java/soot/tagkit/BytecodeOffsetTag.java
@@ -49,19 +49,6 @@ public class BytecodeOffsetTag implements Tag {
   }
 
   /**
-   * Returns the offset in a four byte array.
-   */
-  @Override
-  public byte[] getValue() {
-    byte[] v = new byte[4];
-    v[0] = (byte) ((offset >> 24) % 256);
-    v[1] = (byte) ((offset >> 16) % 256);
-    v[2] = (byte) ((offset >> 8) % 256);
-    v[3] = (byte) (offset % 256);
-    return v;
-  }
-
-  /**
    * Returns the offset as an int.
    */
   public int getBytecodeOffset() {

--- a/src/main/java/soot/tagkit/ColorTag.java
+++ b/src/main/java/soot/tagkit/ColorTag.java
@@ -163,11 +163,6 @@ public class ColorTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[2];
-  }
-
-  @Override
   public String toString() {
     return "" + red + " " + green + " " + blue;
   }

--- a/src/main/java/soot/tagkit/ConstantValueTag.java
+++ b/src/main/java/soot/tagkit/ConstantValueTag.java
@@ -34,11 +34,6 @@ public abstract class ConstantValueTag implements Tag {
     this.bytes = bytes;
   }
 
-  @Override
-  public byte[] getValue() {
-    return bytes;
-  }
-
   public abstract Constant getConstant();
 
   @Override

--- a/src/main/java/soot/tagkit/DebugTypeTag.java
+++ b/src/main/java/soot/tagkit/DebugTypeTag.java
@@ -47,9 +47,4 @@ public class DebugTypeTag extends SignatureTag {
   public String getInfo() {
     return "DebugType";
   }
-
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("DebugTypeTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/DeprecatedTag.java
+++ b/src/main/java/soot/tagkit/DeprecatedTag.java
@@ -68,8 +68,4 @@ public class DeprecatedTag implements Tag {
     return since;
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("DeprecatedTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/EnclosingMethodTag.java
+++ b/src/main/java/soot/tagkit/EnclosingMethodTag.java
@@ -66,8 +66,4 @@ public class EnclosingMethodTag implements Tag {
     return enclosingMethodSig;
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("EnclosingMethodTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/ExpectedTypeTag.java
+++ b/src/main/java/soot/tagkit/ExpectedTypeTag.java
@@ -45,9 +45,4 @@ public class ExpectedTypeTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() throws AttributeValueException {
-    return null;
-  }
-
 }

--- a/src/main/java/soot/tagkit/InnerClassAttribute.java
+++ b/src/main/java/soot/tagkit/InnerClassAttribute.java
@@ -70,11 +70,6 @@ public class InnerClassAttribute implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() throws AttributeValueException {
-    return new byte[1];
-  }
-
   public List<InnerClassTag> getSpecs() {
     return list == null ? Collections.<InnerClassTag>emptyList() : list;
   }

--- a/src/main/java/soot/tagkit/InnerClassTag.java
+++ b/src/main/java/soot/tagkit/InnerClassTag.java
@@ -1,5 +1,26 @@
 package soot.tagkit;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Archie L. Cobbs
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
 public class InnerClassTag implements Tag {
 
   public static final String NAME = "InnerClassTag";

--- a/src/main/java/soot/tagkit/InnerClassTag.java
+++ b/src/main/java/soot/tagkit/InnerClassTag.java
@@ -1,29 +1,5 @@
 package soot.tagkit;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2003 Archie L. Cobbs
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import java.io.UnsupportedEncodingException;
-
 public class InnerClassTag implements Tag {
 
   public static final String NAME = "InnerClassTag";
@@ -54,19 +30,6 @@ public class InnerClassTag implements Tag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  /**
-   * Returns the inner class name (only) encoded in UTF8. There is no obvious standalone byte[] encoding for this attribute
-   * because it contains embedded constant pool indices.
-   */
-  @Override
-  public byte[] getValue() {
-    try {
-      return innerClass.getBytes("UTF8");
-    } catch (UnsupportedEncodingException e) {
-      return new byte[0];
-    }
   }
 
   public String getInnerClass() {

--- a/src/main/java/soot/tagkit/JimpleLineNumberTag.java
+++ b/src/main/java/soot/tagkit/JimpleLineNumberTag.java
@@ -58,11 +58,6 @@ public class JimpleLineNumberTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[2];
-  }
-
-  @Override
   public String toString() {
     return "Jimple Line Tag: " + startLineNumber;
   }

--- a/src/main/java/soot/tagkit/KeyTag.java
+++ b/src/main/java/soot/tagkit/KeyTag.java
@@ -118,8 +118,4 @@ public class KeyTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    return new byte[4];
-  }
 }

--- a/src/main/java/soot/tagkit/LineNumberTag.java
+++ b/src/main/java/soot/tagkit/LineNumberTag.java
@@ -38,14 +38,6 @@ public class LineNumberTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    byte[] v = new byte[2];
-    v[0] = (byte) (line_number / 256);
-    v[1] = (byte) (line_number % 256);
-    return v;
-  }
-
   public int getLineNumber() {
     return line_number;
   }

--- a/src/main/java/soot/tagkit/LinkTag.java
+++ b/src/main/java/soot/tagkit/LinkTag.java
@@ -56,9 +56,4 @@ public class LinkTag extends StringTag {
   public String getName() {
     return NAME;
   }
-
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("LinkTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/OuterClassTag.java
+++ b/src/main/java/soot/tagkit/OuterClassTag.java
@@ -1,29 +1,5 @@
 package soot.tagkit;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2004 Jennifer Lhotak
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import java.io.UnsupportedEncodingException;
-
 import soot.SootClass;
 
 public class OuterClassTag implements Tag {
@@ -43,15 +19,6 @@ public class OuterClassTag implements Tag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public byte[] getValue() {
-    try {
-      return outerClass.getName().getBytes("UTF8");
-    } catch (UnsupportedEncodingException e) {
-      return new byte[0];
-    }
   }
 
   public SootClass getOuterClass() {

--- a/src/main/java/soot/tagkit/OuterClassTag.java
+++ b/src/main/java/soot/tagkit/OuterClassTag.java
@@ -1,5 +1,26 @@
 package soot.tagkit;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2004 Jennifer Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
 import soot.SootClass;
 
 public class OuterClassTag implements Tag {

--- a/src/main/java/soot/tagkit/ParamNamesTag.java
+++ b/src/main/java/soot/tagkit/ParamNamesTag.java
@@ -68,9 +68,4 @@ public class ParamNamesTag implements Tag {
   public List<String> getInfo() {
     return getNames();
   }
-
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("ParamNamesTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/PositionTag.java
+++ b/src/main/java/soot/tagkit/PositionTag.java
@@ -51,11 +51,6 @@ public class PositionTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[2];
-  }
-
-  @Override
   public String toString() {
     return "Jimple pos tag: spos: " + startOffset + " epos: " + endOffset;
   }

--- a/src/main/java/soot/tagkit/SignatureTag.java
+++ b/src/main/java/soot/tagkit/SignatureTag.java
@@ -44,11 +44,6 @@ public class SignatureTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException(NAME + " has no value for bytecode");
-  }
-
   public String getInfo() {
     return "Signature";
   }

--- a/src/main/java/soot/tagkit/SourceFileTag.java
+++ b/src/main/java/soot/tagkit/SourceFileTag.java
@@ -1,29 +1,5 @@
 package soot.tagkit;
 
-/*-
- * #%L
- * Soot - a J*va Optimization Framework
- * %%
- * Copyright (C) 2003 Archie L. Cobbs
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
-
-import java.nio.charset.StandardCharsets;
-
 public class SourceFileTag implements Tag {
 
   public static final String NAME = "SourceFileTag";
@@ -46,11 +22,6 @@ public class SourceFileTag implements Tag {
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public byte[] getValue() {
-    return sourceFile.getBytes(StandardCharsets.UTF_8);
   }
 
   public void setSourceFile(String srcFile) {

--- a/src/main/java/soot/tagkit/SourceFileTag.java
+++ b/src/main/java/soot/tagkit/SourceFileTag.java
@@ -1,5 +1,26 @@
 package soot.tagkit;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Archie L. Cobbs
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
 public class SourceFileTag implements Tag {
 
   public static final String NAME = "SourceFileTag";

--- a/src/main/java/soot/tagkit/SourceLineNumberTag.java
+++ b/src/main/java/soot/tagkit/SourceLineNumberTag.java
@@ -71,11 +71,6 @@ public class SourceLineNumberTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    return new byte[2];
-  }
-
-  @Override
   public String toString() {
     return String.valueOf(startLineNumber);
   }

--- a/src/main/java/soot/tagkit/SourceLnPosTag.java
+++ b/src/main/java/soot/tagkit/SourceLnPosTag.java
@@ -60,14 +60,6 @@ public class SourceLnPosTag implements Tag {
   }
 
   @Override
-  public byte[] getValue() {
-    byte[] v = new byte[2];
-    v[0] = (byte) (startLn / 256);
-    v[1] = (byte) (startLn % 256);
-    return v;
-  }
-
-  @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("Source Line Pos Tag: ");

--- a/src/main/java/soot/tagkit/StringTag.java
+++ b/src/main/java/soot/tagkit/StringTag.java
@@ -58,9 +58,4 @@ public class StringTag implements Tag {
   public String getInfo() {
     return s;
   }
-
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("StringTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/SyntheticParamTag.java
+++ b/src/main/java/soot/tagkit/SyntheticParamTag.java
@@ -46,8 +46,4 @@ public class SyntheticParamTag implements Tag {
     return "SyntheticParam";
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("SyntheticParamTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/SyntheticTag.java
+++ b/src/main/java/soot/tagkit/SyntheticTag.java
@@ -46,8 +46,4 @@ public class SyntheticTag implements Tag {
     return "Synthetic";
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("SyntheticTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/Tag.java
+++ b/src/main/java/soot/tagkit/Tag.java
@@ -31,8 +31,4 @@ public interface Tag {
    */
   public String getName();
 
-  /**
-   * Returns the tag raw data.
-   */
-  public byte[] getValue() throws AttributeValueException;
 }

--- a/src/main/java/soot/tagkit/ThrowCreatedByCompilerTag.java
+++ b/src/main/java/soot/tagkit/ThrowCreatedByCompilerTag.java
@@ -37,8 +37,4 @@ public class ThrowCreatedByCompilerTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("ThrowCreatedByCompilerTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/TryCatchTag.java
+++ b/src/main/java/soot/tagkit/TryCatchTag.java
@@ -46,8 +46,4 @@ public class TryCatchTag implements Tag {
     return NAME;
   }
 
-  @Override
-  public byte[] getValue() throws AttributeValueException {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/src/main/java/soot/tagkit/VisibilityAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityAnnotationTag.java
@@ -83,11 +83,6 @@ public class VisibilityAnnotationTag implements Tag {
     return visibility;
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("VisibilityAnnotationTag has no value for bytecode");
-  }
-
   public void addAnnotation(AnnotationTag a) {
     if (annotations == null) {
       annotations = new ArrayList<AnnotationTag>();

--- a/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityLocalVariableAnnotationTag.java
@@ -74,14 +74,4 @@ public class VisibilityLocalVariableAnnotationTag extends VisibilityParameterAnn
   public String getInfo() {
     return "VisibilityLocalVariableAnnotation";
   }
-
-  /**
-   * VisibilityLocalVariableAnnotationTag not support
-   * 
-   * @return
-   */
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("VisibilityLocalVariableAnnotationTag has no value for bytecode");
-  }
 }

--- a/src/main/java/soot/tagkit/VisibilityParameterAnnotationTag.java
+++ b/src/main/java/soot/tagkit/VisibilityParameterAnnotationTag.java
@@ -75,11 +75,6 @@ public class VisibilityParameterAnnotationTag implements Tag {
     return "VisibilityParameterAnnotation";
   }
 
-  @Override
-  public byte[] getValue() {
-    throw new RuntimeException("VisibilityParameterAnnotationTag has no value for bytecode");
-  }
-
   public void addVisibilityAnnotation(VisibilityAnnotationTag a) {
     if (visibilityAnnotations == null) {
       visibilityAnnotations = new ArrayList<VisibilityAnnotationTag>();


### PR DESCRIPTION
Tag.getValue() is used for a very specific purpose in ASM, but not anywhere else. Therefore, it should be moved to Attribute.