### PR TITLE
Tim-hoffman: fix bugs in *ASMBackend bytecode version computation

### DIFF
--- a/src/main/generated/options/soot/options/Options.java
+++ b/src/main/generated/options/soot/options/Options.java
@@ -51,6 +51,7 @@ public class Options extends OptionsBase {
     public static final int src_prec_apk = 5;
     public static final int src_prec_apk_class_jimple = 6;
     public static final int src_prec_apk_c_j = 6;
+    public static final int src_prec_MAX = 6;
     public static final int output_format_J = 1;
     public static final int output_format_jimple = 1;
     public static final int output_format_j = 2;
@@ -81,6 +82,7 @@ public class Options extends OptionsBase {
     public static final int output_format_template = 16;
     public static final int output_format_a = 17;
     public static final int output_format_asm = 17;
+    public static final int output_format_MAX = 17;
     public static final int java_version_default = 1;
     public static final int java_version_1_1 = 2;
     public static final int java_version_1 = 2;
@@ -106,21 +108,26 @@ public class Options extends OptionsBase {
     public static final int java_version_11 = 12;
     public static final int java_version_1_12 = 13;
     public static final int java_version_12 = 13;
+    public static final int java_version_MAX = 13;
     public static final int wrong_staticness_fail = 1;
     public static final int wrong_staticness_ignore = 2;
     public static final int wrong_staticness_fix = 3;
     public static final int wrong_staticness_fixstrict = 4;
+    public static final int wrong_staticness_MAX = 4;
     public static final int field_type_mismatches_fail = 1;
     public static final int field_type_mismatches_ignore = 2;
     public static final int field_type_mismatches_null = 3;
+    public static final int field_type_mismatches_MAX = 3;
     public static final int throw_analysis_pedantic = 1;
     public static final int throw_analysis_unit = 2;
     public static final int throw_analysis_dalvik = 3;
     public static final int throw_analysis_auto_select = 4;
+    public static final int throw_analysis_MAX = 4;
     public static final int check_init_throw_analysis_auto = 1;
     public static final int check_init_throw_analysis_pedantic = 2;
     public static final int check_init_throw_analysis_unit = 3;
     public static final int check_init_throw_analysis_dalvik = 4;
+    public static final int check_init_throw_analysis_MAX = 4;
 
     @SuppressWarnings("unused")
     public boolean parse(String[] argv) {

--- a/src/main/xml/options/make-soot-options.xsl
+++ b/src/main/xml/options/make-soot-options.xsl
@@ -392,6 +392,7 @@ public class Options extends OptionsBase {
     public static final int <xsl:copy-of select="$name"/>_<xsl:value-of select="translate(.,'-. ','___')"/> = <xsl:value-of select="$number"/>;<xsl:text/>
             </xsl:for-each>
         </xsl:for-each>
+    public static final int <xsl:copy-of select="$name"/>_MAX = <xsl:value-of select="count(value)"/>;<xsl:text/>
     </xsl:template>
 
     <!--*************************************************************************-->

--- a/src/systemTest/java/soot/baf/BafASMBackendTest.java
+++ b/src/systemTest/java/soot/baf/BafASMBackendTest.java
@@ -1,0 +1,126 @@
+package soot.baf;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2021 Timothy Hoffman
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
+import soot.G;
+import soot.ModulePathSourceLocator;
+import soot.ModuleScene;
+import soot.Scene;
+import soot.SootClass;
+import soot.SootMethod;
+import soot.options.Options;
+import soot.testing.framework.AbstractTestingFramework;
+
+/**
+ * Test the bytecode version computation in {@link soot.baf.BafASMBackend}.
+ * 
+ * @author Timothy Hoffman
+ */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
+public class BafASMBackendTest extends AbstractTestingFramework {
+
+  @Override
+  protected void setupSoot() {
+  }
+
+  @Test
+  public void testCachingInvalidation() throws Exception {
+    final String targetClass = "soot.baf.BafASMBackendTestInput_Default";
+    final Scene scene = customSetupLib(rtJar(), Collections.singletonList(targetClass));
+
+    SootClass sc = getOrResolveSootClass(scene, targetClass, SootClass.BODIES);
+    Assert.assertNotNull(sc);
+    Assert.assertEquals(targetClass, sc.getName());
+
+    // Ensure the class was loaded properly with all bodies
+    Assert.assertEquals(6, sc.getMethodCount());
+    Assert.assertTrue(sc.getMethods().stream().allMatch(SootMethod::hasActiveBody));
+
+    // Ensure the version will be derived only by BafASMBackend
+    // (and not from the input source version).
+    Assert.assertEquals(0, Options.v().java_version());
+
+    byte[] bytecode = generateBytecode(sc);
+
+    // Run ASM verifier and ensure the message is empty (i.e. there are no VerifyErrors).
+    StringWriter strWriter = new StringWriter();
+    CheckClassAdapter.verify(new ClassReader(bytecode), null, false, new PrintWriter(strWriter));
+    String verifyMsg = strWriter.toString();
+    Assert.assertTrue(verifyMsg, verifyMsg.isEmpty());
+  }
+
+  private Scene customSetupLib(String rtJar, List<String> classNames) {
+    G.reset();
+
+    final Options opts = Options.v();
+
+    opts.set_whole_program(true);
+    opts.set_output_format(Options.output_format_none);
+    opts.set_allow_phantom_refs(true);
+    opts.set_no_bodies_for_excluded(true);
+    opts.set_exclude(getExcludes());
+    opts.set_include(classNames);
+    opts.set_process_dir(Collections.singletonList(SYSTEMTEST_TARGET_CLASSES_DIR));
+
+    // Disable deriving Java version from the input bytecode so that the
+    // version is computed based only on the logic in BafASMBackend.
+    opts.set_derive_java_version(false);
+
+    final boolean isModuleJar = isModuleJar(rtJar);
+    if (isModuleJar) {
+      opts.set_soot_modulepath(ModulePathSourceLocator.DUMMY_CLASSPATH_JDK9_FS);
+    } else {
+      opts.set_soot_classpath(rtJar);
+    }
+
+    // NOTE: must obtain Scene after all options are set
+    Scene scene = isModuleJar ? ModuleScene.v() : Scene.v();
+    scene.loadNecessaryClasses();
+    runSoot();
+    return scene;
+  }
+
+  private static String rtJar() throws IOException {
+    Path p = Paths.get(System.getProperty("java.home"), "lib", "rt.jar");
+    return Files.exists(p) ? p.toRealPath().toString() : null;
+  }
+
+  private static boolean isModuleJar(String rtJar) {
+    return (rtJar == null);
+  }
+}

--- a/src/systemTest/java/soot/baf/BafASMBackendTest.java
+++ b/src/systemTest/java/soot/baf/BafASMBackendTest.java
@@ -22,14 +22,8 @@ package soot.baf;
  * #L%
  */
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,10 +31,6 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.util.CheckClassAdapter;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
-import soot.G;
-import soot.ModulePathSourceLocator;
-import soot.ModuleScene;
-import soot.Scene;
 import soot.SootClass;
 import soot.SootMethod;
 import soot.options.Options;
@@ -56,14 +46,14 @@ public class BafASMBackendTest extends AbstractTestingFramework {
 
   @Override
   protected void setupSoot() {
+      final Options opts = Options.v();
+      opts.set_derive_java_version(false);
   }
 
   @Test
   public void testCachingInvalidation() throws Exception {
     final String targetClass = "soot.baf.BafASMBackendTestInput_Default";
-    final Scene scene = customSetupLib(rtJar(), Collections.singletonList(targetClass));
-
-    SootClass sc = getOrResolveSootClass(scene, targetClass, SootClass.BODIES);
+    SootClass sc = prepareTarget("<" + targetClass + ": void <init>()>", targetClass).getDeclaringClass();
     Assert.assertNotNull(sc);
     Assert.assertEquals(targetClass, sc.getName());
 
@@ -82,45 +72,5 @@ public class BafASMBackendTest extends AbstractTestingFramework {
     CheckClassAdapter.verify(new ClassReader(bytecode), null, false, new PrintWriter(strWriter));
     String verifyMsg = strWriter.toString();
     Assert.assertTrue(verifyMsg, verifyMsg.isEmpty());
-  }
-
-  private Scene customSetupLib(String rtJar, List<String> classNames) {
-    G.reset();
-
-    final Options opts = Options.v();
-
-    opts.set_whole_program(true);
-    opts.set_output_format(Options.output_format_none);
-    opts.set_allow_phantom_refs(true);
-    opts.set_no_bodies_for_excluded(true);
-    opts.set_exclude(getExcludes());
-    opts.set_include(classNames);
-    opts.set_process_dir(Collections.singletonList(SYSTEMTEST_TARGET_CLASSES_DIR));
-
-    // Disable deriving Java version from the input bytecode so that the
-    // version is computed based only on the logic in BafASMBackend.
-    opts.set_derive_java_version(false);
-
-    final boolean isModuleJar = isModuleJar(rtJar);
-    if (isModuleJar) {
-      opts.set_soot_modulepath(ModulePathSourceLocator.DUMMY_CLASSPATH_JDK9_FS);
-    } else {
-      opts.set_soot_classpath(rtJar);
-    }
-
-    // NOTE: must obtain Scene after all options are set
-    Scene scene = isModuleJar ? ModuleScene.v() : Scene.v();
-    scene.loadNecessaryClasses();
-    runSoot();
-    return scene;
-  }
-
-  private static String rtJar() throws IOException {
-    Path p = Paths.get(System.getProperty("java.home"), "lib", "rt.jar");
-    return Files.exists(p) ? p.toRealPath().toString() : null;
-  }
-
-  private static boolean isModuleJar(String rtJar) {
-    return (rtJar == null);
   }
 }

--- a/src/systemTest/java/soot/testing/framework/AbstractTestingFramework.java
+++ b/src/systemTest/java/soot/testing/framework/AbstractTestingFramework.java
@@ -240,13 +240,10 @@ public abstract class AbstractTestingFramework {
     return sootClass;
   }
 
-  private String classFromSignature(String targetMethod) {
-    return targetMethod.substring(1, targetMethod.indexOf(':'));
-  }
-
-  private SootMethod getMethodForSig(String sig) {
-    Scene.v().forceResolve(classFromSignature(sig), SootClass.BODIES);
-    return Scene.v().getMethod(sig);
+  private static SootMethod getMethodForSig(String sig) {
+    final Scene scene = Scene.v();
+    scene.forceResolve(Scene.signatureToClass(sig), SootClass.BODIES);
+    return scene.getMethod(sig);
   }
 
   /**

--- a/src/systemTest/targets/soot/baf/BafASMBackendTestInput_Default.java
+++ b/src/systemTest/targets/soot/baf/BafASMBackendTestInput_Default.java
@@ -1,0 +1,63 @@
+package soot.baf;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2021 Timothy Hoffman
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+import java.lang.annotation.Annotation;
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.TypeVariable;
+
+/**
+ * Copied {@link #isAnnotationPresent} from {@link java.lang.Class} because it contains a call to a "default" method in an
+ * interface which requires {@link soot.baf.BafASMBackend} to produce bytecode version 1.8 or greater.
+ * 
+ * @author Timothy Hoffman
+ */
+public class BafASMBackendTestInput_Default implements GenericDeclaration {
+
+  public BafASMBackendTestInput_Default() {
+  }
+
+  @Override
+  public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
+    return GenericDeclaration.super.isAnnotationPresent(annotationClass);
+  }
+
+  @Override
+  public TypeVariable<?>[] getTypeParameters() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Annotation[] getAnnotations() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Annotation[] getDeclaredAnnotations() {
+    throw new UnsupportedOperationException();
+  }
+}


### PR DESCRIPTION
Solves the merge conflicts of https://github.com/soot-oss/soot/pull/1694

> Also, add ASM validator and a test case for the 1.8 bug.

> The fixed bugs are:
>  1. bytecode version was not high enough when using special invoke to call a default method. There was no check for this case but it requires version 1.8.
>  2. AbstractASMBackend previously stopped increasing the version number if at least 1.8 was necessary for some method which may have missed a higher version number being required by a later method! The fix was to check the MAX version number instead.
