### PR TITLE
Fix edge removal in the CallGraph class + improve runtime a bit

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -100,7 +100,6 @@ public class CallGraph implements Iterable<Edge> {
     for (QueueReader<Edge> edgeRdr = listener(); edgeRdr.hasNext();) {
       Edge e = edgeRdr.next();
       if (e != null && e.srcUnit() == u) {
-        e.remove();
         removeEdge(e, false);
         edgesToRemove.add(e);
         hasRemoved = true;
@@ -197,14 +196,12 @@ public class CallGraph implements Iterable<Edge> {
    * @return whether the removal was successful.
    */
   public boolean removeEdges(Collection<Edge> edges) {
-    if (!this.edges.removeAll(edges)) {
-      return false;
-    }
+    boolean removedEdges = false;
     for (Edge e : edges) {
-      removeEdge(e, false);
+      removedEdges |= removeEdge(e, false);
     }
     reader.remove(edges);
-    return true;
+    return removedEdges;
   }
 
   /**

--- a/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/CallGraph.java
@@ -95,20 +95,11 @@ public class CallGraph implements Iterable<Edge> {
    * @return True if at least one edge has been removed, otherwise false
    */
   public boolean removeAllEdgesOutOf(Unit u) {
-    boolean hasRemoved = false;
     Set<Edge> edgesToRemove = new HashSet<>();
-    for (QueueReader<Edge> edgeRdr = listener(); edgeRdr.hasNext();) {
-      Edge e = edgeRdr.next();
-      if (e != null && e.srcUnit() == u) {
-        removeEdge(e, false);
-        edgesToRemove.add(e);
-        hasRemoved = true;
-      }
+    for (Iterator<Edge> it = edgesOutOf(u); it.hasNext(); ) {
+      edgesToRemove.add(it.next());
     }
-    if (hasRemoved) {
-      reader.remove(edgesToRemove);
-    }
-    return hasRemoved;
+    return removeEdges(edgesToRemove);
   }
 
   /**

--- a/src/test/java/soot/jimple/toolkit/callgraph/CallGraphTest.java
+++ b/src/test/java/soot/jimple/toolkit/callgraph/CallGraphTest.java
@@ -1,0 +1,121 @@
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997 - 2014 Raja Vallee-Rai and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package soot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import soot.Local;
+import soot.SootClass;
+import soot.SootMethod;
+import soot.Unit;
+import soot.jimple.Jimple;
+import soot.jimple.JimpleBody;
+import soot.jimple.Stmt;
+import soot.jimple.toolkits.callgraph.CallGraph;
+import soot.jimple.toolkits.callgraph.Edge;
+
+/**
+ * Test the CallGraph data structure.
+ */
+public class CallGraphTest {
+
+  private SootMethod tgtMethod;
+  private SootMethod srcMethod;
+  private Stmt invokeStmt;
+
+  private static class TestCallGraph extends CallGraph {
+
+    public void assertMapsEmpty() {
+      assertTrue(srcMethodToEdge.keySet().isEmpty());
+      assertTrue(srcUnitToEdge.keySet().isEmpty());
+      assertTrue(tgtToEdge.keySet().isEmpty());
+    }
+
+    public void assertMapsNotEmpty() {
+      assertFalse(srcMethodToEdge.keySet().isEmpty());
+      assertFalse(srcUnitToEdge.keySet().isEmpty());
+      assertFalse(tgtToEdge.keySet().isEmpty());
+    }
+
+  }
+
+  @Before
+  public void setup() {
+    SootClass sootClass = new SootClass("Dummy", Modifier.PUBLIC);
+    tgtMethod = new SootMethod("tgt", Collections.emptyList(), VoidType.v(), Modifier.PUBLIC);
+    sootClass.addMethod(tgtMethod);
+    srcMethod = new SootMethod("src", Collections.emptyList(), VoidType.v(), Modifier.PUBLIC);
+    sootClass.addMethod(srcMethod);
+    JimpleBody body = Jimple.v().newBody(srcMethod);
+    Local base = Jimple.v().newLocal("base", RefType.v(sootClass));
+    body.getLocals().add(base);
+    invokeStmt = Jimple.v().newInvokeStmt(Jimple.v().newVirtualInvokeExpr(base, tgtMethod.makeRef()));
+    body.getUnits().add(invokeStmt);
+  }
+
+  @Test
+  public void testAddRemoveEdge() {
+    TestCallGraph cg = new TestCallGraph();
+    cg.assertMapsEmpty();
+    Edge e = new Edge(srcMethod, invokeStmt, tgtMethod);
+    cg.addEdge(e);
+    cg.assertMapsNotEmpty();
+    assertEquals(1, cg.size());
+    assertTrue(cg.edgesOutOf(invokeStmt).hasNext());
+    cg.removeEdge(e);
+    assertEquals(0, cg.size());
+    assertFalse(cg.edgesOutOf(invokeStmt).hasNext());
+    cg.assertMapsEmpty();
+  }
+
+  @Test
+  public void testAddRemoveEdges() {
+    TestCallGraph cg = new TestCallGraph();
+    Edge e = new Edge(srcMethod, invokeStmt, tgtMethod);
+    cg.addEdge(e);
+    boolean removedEdges = cg.removeEdges(List.of(e));
+    assertTrue(removedEdges);
+    assertEquals(0, cg.size());
+    cg.assertMapsEmpty();
+  }
+
+  @Test
+  public void testAddRemoveAllEdgesOutOf() {
+    TestCallGraph cg = new TestCallGraph();
+    Edge e = new Edge(srcMethod, invokeStmt, tgtMethod);
+    cg.addEdge(e);
+    boolean removedEdges = cg.removeAllEdgesOutOf(invokeStmt);
+    assertTrue(removedEdges);
+    assertEquals(0, cg.size());
+    cg.assertMapsEmpty();
+    assertFalse(cg.edgesOutOf(invokeStmt).hasNext());
+  }
+
+}


### PR DESCRIPTION
First commit: Fix edge removal in the CallGraph class  
  
If CallGraph.removeAllEdgesOutOf or CallGraph.removeEdges is called,  
the corresponding edge(s) is not entirely removed from the CallGraph  
data structures.  
  
- removeAllEdgesOutOf(Unit u):  
  The to be removed edges are not removed from the call graph data structures.  
  For each to be removed edge e, the code first calls e.remove(), which sets  
  the Edge.invalid attribute to true. Afterwards, removeEdge(e, false) is  
  calledonly executed. The edge removal code in removeEdge(...) is only  
  executed, if the edge e is contained in the edges set. Since Edge.invalid  
  was set to true, e.hashCode() returns the constant value 0. Since the return  
  value of e.hashCode() was different before Edge.invalid was set to true, the  
  edge cannot be found in the edges set. Hence, no edge removal code is  
  executed.  
  In order to fix this, do not call e.remove() before calling removeEdge(...).  
  Moreoever, the call to e.remove() is not needed because it is already called  
  in removeEdge(...).  
  
- removeEdges(Collection<Edge> edges):  
  First, this.edges.removeAll(edges) is executed and afterwards, for each  
  edge e in the passed edges collection, removeEdge(e, false) is executed.  
  Since the edge is not contained anymore in the this.edges set, no edge  
  removal code in removeEdge(...) is executed.  
  In order to fix this, do not call this.edges.removeAll(edges).  
  
The expected behavior is documented in the CallGraphTest test case.  
  
  
Second commit: Improve the runtime of CallGraph.removeAllEdgesOutOf a bit  
  
Instead of iterating over all callgraph edges to find all edges that  
originate from a specific unit, simply call edgesOutOf(...) (which  
internally uses a LinkedHashMap for the initial lookup).  
This seems to cause a noticeable speedup in UnreachableCodeEliminator.