### PR TITLE
Fix phases & process multidex by default

### DIFF
--- a/src/main/java/soot/PackManager.java
+++ b/src/main/java/soot/PackManager.java
@@ -321,20 +321,6 @@ public class PackManager {
 
     // Baf optimization pack
     addPack(p = new BodyPack("bop"));
-
-    // Dummy Dava Phase
-    /*
-     * Nomair A. Naeem 13th Feb 2006 Added so that Dava Options can be added as phase options rather than main soot options
-     * since they only make sense when decompiling The db phase options are added in soot_options.xml
-     */
-    addPack(p = new BodyPack("db"));
-    {
-      p.add(new Transform("db.transformations", null));
-      p.add(new Transform("db.renamer", null));
-      p.add(new Transform("db.deobfuscate", null));
-      p.add(new Transform("db.force-recompile", null));
-    }
-
     onlyStandardPacks = true;
   }
 

--- a/src/main/xml/options/soot_options.xml
+++ b/src/main/xml/options/soot_options.xml
@@ -1692,6 +1692,16 @@
                     <short_desc>Splits primitive locals used as different types</short_desc>
                 </sub_phase>
                 <sub_phase>
+                    <name>Array Writer Aggregregator</name>
+                    <alias>jb.awa</alias>
+                    <boolopt>
+                        <name>Enabled</name>
+                        <alias>enabled</alias>
+                        <default>true</default>
+                    </boolopt>
+                    <short_desc>Reorder array writes to save local variables</short_desc>
+                </sub_phase>
+                <sub_phase>
                     <name>Jimple Local Aggregator</name>
                     <alias>jb.a</alias>
                     <short_desc>Aggregator: removes some unnecessary copies</short_desc>

--- a/src/main/xml/options/soot_options.xml
+++ b/src/main/xml/options/soot_options.xml
@@ -516,6 +516,7 @@
         <boolopt>
             <name>Process all DEX files in APK</name>
             <alias>process-multiple-dex</alias>
+            <default>true</default>
             <short_desc>Process all DEX files found in APK.</short_desc>
             <long_desc>
                 <p>


### PR DESCRIPTION
Remove dava phases and add Array Write Aggregator to the options.xml file
Enabling multidex by default