### PR TITLE
fix DexFileProvider DEFAULT_PRIORITIZER

### DIFF
--- a/src/main/java/soot/dexpler/DexFileProvider.java
+++ b/src/main/java/soot/dexpler/DexFileProvider.java
@@ -69,19 +69,26 @@ public class DexFileProvider {
 
           // "classes.dex" has highest priority
           if (s1.equals("classes.dex")) {
-            return 1;
-          } else if (s2.equals("classes.dex")) {
             return -1;
+          } else if (s2.equals("classes.dex")) {
+            return 1;
           }
 
-          // if one of the strings starts with "classes", we give it the edge right here
-          boolean s1StartsClasses = s1.startsWith("classes");
-          boolean s2StartsClasses = s2.startsWith("classes");
+          // if only one of the string is a valide dex file name, we give it the edge right here
+          boolean s1IsValidDexName = s1.matches("classes[1-9]\\d*.dex") && !s1.equals("classes1.dex");
+          boolean s2IsValidDexName = s2.matches("classes[1-9]\\d*.dex") && !s2.equals("classes1.dex");
 
-          if (s1StartsClasses && !s2StartsClasses) {
-            return 1;
-          } else if (s2StartsClasses && !s1StartsClasses) {
+          if (s1IsValidDexName && !s2IsValidDexName) {
             return -1;
+          } else if (s2IsValidDexName && !s1IsValidDexName) {
+            return 1;
+          }
+
+          // if both are valid, compare the dexfiles numbers as numbers ("classes9.dex" has priority over "classes10.dex")
+          if (s1IsValidDexName && s2IsValidDexName) {
+              Long d1 = new Long(s1.substring(7, s1.length() - 4));
+              Long d2 = new Long(s2.substring(7, s2.length() - 4));
+              return d1.compareTo(d2);
           }
 
           // otherwise, use natural string ordering


### PR DESCRIPTION
DEFAULT_PRIORITIZER incorrectly sort dex files in applications.
classes.dex should be prioritzed over classes2.dex, then classes3.dex, ..., classes9.dex, classes10.dex, ..., then the other dexfiles.
Current implementation sort alphabetically, putting classes10.dex before classes2.dex, as well as classes1.dex, classes0.dex, classes0N.dex, which are invalid names and should be prioritized.
Also, I believe the hard-coded return values are swapped.

This pull request modify the DEFAULT_PRIORITIZER so that:
- classes.dex has the highest priority
- valid dexfile names have higher priority than invalid dexfile names
- valid dexfile names are sorted numerically instead of alphabetically
- invalid dexfile names are sorted alphabetically (previous behavior)

Unfortunately  I did not manage to write a test for Soot.
 I discovered the issue when using flowdroid, it can be tested with the [following APKs and script](https://github.com/user-attachments/files/23528322/demo.zip):

```bash
TMP=$(mktemp -d)
git clone https://github.com/secure-software-engineering/FlowDroid.git "${TMP}/FlowDroid"
git clone https://github.com/soot-oss/soot.git "${TMP}/soot"
cat <<EOF > "${TMP}/SourcesAndSinks.txt"
<com.example.shadowing.Main: java.lang.String actual()> -> _SOURCE_

<android.util.Log: int i(java.lang.String,java.lang.String)> -> _SINK_
EOF

cd "${TMP}/soot"
mvn install
cd -
cd "${TMP}/FlowDroid"
mvn install -DskipTests
cd -

for apk in $(find ./bench -name '*.apk'); do
  echo "Test ${apk}"
  java -jar "${TMP}/FlowDroid/soot-infoflow-cmd/target/soot-infoflow-cmd-jar-with-dependencies.jar" \
    -a "${apk}" \
    -p ~/Android/Sdk/platforms \
    -s "${TMP}/SourcesAndSinks.txt" |& grep ' - Found'
done
```

A data leak should be detected in each application, but the two are detected:
```
[main] INFO soot.jimple.infoflow.android.SetupApplication - Found 0 leaks from 0 sources
Test ./bench/com.example.shadowing.two.apk
[main] INFO soot.jimple.infoflow.android.SetupApplication - Found 1 leaks from 1 sources
Test ./bench/com.example.shadowing.control.apk
[main] INFO soot.jimple.infoflow.android.SetupApplication - Found 1 leaks from 1 sources
Test ./bench/com.example.shadowing.four.apk
[main] INFO soot.jimple.infoflow.android.SetupApplication - Found 0 leaks from 0 sources
Test ./bench/com.example.shadowing.one.apk
[main] INFO soot.jimple.infoflow.android.SetupApplication - Found 0 leaks from 0 sources
```
