### PR TITLE
Switch dexlib2 library from JesusFreke to Google

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,6 @@
                 <configuration>
                     <propertyExpansion>config_loc=${checkstyle.dir.path}</propertyExpansion>
                     <configLocation>${checkstyle.file.path}</configLocation>
-                    <encoding>UTF-8</encoding>
                     <logViolationsToConsole>true</logViolationsToConsole>
                     <failOnViolation>${checkstyle.failOnViolation}</failOnViolation>
                     <violationSeverity>warning</violationSeverity>
@@ -447,9 +446,9 @@
             <version>2.17.0</version>
         </dependency>
         <dependency>
-            <groupId>org.smali</groupId>
-            <artifactId>dexlib2</artifactId>
-            <version>2.5.2</version>
+            <groupId>com.android.tools.smali</groupId>
+            <artifactId>smali-dexlib2</artifactId>
+            <version>3.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -581,6 +580,13 @@
     </dependencies>
 
     <repositories>
+        <repository>
+            <id>google</id>
+            <url>https://maven.google.com/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>sonatype-snapshot</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>

--- a/src/main/java/soot/DexClassProvider.java
+++ b/src/main/java/soot/DexClassProvider.java
@@ -1,5 +1,3 @@
-package soot;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,6 +20,11 @@ package soot;
  * #L%
  */
 
+package soot;
+
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,8 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.DexFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/soot/SourceLocator.java
+++ b/src/main/java/soot/SourceLocator.java
@@ -1,5 +1,3 @@
-package soot;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,6 +20,9 @@ package soot;
  * #L%
  */
 
+package soot;
+
+import com.android.tools.smali.dexlib2.iface.DexFile;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -54,7 +55,6 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.jf.dexlib2.iface.DexFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/soot/Unit.java
+++ b/src/main/java/soot/Unit.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import soot.tagkit.Host;
+import soot.util.Chain;
 import soot.util.Switchable;
 
 /**

--- a/src/main/java/soot/dexpler/DexAnnotation.java
+++ b/src/main/java/soot/dexpler/DexAnnotation.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,6 +20,34 @@ package soot.dexpler;
  * #L%
  */
 
+package soot.dexpler;
+
+import com.android.tools.smali.dexlib2.AnnotationVisibility;
+import com.android.tools.smali.dexlib2.iface.Annotation;
+import com.android.tools.smali.dexlib2.iface.AnnotationElement;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.Field;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.iface.MethodParameter;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
+import com.android.tools.smali.dexlib2.iface.value.AnnotationEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.BooleanEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ByteEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.CharEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.DoubleEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.EnumEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.FieldEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.FloatEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.IntEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.LongEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.MethodEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ShortEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.StringEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.TypeEncodedValue;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,31 +58,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.jf.dexlib2.AnnotationVisibility;
-import org.jf.dexlib2.iface.Annotation;
-import org.jf.dexlib2.iface.AnnotationElement;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.Field;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.iface.MethodParameter;
-import org.jf.dexlib2.iface.reference.FieldReference;
-import org.jf.dexlib2.iface.reference.MethodReference;
-import org.jf.dexlib2.iface.value.AnnotationEncodedValue;
-import org.jf.dexlib2.iface.value.ArrayEncodedValue;
-import org.jf.dexlib2.iface.value.BooleanEncodedValue;
-import org.jf.dexlib2.iface.value.ByteEncodedValue;
-import org.jf.dexlib2.iface.value.CharEncodedValue;
-import org.jf.dexlib2.iface.value.DoubleEncodedValue;
-import org.jf.dexlib2.iface.value.EncodedValue;
-import org.jf.dexlib2.iface.value.EnumEncodedValue;
-import org.jf.dexlib2.iface.value.FieldEncodedValue;
-import org.jf.dexlib2.iface.value.FloatEncodedValue;
-import org.jf.dexlib2.iface.value.IntEncodedValue;
-import org.jf.dexlib2.iface.value.LongEncodedValue;
-import org.jf.dexlib2.iface.value.MethodEncodedValue;
-import org.jf.dexlib2.iface.value.ShortEncodedValue;
-import org.jf.dexlib2.iface.value.StringEncodedValue;
-import org.jf.dexlib2.iface.value.TypeEncodedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -467,7 +468,8 @@ public class DexAnnotation {
    * @param annotations
    * @return
    */
-  private List<Tag> handleAnnotation(Set<? extends org.jf.dexlib2.iface.Annotation> annotations, String classType) {
+  private List<Tag> handleAnnotation(Set<? extends com.android.tools.smali.dexlib2.iface.Annotation> annotations,
+      String classType) {
     if (annotations == null || annotations.size() == 0) {
       return null;
     }

--- a/src/main/java/soot/dexpler/DexBody.java
+++ b/src/main/java/soot/dexpler/DexBody.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -20,15 +18,35 @@ package soot.dexpler;
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 
+package soot.dexpler;
+
 import static soot.dexpler.instructions.InstructionFactory.fromInstruction;
 
+import com.android.tools.smali.dexlib2.analysis.ClassPath;
+import com.android.tools.smali.dexlib2.analysis.ClassPathResolver;
+import com.android.tools.smali.dexlib2.analysis.ClassProvider;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.ExceptionHandler;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.iface.MethodImplementation;
+import com.android.tools.smali.dexlib2.iface.MethodParameter;
+import com.android.tools.smali.dexlib2.iface.MultiDexContainer.DexEntry;
+import com.android.tools.smali.dexlib2.iface.TryBlock;
+import com.android.tools.smali.dexlib2.iface.debug.DebugItem;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.immutable.debug.ImmutableEndLocal;
+import com.android.tools.smali.dexlib2.immutable.debug.ImmutableLineNumber;
+import com.android.tools.smali.dexlib2.immutable.debug.ImmutableRestartLocal;
+import com.android.tools.smali.dexlib2.immutable.debug.ImmutableStartLocal;
+import com.android.tools.smali.dexlib2.util.MethodUtil;
 import com.google.common.collect.ArrayListMultimap;
 
 import java.io.File;
@@ -49,24 +67,6 @@ import java.util.TreeMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.jf.dexlib2.analysis.ClassPath;
-import org.jf.dexlib2.analysis.ClassPathResolver;
-import org.jf.dexlib2.analysis.ClassProvider;
-import org.jf.dexlib2.dexbacked.DexBackedDexFile;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.ExceptionHandler;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.iface.MethodImplementation;
-import org.jf.dexlib2.iface.MethodParameter;
-import org.jf.dexlib2.iface.MultiDexContainer.DexEntry;
-import org.jf.dexlib2.iface.TryBlock;
-import org.jf.dexlib2.iface.debug.DebugItem;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.immutable.debug.ImmutableEndLocal;
-import org.jf.dexlib2.immutable.debug.ImmutableLineNumber;
-import org.jf.dexlib2.immutable.debug.ImmutableRestartLocal;
-import org.jf.dexlib2.immutable.debug.ImmutableStartLocal;
-import org.jf.dexlib2.util.MethodUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/soot/dexpler/DexClassLoader.java
+++ b/src/main/java/soot/dexpler/DexClassLoader.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,13 +20,15 @@ package soot.dexpler;
  * #L%
  */
 
-import java.util.Iterator;
+package soot.dexpler;
 
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.Field;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.iface.MultiDexContainer.DexEntry;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.Field;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.iface.MultiDexContainer.DexEntry;
+
+import java.util.Iterator;
 
 import soot.Dependencies;
 import soot.Modifier;

--- a/src/main/java/soot/dexpler/DexField.java
+++ b/src/main/java/soot/dexpler/DexField.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,17 +25,19 @@ package soot.dexpler;
  * #L%
  */
 
-import org.jf.dexlib2.iface.Field;
-import org.jf.dexlib2.iface.value.BooleanEncodedValue;
-import org.jf.dexlib2.iface.value.ByteEncodedValue;
-import org.jf.dexlib2.iface.value.CharEncodedValue;
-import org.jf.dexlib2.iface.value.DoubleEncodedValue;
-import org.jf.dexlib2.iface.value.EncodedValue;
-import org.jf.dexlib2.iface.value.FloatEncodedValue;
-import org.jf.dexlib2.iface.value.IntEncodedValue;
-import org.jf.dexlib2.iface.value.LongEncodedValue;
-import org.jf.dexlib2.iface.value.ShortEncodedValue;
-import org.jf.dexlib2.iface.value.StringEncodedValue;
+package soot.dexpler;
+
+import com.android.tools.smali.dexlib2.iface.Field;
+import com.android.tools.smali.dexlib2.iface.value.BooleanEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ByteEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.CharEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.DoubleEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.FloatEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.IntEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.LongEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ShortEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.StringEncodedValue;
 
 import soot.Scene;
 import soot.SootField;

--- a/src/main/java/soot/dexpler/DexFileProvider.java
+++ b/src/main/java/soot/dexpler/DexFileProvider.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,6 +20,15 @@ package soot.dexpler;
  * #L%
  */
 
+package soot.dexpler;
+
+import com.android.tools.smali.dexlib2.DexFileFactory;
+import com.android.tools.smali.dexlib2.Opcodes;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.MultiDexContainer;
+import com.android.tools.smali.dexlib2.iface.MultiDexContainer.DexEntry;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -37,12 +44,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import org.jf.dexlib2.DexFileFactory;
-import org.jf.dexlib2.Opcodes;
-import org.jf.dexlib2.dexbacked.DexBackedDexFile;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.MultiDexContainer;
-import org.jf.dexlib2.iface.MultiDexContainer.DexEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,9 +87,9 @@ public class DexFileProvider {
 
           // if both are valid, compare the dexfiles numbers as numbers ("classes9.dex" has priority over "classes10.dex")
           if (s1IsValidDexName && s2IsValidDexName) {
-              Long d1 = new Long(s1.substring(7, s1.length() - 4));
-              Long d2 = new Long(s2.substring(7, s2.length() - 4));
-              return d1.compareTo(d2);
+            Long d1 = new Long(s1.substring(7, s1.length() - 4));
+            Long d2 = new Long(s2.substring(7, s2.length() - 4));
+            return d1.compareTo(d2);
           }
 
           // otherwise, use natural string ordering

--- a/src/main/java/soot/dexpler/DexMethod.java
+++ b/src/main/java/soot/dexpler/DexMethod.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,17 +25,20 @@ package soot.dexpler;
  * #L%
  */
 
+package soot.dexpler;
+
+import com.android.tools.smali.dexlib2.iface.Annotation;
+import com.android.tools.smali.dexlib2.iface.AnnotationElement;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.iface.MultiDexContainer.DexEntry;
+import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.TypeEncodedValue;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jf.dexlib2.iface.Annotation;
-import org.jf.dexlib2.iface.AnnotationElement;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.iface.MultiDexContainer.DexEntry;
-import org.jf.dexlib2.iface.value.ArrayEncodedValue;
-import org.jf.dexlib2.iface.value.EncodedValue;
-import org.jf.dexlib2.iface.value.TypeEncodedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/soot/dexpler/DexType.java
+++ b/src/main/java/soot/dexpler/DexType.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler;
  * #L%
  */
 
-import org.jf.dexlib2.iface.reference.TypeReference;
-import org.jf.dexlib2.immutable.reference.ImmutableTypeReference;
+package soot.dexpler;
+
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableTypeReference;
 
 import soot.BooleanType;
 import soot.ByteType;

--- a/src/main/java/soot/dexpler/DexlibWrapper.java
+++ b/src/main/java/soot/dexpler/DexlibWrapper.java
@@ -1,5 +1,3 @@
-package soot.dexpler;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,6 +25,14 @@ package soot.dexpler;
  * #L%
  */
 
+package soot.dexpler;
+
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile;
+import com.android.tools.smali.dexlib2.dexbacked.reference.DexBackedTypeReference;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.MultiDexContainer.DexEntry;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,12 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.jf.dexlib2.dexbacked.DexBackedDexFile;
-import org.jf.dexlib2.dexbacked.reference.DexBackedTypeReference;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.MultiDexContainer.DexEntry;
 
 import soot.ArrayType;
 import soot.CompilationDeathException;

--- a/src/main/java/soot/dexpler/instructions/AgetInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/AgetInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,9 +25,11 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction23x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction23x;
 
 import soot.Local;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/AputInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/AputInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,9 +25,11 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction23x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction23x;
 
 import soot.ArrayType;
 import soot.Local;

--- a/src/main/java/soot/dexpler/instructions/ArrayLengthInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ArrayLengthInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,9 +25,11 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction12x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction12x;
 
 import soot.Local;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/Binop2addrInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/Binop2addrInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction12x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction12x;
 
 import soot.Local;
 import soot.Value;

--- a/src/main/java/soot/dexpler/instructions/BinopInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/BinopInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ThreeRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction23x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ThreeRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction23x;
 
 import soot.Local;
 import soot.Value;

--- a/src/main/java/soot/dexpler/instructions/BinopLitInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/BinopLitInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,12 +25,14 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.NarrowLiteralInstruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction22b;
-import org.jf.dexlib2.iface.instruction.formats.Instruction22s;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction22b;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction22s;
 
 import soot.Local;
 import soot.Value;

--- a/src/main/java/soot/dexpler/instructions/CastInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/CastInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,9 +25,11 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
 
 import soot.ByteType;
 import soot.CharType;

--- a/src/main/java/soot/dexpler/instructions/CheckCastInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/CheckCastInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,13 +25,15 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction21c;
-import org.jf.dexlib2.iface.reference.TypeReference;
 
 import soot.Local;
 import soot.Type;

--- a/src/main/java/soot/dexpler/instructions/CmpInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/CmpInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ThreeRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction23x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ThreeRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction23x;
 
 import soot.DoubleType;
 import soot.FloatType;

--- a/src/main/java/soot/dexpler/instructions/ConditionalJumpInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ConditionalJumpInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.Immediate;
 import soot.Local;

--- a/src/main/java/soot/dexpler/instructions/ConstClassInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ConstClassInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,14 +25,16 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction21c;
-import org.jf.dexlib2.iface.reference.TypeReference;
 
 import soot.Type;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/ConstInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ConstInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,11 +25,13 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.NarrowLiteralInstruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.WideLiteralInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.AssignStmt;

--- a/src/main/java/soot/dexpler/instructions/ConstStringInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ConstStringInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,11 +25,13 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction21c;
-import org.jf.dexlib2.iface.instruction.formats.Instruction31c;
-import org.jf.dexlib2.iface.reference.StringReference;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction31c;
+import com.android.tools.smali.dexlib2.iface.reference.StringReference;
 
 import soot.dexpler.DexBody;
 import soot.jimple.AssignStmt;

--- a/src/main/java/soot/dexpler/instructions/DanglingInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/DanglingInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -26,6 +24,8 @@ package soot.dexpler.instructions;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
+
+package soot.dexpler.instructions;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/DeferableInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/DeferableInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -26,6 +24,8 @@ package soot.dexpler.instructions;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
+
+package soot.dexpler.instructions;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/DexlibAbstractInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/DexlibAbstractInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,14 +25,16 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.FiveRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.RegisterRangeInstruction;
 
 import soot.Type;
 import soot.Unit;

--- a/src/main/java/soot/dexpler/instructions/ExecuteInlineInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ExecuteInlineInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,19 +20,21 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import java.util.List;
+package soot.dexpler.instructions;
 
-import org.jf.dexlib2.AccessFlags;
-import org.jf.dexlib2.analysis.AnalyzedInstruction;
-import org.jf.dexlib2.analysis.ClassPath;
-import org.jf.dexlib2.analysis.InlineMethodResolver;
-import org.jf.dexlib2.analysis.MethodAnalyzer;
-import org.jf.dexlib2.dexbacked.DexBackedOdexFile;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction35mi;
-import org.jf.dexlib2.iface.instruction.formats.Instruction3rmi;
+import com.android.tools.smali.dexlib2.AccessFlags;
+import com.android.tools.smali.dexlib2.analysis.AnalyzedInstruction;
+import com.android.tools.smali.dexlib2.analysis.ClassPath;
+import com.android.tools.smali.dexlib2.analysis.InlineMethodResolver;
+import com.android.tools.smali.dexlib2.analysis.MethodAnalyzer;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedOdexFile;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction35mi;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction3rmi;
+
+import java.util.List;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/FieldInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/FieldInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,18 +25,20 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
 import static soot.dexpler.Util.dottedClassName;
 import static soot.dexpler.Util.isFloatLike;
 
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction22c;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction23x;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction21c;
-import org.jf.dexlib2.iface.instruction.formats.Instruction22c;
-import org.jf.dexlib2.iface.instruction.formats.Instruction23x;
-import org.jf.dexlib2.iface.reference.FieldReference;
 
 import soot.Local;
 import soot.Scene;

--- a/src/main/java/soot/dexpler/instructions/FillArrayDataInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/FillArrayDataInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,16 +25,21 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.ArrayPayload;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction31t;
+
 import java.util.List;
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.ArrayPayload;
-import org.jf.dexlib2.iface.instruction.formats.Instruction31t;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import soot.Local;
 import soot.dexpler.DexBody;
+import soot.dexpler.DexFillArrayDataTransformer;
+import soot.dexpler.typing.UntypedConstant;
 import soot.dexpler.typing.UntypedIntOrFloatConstant;
 import soot.dexpler.typing.UntypedLongOrDoubleConstant;
 import soot.jimple.ArrayRef;

--- a/src/main/java/soot/dexpler/instructions/FilledArrayInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/FilledArrayInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,12 +25,14 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.reference.TypeReference;
 
 import soot.Type;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/FilledNewArrayInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/FilledNewArrayInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,11 +25,13 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
 import static soot.dexpler.Util.isFloatLike;
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction35c;
-import org.jf.dexlib2.iface.reference.TypeReference;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction35c;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
 
 import soot.ArrayType;
 import soot.Local;

--- a/src/main/java/soot/dexpler/instructions/FilledNewArrayRangeInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/FilledNewArrayRangeInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,11 +25,13 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
 import static soot.dexpler.Util.isFloatLike;
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction3rc;
-import org.jf.dexlib2.iface.reference.TypeReference;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction3rc;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
 
 import soot.ArrayType;
 import soot.Local;
@@ -73,8 +73,7 @@ public class FilledNewArrayRangeInstruction extends FilledArrayInstruction {
     for (int i = 0; i < usedRegister; i++) {
       ArrayRef arrayRef = j.newArrayRef(arrayLocal, IntConstant.v(i));
 
-      AssignStmt assign
-          = j.newAssignStmt(arrayRef, body.getRegisterLocal(i + filledNewArrayInstr.getStartRegister()));
+      AssignStmt assign = j.newAssignStmt(arrayRef, body.getRegisterLocal(i + filledNewArrayInstr.getStartRegister()));
       if (elementType instanceof RefLikeType) {
         assign.addTag(new ObjectOpTag());
       }

--- a/src/main/java/soot/dexpler/instructions/GotoInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/GotoInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.GotoStmt;

--- a/src/main/java/soot/dexpler/instructions/IfTestInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/IfTestInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction22t;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction22t;
 
 import soot.Local;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/IfTestzInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/IfTestzInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction21t;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21t;
 
 import soot.dexpler.DexBody;
 import soot.jimple.BinopExpr;

--- a/src/main/java/soot/dexpler/instructions/IgetInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/IgetInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.reference.FieldReference;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
 
 import soot.dexpler.DexBody;
 import soot.jimple.AssignStmt;

--- a/src/main/java/soot/dexpler/instructions/InstanceOfInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InstanceOfInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,14 +25,16 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction22c;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction22c;
-import org.jf.dexlib2.iface.reference.TypeReference;
 
 import soot.Type;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/InstructionFactory.java
+++ b/src/main/java/soot/dexpler/instructions/InstructionFactory.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 /**
  * Factory that returns an appropriate Instruction instances for given dexlib instructions and opcodes.

--- a/src/main/java/soot/dexpler/instructions/InvokeCustomInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeCustomInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,32 +25,34 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.MethodHandleType;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.reference.CallSiteReference;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
+import com.android.tools.smali.dexlib2.iface.reference.MethodHandleReference;
+import com.android.tools.smali.dexlib2.iface.reference.MethodProtoReference;
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+import com.android.tools.smali.dexlib2.iface.value.BooleanEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ByteEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.CharEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.DoubleEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.FloatEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.IntEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.LongEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.MethodHandleEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.MethodTypeEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.NullEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.ShortEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.StringEncodedValue;
+import com.android.tools.smali.dexlib2.iface.value.TypeEncodedValue;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jf.dexlib2.MethodHandleType;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.reference.CallSiteReference;
-import org.jf.dexlib2.iface.reference.FieldReference;
-import org.jf.dexlib2.iface.reference.MethodHandleReference;
-import org.jf.dexlib2.iface.reference.MethodProtoReference;
-import org.jf.dexlib2.iface.reference.MethodReference;
-import org.jf.dexlib2.iface.reference.Reference;
-import org.jf.dexlib2.iface.value.BooleanEncodedValue;
-import org.jf.dexlib2.iface.value.ByteEncodedValue;
-import org.jf.dexlib2.iface.value.CharEncodedValue;
-import org.jf.dexlib2.iface.value.DoubleEncodedValue;
-import org.jf.dexlib2.iface.value.EncodedValue;
-import org.jf.dexlib2.iface.value.FloatEncodedValue;
-import org.jf.dexlib2.iface.value.IntEncodedValue;
-import org.jf.dexlib2.iface.value.LongEncodedValue;
-import org.jf.dexlib2.iface.value.MethodHandleEncodedValue;
-import org.jf.dexlib2.iface.value.MethodTypeEncodedValue;
-import org.jf.dexlib2.iface.value.NullEncodedValue;
-import org.jf.dexlib2.iface.value.ShortEncodedValue;
-import org.jf.dexlib2.iface.value.StringEncodedValue;
-import org.jf.dexlib2.iface.value.TypeEncodedValue;
 
 import soot.Local;
 import soot.Scene;

--- a/src/main/java/soot/dexpler/instructions/InvokeInterfaceInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeInterfaceInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/InvokePolymorphicInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokePolymorphicInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,12 +25,14 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.DualReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.reference.MethodProtoReference;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jf.dexlib2.iface.instruction.DualReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.reference.MethodProtoReference;
 
 import soot.Local;
 import soot.Scene;

--- a/src/main/java/soot/dexpler/instructions/InvokeSpecialDirectInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeSpecialDirectInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 import soot.dexpler.tags.SpecialInvokeTypeTag;

--- a/src/main/java/soot/dexpler/instructions/InvokeSpecialInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeSpecialInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.InvokeExpr;

--- a/src/main/java/soot/dexpler/instructions/InvokeSpecialSuperInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeSpecialSuperInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 import soot.dexpler.tags.SpecialInvokeTypeTag;

--- a/src/main/java/soot/dexpler/instructions/InvokeStaticInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeStaticInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/InvokeVirtualInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/InvokeVirtualInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/IputInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/IputInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.reference.FieldReference;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
 
 import soot.Local;
 import soot.Type;

--- a/src/main/java/soot/dexpler/instructions/JumpInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/JumpInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OffsetInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OffsetInstruction;
 
 import soot.Unit;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/MethodInvocationInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/MethodInvocationInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,22 +25,24 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
 import static soot.dexpler.Util.dottedClassName;
 import static soot.dexpler.Util.isFloatLike;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction35c;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction3rc;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction45cc;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction4rcc;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction35c;
-import org.jf.dexlib2.iface.instruction.formats.Instruction3rc;
-import org.jf.dexlib2.iface.instruction.formats.Instruction45cc;
-import org.jf.dexlib2.iface.instruction.formats.Instruction4rcc;
-import org.jf.dexlib2.iface.reference.FieldReference;
-import org.jf.dexlib2.iface.reference.MethodReference;
 
 import soot.Local;
 import soot.Modifier;

--- a/src/main/java/soot/dexpler/instructions/MonitorEnterInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/MonitorEnterInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
 
 import soot.Local;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/MonitorExitInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/MonitorExitInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
 
 import soot.Local;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/MoveExceptionInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/MoveExceptionInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
 
 import soot.Body;
 import soot.Local;

--- a/src/main/java/soot/dexpler/instructions/MoveInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/MoveInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.AssignStmt;

--- a/src/main/java/soot/dexpler/instructions/MoveResultInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/MoveResultInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.AssignStmt;

--- a/src/main/java/soot/dexpler/instructions/NewArrayInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/NewArrayInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,14 +25,16 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction22c;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction22c;
-import org.jf.dexlib2.iface.reference.TypeReference;
 
 import soot.ArrayType;
 import soot.Local;

--- a/src/main/java/soot/dexpler/instructions/NewInstanceInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/NewInstanceInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,16 +25,18 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
 import static soot.dexpler.Util.dottedClassName;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction21c;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction21c;
-import org.jf.dexlib2.iface.reference.TypeReference;
 
 import soot.RefType;
 import soot.Type;

--- a/src/main/java/soot/dexpler/instructions/NopInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/NopInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.Jimple;

--- a/src/main/java/soot/dexpler/instructions/OdexInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/OdexInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,9 +20,11 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.analysis.ClassPath;
-import org.jf.dexlib2.iface.DexFile;
-import org.jf.dexlib2.iface.Method;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.analysis.ClassPath;
+import com.android.tools.smali.dexlib2.iface.DexFile;
+import com.android.tools.smali.dexlib2.iface.Method;
 
 /**
  * Interface for instructions that are only valid in optimized dex files (ODEX). These instructions require special handling

--- a/src/main/java/soot/dexpler/instructions/PackedSwitchInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/PackedSwitchInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,12 +25,14 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.PackedSwitchPayload;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.SwitchElement;
-import org.jf.dexlib2.iface.instruction.formats.PackedSwitchPayload;
 
 import soot.Local;
 import soot.Unit;

--- a/src/main/java/soot/dexpler/instructions/PseudoInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/PseudoInstruction.java
@@ -18,8 +18,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 //
 
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -42,7 +40,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 

--- a/src/main/java/soot/dexpler/instructions/ReturnInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ReturnInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction11x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction11x;
 
 import soot.Local;
 import soot.dexpler.DexBody;

--- a/src/main/java/soot/dexpler/instructions/ReturnVoidInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ReturnVoidInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,7 +25,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.dexpler.DexBody;
 import soot.jimple.Jimple;

--- a/src/main/java/soot/dexpler/instructions/RetypeableInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/RetypeableInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -26,6 +24,8 @@ package soot.dexpler.instructions;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
+
+package soot.dexpler.instructions;
 
 import soot.Body;
 import soot.Type;

--- a/src/main/java/soot/dexpler/instructions/SgetInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/SgetInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.reference.FieldReference;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
 
 import soot.dexpler.DexBody;
 import soot.jimple.AssignStmt;

--- a/src/main/java/soot/dexpler/instructions/SparseSwitchInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/SparseSwitchInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,12 +25,14 @@ package soot.dexpler.instructions;
  * #L%
  */
 
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.SwitchElement;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.SparseSwitchPayload;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.SwitchElement;
-import org.jf.dexlib2.iface.instruction.formats.SparseSwitchPayload;
 
 import soot.Local;
 import soot.Unit;

--- a/src/main/java/soot/dexpler/instructions/SputInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/SputInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
-import org.jf.dexlib2.iface.reference.FieldReference;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
 
 import soot.Local;
 import soot.Type;

--- a/src/main/java/soot/dexpler/instructions/SwitchInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/SwitchInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,9 +25,11 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.OffsetInstruction;
-import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OffsetInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction;
 
 import soot.Local;
 import soot.Unit;

--- a/src/main/java/soot/dexpler/instructions/TaggedInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/TaggedInstruction.java
@@ -17,9 +17,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
-
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -42,7 +39,9 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
 
 import soot.tagkit.Tag;
 

--- a/src/main/java/soot/dexpler/instructions/ThrowInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/ThrowInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,8 +25,10 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction11x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction11x;
 
 import soot.dexpler.DexBody;
 import soot.jimple.Jimple;

--- a/src/main/java/soot/dexpler/instructions/UnopInstruction.java
+++ b/src/main/java/soot/dexpler/instructions/UnopInstruction.java
@@ -1,5 +1,3 @@
-package soot.dexpler.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -27,10 +25,12 @@ package soot.dexpler.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.instruction.TwoRegisterInstruction;
-import org.jf.dexlib2.iface.instruction.formats.Instruction12x;
+package soot.dexpler.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction12x;
 
 import soot.Local;
 import soot.Value;

--- a/src/main/java/soot/toDex/ConstantVisitor.java
+++ b/src/main/java/soot/toDex/ConstantVisitor.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.reference.StringReference;
-import org.jf.dexlib2.iface.reference.TypeReference;
-import org.jf.dexlib2.immutable.reference.ImmutableStringReference;
-import org.jf.dexlib2.immutable.reference.ImmutableTypeReference;
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.reference.StringReference;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableStringReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableTypeReference;
 
 import soot.jimple.AbstractConstantSwitch;
 import soot.jimple.ClassConstant;

--- a/src/main/java/soot/toDex/DexPrinter.java
+++ b/src/main/java/soot/toDex/DexPrinter.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -21,6 +19,59 @@ package soot.toDex;
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
+
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.AnnotationVisibility;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.Opcodes;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.BuilderOffsetInstruction;
+import com.android.tools.smali.dexlib2.builder.Label;
+import com.android.tools.smali.dexlib2.builder.MethodImplementationBuilder;
+import com.android.tools.smali.dexlib2.iface.Annotation;
+import com.android.tools.smali.dexlib2.iface.AnnotationElement;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.ExceptionHandler;
+import com.android.tools.smali.dexlib2.iface.Field;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.iface.MethodImplementation;
+import com.android.tools.smali.dexlib2.iface.MethodParameter;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
+import com.android.tools.smali.dexlib2.iface.reference.StringReference;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+import com.android.tools.smali.dexlib2.iface.value.EncodedValue;
+import com.android.tools.smali.dexlib2.immutable.ImmutableAnnotation;
+import com.android.tools.smali.dexlib2.immutable.ImmutableAnnotationElement;
+import com.android.tools.smali.dexlib2.immutable.ImmutableClassDef;
+import com.android.tools.smali.dexlib2.immutable.ImmutableExceptionHandler;
+import com.android.tools.smali.dexlib2.immutable.ImmutableField;
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod;
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableFieldReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableMethodReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableStringReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableTypeReference;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableAnnotationEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableArrayEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableBooleanEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableByteEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableCharEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableDoubleEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableEnumEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableFieldEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableFloatEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableIntEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableLongEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableMethodEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableNullEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableShortEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableStringEncodedValue;
+import com.android.tools.smali.dexlib2.immutable.value.ImmutableTypeEncodedValue;
+import com.android.tools.smali.dexlib2.writer.builder.BuilderEncodedValues;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -55,56 +106,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.jf.dexlib2.AnnotationVisibility;
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.Opcodes;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.BuilderOffsetInstruction;
-import org.jf.dexlib2.builder.Label;
-import org.jf.dexlib2.builder.MethodImplementationBuilder;
-import org.jf.dexlib2.iface.Annotation;
-import org.jf.dexlib2.iface.AnnotationElement;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.ExceptionHandler;
-import org.jf.dexlib2.iface.Field;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.iface.MethodImplementation;
-import org.jf.dexlib2.iface.MethodParameter;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.reference.FieldReference;
-import org.jf.dexlib2.iface.reference.MethodReference;
-import org.jf.dexlib2.iface.reference.StringReference;
-import org.jf.dexlib2.iface.reference.TypeReference;
-import org.jf.dexlib2.iface.value.EncodedValue;
-import org.jf.dexlib2.immutable.ImmutableAnnotation;
-import org.jf.dexlib2.immutable.ImmutableAnnotationElement;
-import org.jf.dexlib2.immutable.ImmutableClassDef;
-import org.jf.dexlib2.immutable.ImmutableExceptionHandler;
-import org.jf.dexlib2.immutable.ImmutableField;
-import org.jf.dexlib2.immutable.ImmutableMethod;
-import org.jf.dexlib2.immutable.ImmutableMethodParameter;
-import org.jf.dexlib2.immutable.reference.ImmutableFieldReference;
-import org.jf.dexlib2.immutable.reference.ImmutableMethodReference;
-import org.jf.dexlib2.immutable.reference.ImmutableStringReference;
-import org.jf.dexlib2.immutable.reference.ImmutableTypeReference;
-import org.jf.dexlib2.immutable.value.ImmutableAnnotationEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableArrayEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableBooleanEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableByteEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableCharEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableDoubleEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableEnumEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableFieldEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableFloatEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableIntEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableLongEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableMethodEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableNullEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableShortEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableStringEncodedValue;
-import org.jf.dexlib2.immutable.value.ImmutableTypeEncodedValue;
-import org.jf.dexlib2.writer.builder.BuilderEncodedValues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/soot/toDex/ExprVisitor.java
+++ b/src/main/java/soot/toDex/ExprVisitor.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,15 +20,17 @@ package soot.toDex;
  * #L%
  */
 
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference;
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableMethodProtoReference;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.iface.reference.MethodReference;
-import org.jf.dexlib2.iface.reference.Reference;
-import org.jf.dexlib2.iface.reference.TypeReference;
-import org.jf.dexlib2.immutable.reference.ImmutableMethodProtoReference;
 
 import soot.ArrayType;
 import soot.DoubleType;
@@ -106,6 +106,7 @@ import soot.toDex.instructions.Insn45cc;
 import soot.toDex.instructions.Insn4rcc;
 import soot.toDex.instructions.InsnWithOffset;
 import soot.util.NumberedString;
+import soot.util.Switchable;
 
 /**
  * A visitor that builds a list of instructions from the Jimple expressions it visits.<br>

--- a/src/main/java/soot/toDex/LabelAssigner.java
+++ b/src/main/java/soot/toDex/LabelAssigner.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,14 +20,16 @@ package soot.toDex;
  * #L%
  */
 
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.builder.Label;
+import com.android.tools.smali.dexlib2.builder.MethodImplementationBuilder;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import org.jf.dexlib2.builder.Label;
-import org.jf.dexlib2.builder.MethodImplementationBuilder;
 
 import soot.jimple.Stmt;
 import soot.toDex.instructions.AbstractPayload;

--- a/src/main/java/soot/toDex/MultiDexBuilder.java
+++ b/src/main/java/soot/toDex/MultiDexBuilder.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,16 +20,18 @@ package soot.toDex;
  * #L%
  */
 
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.Opcodes;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.writer.io.FileDataStore;
+import com.android.tools.smali.dexlib2.writer.pool.DexPool;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.jf.dexlib2.Opcodes;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.writer.io.FileDataStore;
-import org.jf.dexlib2.writer.pool.DexPool;
 
 /**
  * @author Manuel Benz created on 26.09.17

--- a/src/main/java/soot/toDex/RegisterAssigner.java
+++ b/src/main/java/soot/toDex/RegisterAssigner.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,13 +20,15 @@ package soot.toDex;
  * #L%
  */
 
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.Opcode;
+
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-
-import org.jf.dexlib2.Opcode;
 
 import soot.jimple.Stmt;
 import soot.toDex.instructions.AddressInsn;

--- a/src/main/java/soot/toDex/SootToDexUtils.java
+++ b/src/main/java/soot/toDex/SootToDexUtils.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,13 +20,15 @@ package soot.toDex;
  * #L%
  */
 
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.Opcode;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.jf.dexlib2.Opcode;
 
 import soot.ArrayType;
 import soot.BooleanType;

--- a/src/main/java/soot/toDex/StmtVisitor.java
+++ b/src/main/java/soot/toDex/StmtVisitor.java
@@ -1,5 +1,3 @@
-package soot.toDex;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,17 +20,19 @@ package soot.toDex;
  * #L%
  */
 
+package soot.toDex;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction;
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.iface.instruction.Instruction;
-import org.jf.dexlib2.iface.reference.FieldReference;
 
 import soot.ArrayType;
 import soot.BooleanType;
@@ -101,6 +101,7 @@ import soot.toDex.instructions.SparseSwitchPayload;
 import soot.toDex.instructions.SwitchPayload;
 import soot.util.HashMultiMap;
 import soot.util.MultiMap;
+import soot.util.Switchable;
 
 /**
  * A visitor that builds a list of instructions from the Jimple statements it visits.<br>

--- a/src/main/java/soot/toDex/instructions/AbstractInsn.java
+++ b/src/main/java/soot/toDex/instructions/AbstractInsn.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
-
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/AbstractPayload.java
+++ b/src/main/java/soot/toDex/instructions/AbstractPayload.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,7 +20,9 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
 
 /**
  * Abstract base class for all payloads (switch, fill-array) in dex instructions

--- a/src/main/java/soot/toDex/instructions/AddressInsn.java
+++ b/src/main/java/soot/toDex/instructions/AddressInsn.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,8 +20,10 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
 
 import soot.toDex.LabelAssigner;
 

--- a/src/main/java/soot/toDex/instructions/ArrayDataPayload.java
+++ b/src/main/java/soot/toDex/instructions/ArrayDataPayload.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,10 +20,12 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.List;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderArrayPayload;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderArrayPayload;
+
+import java.util.List;
 
 import soot.toDex.LabelAssigner;
 

--- a/src/main/java/soot/toDex/instructions/Insn.java
+++ b/src/main/java/soot/toDex/instructions/Insn.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+
 import java.util.BitSet;
 import java.util.List;
-
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn10t.java
+++ b/src/main/java/soot/toDex/instructions/Insn10t.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,9 +20,11 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction10t;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction10t;
 
 import soot.toDex.LabelAssigner;
 

--- a/src/main/java/soot/toDex/instructions/Insn10x.java
+++ b/src/main/java/soot/toDex/instructions/Insn10x.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,9 +20,11 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction10x;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction10x;
 
 import soot.toDex.LabelAssigner;
 

--- a/src/main/java/soot/toDex/instructions/Insn11n.java
+++ b/src/main/java/soot/toDex/instructions/Insn11n.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction11n;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction11n;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn11x.java
+++ b/src/main/java/soot/toDex/instructions/Insn11x.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction11x;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction11x;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn12x.java
+++ b/src/main/java/soot/toDex/instructions/Insn12x.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction12x;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction12x;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn20t.java
+++ b/src/main/java/soot/toDex/instructions/Insn20t.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,9 +20,11 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction20t;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction20t;
 
 import soot.toDex.LabelAssigner;
 

--- a/src/main/java/soot/toDex/instructions/Insn21c.java
+++ b/src/main/java/soot/toDex/instructions/Insn21c.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction21c;
-import org.jf.dexlib2.iface.reference.Reference;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21c;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn21s.java
+++ b/src/main/java/soot/toDex/instructions/Insn21s.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction21s;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21s;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn21t.java
+++ b/src/main/java/soot/toDex/instructions/Insn21t.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction21t;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21t;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn22b.java
+++ b/src/main/java/soot/toDex/instructions/Insn22b.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction22b;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22b;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn22c.java
+++ b/src/main/java/soot/toDex/instructions/Insn22c.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction22c;
-import org.jf.dexlib2.iface.reference.Reference;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22c;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn22s.java
+++ b/src/main/java/soot/toDex/instructions/Insn22s.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction22s;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22s;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn22t.java
+++ b/src/main/java/soot/toDex/instructions/Insn22t.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction22t;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22t;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn22x.java
+++ b/src/main/java/soot/toDex/instructions/Insn22x.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction22x;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction22x;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn23x.java
+++ b/src/main/java/soot/toDex/instructions/Insn23x.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction23x;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction23x;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn30t.java
+++ b/src/main/java/soot/toDex/instructions/Insn30t.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,9 +20,11 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction30t;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction30t;
 
 import soot.toDex.LabelAssigner;
 

--- a/src/main/java/soot/toDex/instructions/Insn31i.java
+++ b/src/main/java/soot/toDex/instructions/Insn31i.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction31i;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31i;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn31t.java
+++ b/src/main/java/soot/toDex/instructions/Insn31t.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction31t;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31t;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn32x.java
+++ b/src/main/java/soot/toDex/instructions/Insn32x.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction32x;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction32x;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn35c.java
+++ b/src/main/java/soot/toDex/instructions/Insn35c.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction35c;
-import org.jf.dexlib2.iface.reference.Reference;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn3rc.java
+++ b/src/main/java/soot/toDex/instructions/Insn3rc.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,13 +20,15 @@ package soot.toDex.instructions;
  * #L%
  */
 
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+
 import java.util.BitSet;
 import java.util.List;
-
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction3rc;
-import org.jf.dexlib2.iface.reference.Reference;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn45cc.java
+++ b/src/main/java/soot/toDex/instructions/Insn45cc.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction45cc;
-import org.jf.dexlib2.iface.reference.Reference;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction45cc;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn4rcc.java
+++ b/src/main/java/soot/toDex/instructions/Insn4rcc.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,13 +20,15 @@ package soot.toDex.instructions;
  * #L%
  */
 
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction4rcc;
+import com.android.tools.smali.dexlib2.iface.reference.Reference;
+
 import java.util.BitSet;
 import java.util.List;
-
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction4rcc;
-import org.jf.dexlib2.iface.reference.Reference;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/Insn51l.java
+++ b/src/main/java/soot/toDex/instructions/Insn51l.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,11 +20,13 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import java.util.BitSet;
+package soot.toDex.instructions;
 
-import org.jf.dexlib2.Opcode;
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.instruction.BuilderInstruction51l;
+import com.android.tools.smali.dexlib2.Opcode;
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction51l;
+
+import java.util.BitSet;
 
 import soot.toDex.LabelAssigner;
 import soot.toDex.Register;

--- a/src/main/java/soot/toDex/instructions/InsnWithOffset.java
+++ b/src/main/java/soot/toDex/instructions/InsnWithOffset.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,7 +20,9 @@ package soot.toDex.instructions;
  * #L%
  */
 
-import org.jf.dexlib2.Opcode;
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.Opcode;
 
 import soot.jimple.Stmt;
 

--- a/src/main/java/soot/toDex/instructions/PackedSwitchPayload.java
+++ b/src/main/java/soot/toDex/instructions/PackedSwitchPayload.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.Label;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderPackedSwitchPayload;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.Label;
-import org.jf.dexlib2.builder.instruction.BuilderPackedSwitchPayload;
 
 import soot.Unit;
 import soot.jimple.Stmt;

--- a/src/main/java/soot/toDex/instructions/SparseSwitchPayload.java
+++ b/src/main/java/soot/toDex/instructions/SparseSwitchPayload.java
@@ -1,5 +1,3 @@
-package soot.toDex.instructions;
-
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -22,12 +20,14 @@ package soot.toDex.instructions;
  * #L%
  */
 
+package soot.toDex.instructions;
+
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction;
+import com.android.tools.smali.dexlib2.builder.SwitchLabelElement;
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderSparseSwitchPayload;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jf.dexlib2.builder.BuilderInstruction;
-import org.jf.dexlib2.builder.SwitchLabelElement;
-import org.jf.dexlib2.builder.instruction.BuilderSparseSwitchPayload;
 
 import soot.Unit;
 import soot.jimple.Stmt;


### PR DESCRIPTION
The library [dexlib2 from JesusFreke](https://github.com/JesusFreke/smali/tree/master/dexlib2) is no longer maintained. 
Google has [forked](https://github.com/google/smali) the project and maintains now an own version. This forked version uses package namespace `com.android.tools.smali.dexlib2` instead of `org.jf.dexlib2`.

As improvement the forked version has DEX v40 and V41 support (prevents error `UnsupportedFile: Dex version 040 is not supported`).