### PR TITLE
Improve performance by introducing new caches for FastHierarchy

### DIFF
--- a/src/main/java/soot/Body.java
+++ b/src/main/java/soot/Body.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import soot.jimple.IdentityStmt;
 import soot.jimple.ParameterRef;
+import soot.jimple.Stmt;
 import soot.jimple.ThisRef;
 import soot.options.Options;
 import soot.tagkit.AbstractHost;
@@ -90,7 +91,7 @@ public abstract class Body extends AbstractHost implements Serializable {
   /**
    * The chain of units for this Body.
    */
-  protected UnitPatchingChain unitChain = new UnitPatchingChain(new HashChain<>());
+  protected UnitPatchingChain unitChain = new UnitPatchingChain(createHashChain());
 
   /**
    * Lazy initialized array containing some validators in order to validate the Body.
@@ -112,6 +113,27 @@ public abstract class Body extends AbstractHost implements Serializable {
   @Override
   public Object clone() {
     return clone(true);
+  }
+
+  protected Chain<Unit> createHashChain() {
+    return new HashChain<Unit>() {
+      @Override
+      protected void elementAdded(Unit added) {
+        if (added instanceof Stmt) {
+          Stmt stmt = (Stmt) added;
+          stmt.setContainingBody(Body.this);
+        }
+      }
+
+      @Override
+      protected void elementRemoved(Unit removed) {
+        if (removed instanceof Stmt) {
+          Stmt stmt = (Stmt) removed;
+          stmt.setContainingBody(null);
+        }
+      }
+
+    };
   }
 
   abstract public Object clone(boolean noLocalsClone);
@@ -587,7 +609,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see Value
    */
   public Iterator<ValueBox> getUseBoxesIterator() {
-    Iterator<ValueBox>[] vb = (Iterator<ValueBox>[]) new Iterator[unitChain.size()];
+    Iterator<ValueBox>[] vb = new Iterator[unitChain.size()];
     int i = 0;
     for (Unit item : unitChain) {
       vb[i] = item.getUseBoxesIterator();
@@ -608,7 +630,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see Value
    */
   public Iterator<ValueBox> getDefBoxesIterator() {
-    Iterator<ValueBox>[] vb = (Iterator<ValueBox>[]) new Iterator[unitChain.size()];
+    Iterator<ValueBox>[] vb = new Iterator[unitChain.size()];
     int i = 0;
     for (Unit item : unitChain) {
       vb[i] = item.getDefBoxesIterator();
@@ -628,7 +650,7 @@ public abstract class Body extends AbstractHost implements Serializable {
    * @see Value
    */
   public Iterator<ValueBox> getUseAndDefBoxesIterator() {
-    Iterator<ValueBox>[] vb = (Iterator<ValueBox>[]) new Iterator[unitChain.size()];
+    Iterator<ValueBox>[] vb = new Iterator[unitChain.size()];
     int i = 0;
     for (Unit item : unitChain) {
       vb[i] = item.getUseAndDefBoxesIterator();

--- a/src/main/java/soot/FastHierarchy.java
+++ b/src/main/java/soot/FastHierarchy.java
@@ -36,10 +36,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import soot.dotnet.types.DotNetBasicTypes;
 import soot.jimple.spark.internal.TypeManager;
 import soot.options.Options;
+import soot.toolkits.scalar.Pair;
 import soot.util.ConcurrentHashMultiMap;
 import soot.util.MultiMap;
 import soot.util.NumberedString;
@@ -99,6 +102,9 @@ public class FastHierarchy {
    */
   protected Map<SootClass, Interval> classToInterval = new HashMap<SootClass, Interval>();
 
+  protected Map<Pair<SootClass, SootMethodRef>, Set<SootMethod>> methodRefToAbstractMethods
+      = new ConcurrentHashMap<Pair<SootClass, SootMethodRef>, Set<SootMethod>>();
+
   protected final Scene sc;
   protected final RefType rtObject;
   protected final RefType rtSerializable;
@@ -109,6 +115,15 @@ public class FastHierarchy {
   protected final RefType cilIconvertible;
   protected final RefType cilIequatable1;
   protected final RefType cilIformattable;
+  private Function<Pair<SootClass, SootMethodRef>, Set<SootMethod>> abstractMethodComputation
+      = new Function<Pair<SootClass, SootMethodRef>, Set<SootMethod>>() {
+
+        @Override
+        public Set<SootMethod> apply(Pair<SootClass, SootMethodRef> arg0) {
+          return doResolveAbstractDispatch(arg0.getO1(), arg0.getO2());
+        }
+
+      };
 
   public static class Interval {
     public int lower;
@@ -670,6 +685,11 @@ public class FastHierarchy {
    *          The declared type C
    */
   public Set<SootMethod> resolveAbstractDispatch(SootClass baseType, SootMethodRef m) {
+    Pair<SootClass, SootMethodRef> pair = new Pair<>(baseType, m);
+    return methodRefToAbstractMethods.computeIfAbsent(pair, abstractMethodComputation);
+  }
+
+  protected Set<SootMethod> doResolveAbstractDispatch(SootClass baseType, SootMethodRef m) {
     HashSet<SootClass> resolved = new HashSet<>();
     HashSet<SootMethod> ret = new HashSet<>();
 
@@ -913,7 +933,7 @@ public class FastHierarchy {
       }
 
       candidate = getSignaturePolymorphicMethod(concreteType, name, parameterTypes, returnType);
-      if (candidate != null) {
+      if (candidate != null && !candidate.isStatic()) {
         if (!calleeExist || isVisible(concreteType, declaringClass, candidate.getModifiers())) {
           if (!allowAbstract && candidate.isAbstract()) {
             candidate = null;
@@ -934,7 +954,7 @@ public class FastHierarchy {
     // look for default methods:
     // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.3
     if (isHandleDefaultMethods()) {
-      // keep our own ignorelist here so we are not restricted to already hit suinterfaces when
+      // keep our own ignorelist here so we are not restricted to already hit super interfaces when
       // determining the most specific super interface
       HashSet<SootClass> interfaceIgnoreList = new HashSet<>();
       for (SootClass concreteType = baseType; concreteType != null;) {
@@ -949,8 +969,8 @@ public class FastHierarchy {
 
           SootMethod method = getSignaturePolymorphicMethod(iFace, name, parameterTypes, returnType);
           if (method != null && isVisible(declaringClass, iFace, method.getModifiers())) {
-            if (!allowAbstract && method.isAbstract()) {
-              // abstract method cannot be dispatched
+            if ((!allowAbstract && method.isAbstract()) || method.isStatic()) {
+              // abstract/static method cannot be dispatched
             } else if (candidate == null || canStoreClass(method.getDeclaringClass(), candidate.getDeclaringClass())) {
               // the found method is more specific than our current candidate
               candidate = method;

--- a/src/main/java/soot/NameAndNumber.java
+++ b/src/main/java/soot/NameAndNumber.java
@@ -1,0 +1,68 @@
+package soot;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 - 2004 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+/**
+ * A tuple consisting of a name and a number.
+ */
+class NameAndNumber {
+  public String name;
+  public int num;
+
+  public NameAndNumber(String name, int num) {
+    this.name = name;
+    this.num = num;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + num;
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    NameAndNumber other = (NameAndNumber) obj;
+    if (name == null) {
+      if (other.name != null) {
+        return false;
+      }
+    } else if (!name.equals(other.name)) {
+      return false;
+    }
+    if (num != other.num) {
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/src/main/java/soot/NameAndNumber.java
+++ b/src/main/java/soot/NameAndNumber.java
@@ -4,7 +4,7 @@ package soot;
  * #%L
  * Soot - a J*va Optimization Framework
  * %%
- * Copyright (C) 2003 - 2004 Ondrej Lhotak
+ * Copyright (C) 2025 Marc Miltenberger
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -23,7 +23,8 @@ package soot;
  */
 
 /**
- * A tuple consisting of a name and a number.
+ * A tuple consisting of a name and a number. Is more memory efficient than a Pair due to not using
+ * java.lang.Integer.
  */
 class NameAndNumber {
   public String name;

--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,6 +98,7 @@ public class SootClass extends AbstractHost {
   private RefType refType;
 
   private volatile int resolvingLevel = DANGLING;
+  protected ConcurrentMap<NameAndNumber, List<SootMethod>> methodParameterMap = new ConcurrentHashMap<>();
 
   /**
    * Lazy initialized array containing some validators in order to validate the SootClass.
@@ -682,8 +685,18 @@ public class SootClass extends AbstractHost {
     }
     this.subSigToMethods.put(m.getNumberedSubSignature(), m);
     this.methodList.add(m);
+    addToNameAndParamMap(m);
     m.setDeclared(true);
     m.setDeclaringClass(this);
+  }
+
+  protected void addToNameAndParamMap(SootMethod m) {
+    List<SootMethod> newList = new ArrayList<>();
+    List<SootMethod> use = methodParameterMap.putIfAbsent(new NameAndNumber(m.getName(), m.getParameterCount()), newList);
+    if (use == null) {
+      use = newList;
+    }
+    use.add(m);
   }
 
   public synchronized SootMethod getOrAddMethod(SootMethod m) {
@@ -701,6 +714,7 @@ public class SootClass extends AbstractHost {
     if (old != null) {
       return old;
     }
+    addToNameAndParamMap(m);
     this.subSigToMethods.put(m.getNumberedSubSignature(), m);
     this.methodList.add(m);
     m.setDeclared(true);
@@ -746,6 +760,12 @@ public class SootClass extends AbstractHost {
     m.setDeclaringClass(null);
     Scene scene = Scene.v();
 
+    List<SootMethod> l = methodParameterMap.get(new NameAndNumber(m.getName(), m.getParameterCount()));
+    if (l != null) {
+      synchronized (l) {
+        l.remove(m);
+      }
+    }
     // We have caches for resolving default methods in the FastHierarchy, which are no longer valid
     scene.modifyHierarchy();
   }
@@ -1291,19 +1311,10 @@ public class SootClass extends AbstractHost {
    * @return the methods
    */
   public Collection<SootMethod> getMethodsByNameAndParamCount(String name, int paramCount) {
-    List<SootMethod> result = null;
-    for (SootMethod m : getMethods()) {
-      if (m.getParameterCount() == paramCount && m.getName().equals(name)) {
-        if (result == null) {
-          result = new ArrayList<>();
-        }
-        result.add(m);
-      }
-    }
-
-    if (result == null) {
+    List<SootMethod> l = methodParameterMap.get(new NameAndNumber(name, paramCount));
+    if (l == null) {
       return Collections.emptyList();
     }
-    return result;
+    return l;
   }
 }

--- a/src/main/java/soot/SootClass.java
+++ b/src/main/java/soot/SootClass.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,6 +100,15 @@ public class SootClass extends AbstractHost {
 
   private volatile int resolvingLevel = DANGLING;
   protected ConcurrentMap<NameAndNumber, List<SootMethod>> methodParameterMap = new ConcurrentHashMap<>();
+
+  private static final Function<? super NameAndNumber, ? extends List<SootMethod>> NEW_LIST_FACTORY
+      = new Function<NameAndNumber, List<SootMethod>>() {
+        @Override
+        public List<SootMethod> apply(NameAndNumber t) {
+          return new ArrayList<>();
+        }
+      };
+
 
   /**
    * Lazy initialized array containing some validators in order to validate the SootClass.
@@ -691,11 +701,8 @@ public class SootClass extends AbstractHost {
   }
 
   protected void addToNameAndParamMap(SootMethod m) {
-    List<SootMethod> newList = new ArrayList<>();
-    List<SootMethod> use = methodParameterMap.putIfAbsent(new NameAndNumber(m.getName(), m.getParameterCount()), newList);
-    if (use == null) {
-      use = newList;
-    }
+    List<SootMethod> use
+        = methodParameterMap.computeIfAbsent(new NameAndNumber(m.getName(), m.getParameterCount()), NEW_LIST_FACTORY);
     use.add(m);
   }
 

--- a/src/main/java/soot/jimple/Stmt.java
+++ b/src/main/java/soot/jimple/Stmt.java
@@ -1,5 +1,7 @@
 package soot.jimple;
 
+import soot.Body;
+
 /*-
  * #%L
  * Soot - a J*va Optimization Framework
@@ -174,5 +176,20 @@ public interface Stmt extends Unit {
    * @return the field reference box
    */
   public ValueBox getFieldRefBox() throws RuntimeException;
+
+  /**
+   * Returns the body the statement is part of, or null if there is no containing body
+   * 
+   * @return the containing body (or null)
+   */
+  public Body getContainingBody();
+
+  /**
+   * Sets the containing body
+   * 
+   * @param body
+   *          the new body (or null if the statement was removed)
+   */
+  public void setContainingBody(Body body);
 
 }

--- a/src/main/java/soot/jimple/internal/AbstractStmt.java
+++ b/src/main/java/soot/jimple/internal/AbstractStmt.java
@@ -25,6 +25,7 @@ package soot.jimple.internal;
 import java.util.List;
 
 import soot.AbstractUnit;
+import soot.Body;
 import soot.Unit;
 import soot.ValueBox;
 import soot.baf.Baf;
@@ -37,6 +38,8 @@ import soot.jimple.Stmt;
 
 @SuppressWarnings("serial")
 public abstract class AbstractStmt extends AbstractUnit implements Stmt, ConvertToBaf {
+
+  private Body body;
 
   @Override
   public void convertToBaf(JimpleToBafContext context, List<Unit> out) {
@@ -103,5 +106,15 @@ public abstract class AbstractStmt extends AbstractUnit implements Stmt, Convert
   @Override
   public ValueBox getFieldRefBox() {
     throw new RuntimeException("getFieldRefBox() called with no FieldRef present!");
+  }
+
+  @Override
+  public Body getContainingBody() {
+    return body;
+  }
+
+  @Override
+  public void setContainingBody(Body body) {
+    this.body = body;
   }
 }

--- a/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
+++ b/src/main/java/soot/jimple/toolkits/ide/icfg/AbstractJimpleBasedICFG.java
@@ -90,8 +90,7 @@ public abstract class AbstractJimpleBasedICFG implements BiDiInterproceduralCFG<
   }
 
   public Body getBodyOf(Unit u) {
-    assert unitToOwner.containsKey(u) : "Statement " + u + " not in unit-to-owner mapping";
-    Body b = unitToOwner.get(u);
+    Body b = ((Stmt) u).getContainingBody();
     return b;
   }
 

--- a/src/main/java/soot/util/Chain.java
+++ b/src/main/java/soot/util/Chain.java
@@ -33,6 +33,9 @@ import java.util.List;
  * @param <E>
  *          element type
  */
+/**
+ * @param <E>
+ */
 public interface Chain<E> extends Collection<E>, Serializable {
 
   /** Inserts <code>toInsert</code> in the Chain before <code>point</code>. */

--- a/src/main/java/soot/util/HashChain.java
+++ b/src/main/java/soot/util/HashChain.java
@@ -304,6 +304,7 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
     } else {
       newLink = new Link<E>(item);
       firstItem = lastItem = item;
+      elementAdded(item);
     }
     map.put(item, newLink);
   }
@@ -325,6 +326,7 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
     } else {
       newLink = new Link<E>(item);
       firstItem = lastItem = item;
+      elementAdded(item);
     }
     map.put(item, newLink);
   }
@@ -451,7 +453,7 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
   }
 
   @Override
-  public synchronized int size() {
+  public int size() {
     return map.size();
   }
 
@@ -502,10 +504,12 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
     }
 
     public void unlinkSelf() {
+      elementRemoved(item);
       bind(previousLink, nextLink);
     }
 
     public Link<X> insertAfter(X item) {
+      elementAdded(item);
       Link<X> newLink = new Link<X>(item);
 
       bind(newLink, nextLink);
@@ -514,6 +518,7 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
     }
 
     public Link<X> insertBefore(X item) {
+      elementAdded(item);
       Link<X> newLink = new Link<X>(item);
 
       bind(previousLink, newLink);
@@ -626,7 +631,8 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
         throw new IllegalStateException();
       } else {
         currentLink.unlinkSelf();
-        map.remove(currentLink.getItem());
+        E it = currentLink.getItem();
+        map.remove(it);
         state = false;
       }
     }
@@ -646,4 +652,25 @@ public class HashChain<E> extends AbstractCollection<E> implements Chain<E> {
   public long getModificationCount() {
     return stateCount;
   }
+
+  /**
+   * Notifies the chain when an element was added
+   * 
+   * @param added
+   *          the added element
+   */
+  protected void elementAdded(E added) {
+
+  }
+
+  /**
+   * Notifies the chain when an element was removed
+   * 
+   * @param removed
+   *          the removed element
+   */
+  protected void elementRemoved(E removed) {
+
+  }
+
 }


### PR DESCRIPTION
Furthermore: Adds a field so that each Jimple statement knows which body the statement belongs to. This allows client analysis to use Statements everywhere instead of keeping track of the containing body.