### PR TITLE
.NET: Fix out-of-bounds error in CIL callvirt instructions

### DIFF
--- a/src/main/java/soot/dotnet/instructions/CilCallInstruction.java
+++ b/src/main/java/soot/dotnet/instructions/CilCallInstruction.java
@@ -210,10 +210,10 @@ public class CilCallInstruction extends AbstractCilnstruction {
         CilInstruction inst = CilInstructionFactory.fromInstructionMsg(arg, dotnetBody, cilBlock);
         Value argValue = inst.jimplifyExpr(jb);
         if (arg.getOpCode() == IlOpCode.LDFLDA || arg.getOpCode() == IlOpCode.LDSFLDA) {
-          //by reference a field
-          if (!ByReferenceWrapperGenerator.needsWrapper(instruction.getMethod().getParameterList().get(z))) {
+          // by reference a field
+          if (!ByReferenceWrapperGenerator.needsWrapper(instruction.getMethod().getParameterList().get(z - startIdx))) {
             throw new IllegalStateException(
-                "We load an address of a field, but apparently this is not a by-reference paramter?");
+                "We load an address of a field, but apparently this is not a by-reference parameter?");
           }
           if (!(argValue instanceof FieldRef)) {
             throw new IllegalStateException("Expected a field reference");


### PR DESCRIPTION
Soot throws an out-of-bounds exception when the last parameter of a virtual method call is a reference since the argument and parameter counts don't match. Subtracting the offset `startIdx` when accessing the parameter resolves the problem.

---

The following instruction is an instance that triggers the problem:

```
op_code: CALLVIRT
method {
  accessibility: PUBLIC
  name: "TryGetValue"
  has_body: true
  parameter {
    type {
      fullname: "System.String"
      namespace: "System"
      type_kind: CLASS
    }
    parameter_name: "key"
  }
  parameter {
    type {
      fullname: "System.Object"
      namespace: "System"
      type_kind: BY_REF
    }
    parameter_name: "value"
    is_out: true
  }
  return_type {
    accessibility: PUBLIC
    fullname: "System.Boolean"
    namespace: "System"
    is_read_only: true
    is_sealed: true
    type_kind: STRUCT
    pe_token: 33554615
  }
  full_name: "Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary.TryGetValue"
  declaring_type {
    accessibility: PUBLIC
    fullname: "Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary"
    namespace: "Microsoft.AspNetCore.Mvc.ViewFeatures"
    type_kind: CLASS
    pe_token: 33554585
  }
  pe_token: 100664525
}
arguments {
  op_code: CALL
  method {
    accessibility: PUBLIC
    name: "get_ViewData"
    has_body: true
    is_accessor: true
    return_type {
      fullname: "Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary`1"
      namespace: "Microsoft.AspNetCore.Mvc.ViewFeatures"
      type_kind: CLASS
      generic_type_arguments {
        fullname: "System.Object"
      }
    }
    full_name: "Microsoft.AspNetCore.Mvc.Razor.RazorPage.get_ViewData"
    declaring_type {
      fullname: "Microsoft.AspNetCore.Mvc.Razor.RazorPage`1"
      namespace: "Microsoft.AspNetCore.Mvc.Razor"
      type_kind: CLASS
      generic_type_arguments {
        accessibility: PUBLIC
        fullname: "System.Object"
        namespace: "System"
        type_kind: CLASS
        pe_token: 33554530
      }
    }
    pe_token: 100663452
  }
  arguments {
    op_code: LDOBJ
    target {
      op_code: LDFLDA
      target {
        op_code: LDLOC
        variable {
          type {
            accessibility: PRIVATE
            fullname: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout$<ExecuteAsync>d__8"
            namespace: "AspNetCoreGeneratedDocument"
            is_sealed: true
            declaring_outer_class: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout"
            type_kind: CLASS
            pe_token: 33554720
          }
          name: "this"
          has_initial_value: true
          variable_kind: PARAMETER
        }
      }
      field {
        accessibility: PUBLIC
        type {
          accessibility: INTERNAL
          fullname: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout"
          namespace: "AspNetCoreGeneratedDocument"
          is_sealed: true
          type_kind: CLASS
          pe_token: 33554488
        }
        name: "<>4__this"
        full_name: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout.<ExecuteAsync>d__8.<>4__this"
        declaring_type {
          accessibility: PRIVATE
          fullname: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout$<ExecuteAsync>d__8"
          namespace: "AspNetCoreGeneratedDocument"
          is_sealed: true
          declaring_outer_class: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout"
          type_kind: CLASS
          pe_token: 33554720
        }
        type_kind: CLASS
        pe_token: 67110700
      }
    }
    type {
      accessibility: INTERNAL
      fullname: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout"
      namespace: "AspNetCoreGeneratedDocument"
      is_sealed: true
      type_kind: CLASS
      pe_token: 33554488
    }
  }
}
arguments {
  op_code: LDSTR
  value_constant_string: "ParentLayout"
}
arguments {
  op_code: LDFLDA
  target {
    op_code: LDLOC
    variable {
      type {
        accessibility: PRIVATE
        fullname: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout$<ExecuteAsync>d__8"
        namespace: "AspNetCoreGeneratedDocument"
        is_sealed: true
        declaring_outer_class: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout"
        type_kind: CLASS
        pe_token: 33554720
      }
      name: "this"
      has_initial_value: true
      variable_kind: PARAMETER
    }
  }
  field {
    accessibility: PRIVATE
    type {
      accessibility: PUBLIC
      fullname: "System.Object"
      namespace: "System"
      type_kind: CLASS
      pe_token: 33554530
    }
    name: "<parentLayout>5__1"
    full_name: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout.<ExecuteAsync>d__8.<parentLayout>5__1"
    declaring_type {
      accessibility: PRIVATE
      fullname: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout$<ExecuteAsync>d__8"
      namespace: "AspNetCoreGeneratedDocument"
      is_sealed: true
      declaring_outer_class: "AspNetCoreGeneratedDocument.Areas_Identity_Pages_Account_Manage__Layout"
      type_kind: CLASS
      pe_token: 33554720
    }
    type_kind: CLASS
    pe_token: 67110701
  }
}
``` 