### PR TITLE
FastTyping: Prune LCAS types greedy

### DIFF
--- a/doc/soot_options.html
+++ b/doc/soot_options.html
@@ -1362,6 +1362,20 @@
                
             </p>
          </li>
+         <li><b>Use precise typing</b>
+            (use-precise-typing)
+            <br>
+            (default value:
+            <span class="value">false</span>
+            )
+            
+            <p>
+               When precise typing is enabled, Soot try to find the global best typing, i.e., 
+               the typing with the least amount of assignments. This might cause Soot 
+               require excessive amounts of computation resources (memory and CPU runtime).
+               
+            </p>
+         </li>
          <li><b>Compare type assigners</b>
             (compare-type-assigners)
             <br>

--- a/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
+++ b/eclipse/ca.mcgill.sable.soot/src/ca/mcgill/sable/soot/ui/PhaseOptionsDialog.java
@@ -84,6 +84,7 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		Composite jbjb_eseChild = jbjb_eseCreate(getPageContainer());
 		Composite jbjb_lsChild = jbjb_lsCreate(getPageContainer());
 		Composite jbjb_silsChild = jbjb_silsCreate(getPageContainer());
+		Composite jbjb_awaChild = jbjb_awaCreate(getPageContainer());
 		Composite jbjb_aChild = jbjb_aCreate(getPageContainer());
 		Composite jbjb_uleChild = jbjb_uleCreate(getPageContainer());
 		Composite jbjb_trChild = jbjb_trCreate(getPageContainer());
@@ -233,6 +234,10 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		addToEnableGroup("jb", "jb.sils", getjbjb_silsenabled_widget(), "enabled");
 		getjbjb_silsenabled_widget().getButton().addSelectionListener(this);
 
+		makeNewEnableGroup("jb", "jb.awa");
+		addToEnableGroup("jb", "jb.awa", getjbjb_awaenabled_widget(), "enabled");
+		getjbjb_awaenabled_widget().getButton().addSelectionListener(this);
+
 		makeNewEnableGroup("jb", "jb.a");
 		addToEnableGroup("jb", "jb.a", getjbjb_aenabled_widget(), "enabled");
 		addToEnableGroup("jb", "jb.a", getjbjb_aonly_stack_locals_widget(), "only-stack-locals");
@@ -246,10 +251,12 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		makeNewEnableGroup("jb", "jb.tr");
 		addToEnableGroup("jb", "jb.tr", getjbjb_trenabled_widget(), "enabled");
 		addToEnableGroup("jb", "jb.tr", getjbjb_truse_older_type_assigner_widget(), "use-older-type-assigner");
+		addToEnableGroup("jb", "jb.tr", getjbjb_truse_precise_typing_widget(), "use-precise-typing");
 		addToEnableGroup("jb", "jb.tr", getjbjb_trcompare_type_assigners_widget(), "compare-type-assigners");
 		addToEnableGroup("jb", "jb.tr", getjbjb_trignore_nullpointer_dereferences_widget(), "ignore-nullpointer-dereferences");
 		getjbjb_trenabled_widget().getButton().addSelectionListener(this);
 		getjbjb_truse_older_type_assigner_widget().getButton().addSelectionListener(this);
+		getjbjb_truse_precise_typing_widget().getButton().addSelectionListener(this);
 		getjbjb_trcompare_type_assigners_widget().getButton().addSelectionListener(this);
 		getjbjb_trignore_nullpointer_dereferences_widget().getButton().addSelectionListener(this);
 
@@ -967,7 +974,7 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 			getConfig().put(getInput_Optionsignore_classpath_errors_widget().getAlias(), new Boolean(boolRes));
 		}
 		boolRes = getInput_Optionsprocess_multiple_dex_widget().getButton().getSelection();
-		defBoolRes = false;
+		defBoolRes = true;
 
 		if (boolRes != defBoolRes) {
 			getConfig().put(getInput_Optionsprocess_multiple_dex_widget().getAlias(), new Boolean(boolRes));
@@ -1337,6 +1344,12 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		if (boolRes != defBoolRes) {
 			getConfig().put(getjbjb_silsenabled_widget().getAlias(), new Boolean(boolRes));
 		}
+		boolRes = getjbjb_awaenabled_widget().getButton().getSelection();
+		defBoolRes = true;
+
+		if (boolRes != defBoolRes) {
+			getConfig().put(getjbjb_awaenabled_widget().getAlias(), new Boolean(boolRes));
+		}
 		boolRes = getjbjb_aenabled_widget().getButton().getSelection();
 		defBoolRes = true;
 
@@ -1366,6 +1379,12 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 
 		if (boolRes != defBoolRes) {
 			getConfig().put(getjbjb_truse_older_type_assigner_widget().getAlias(), new Boolean(boolRes));
+		}
+		boolRes = getjbjb_truse_precise_typing_widget().getButton().getSelection();
+		defBoolRes = false;
+
+		if (boolRes != defBoolRes) {
+			getConfig().put(getjbjb_truse_precise_typing_widget().getAlias(), new Boolean(boolRes));
 		}
 		boolRes = getjbjb_trcompare_type_assigners_widget().getButton().getSelection();
 		defBoolRes = false;
@@ -3083,6 +3102,16 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 
 			
 			subSectParent = jb_jb_sils_branch;
+			
+			
+			SootOption jb_jb_awa_branch = new SootOption("Array Writer Aggregregator", "jbjb_awa");
+			subParent.addChild(jb_jb_awa_branch);
+
+
+			
+
+			
+			subSectParent = jb_jb_awa_branch;
 			
 			
 			SootOption jb_jb_a_branch = new SootOption("Jimple Local Aggregator", "jbjb_a");
@@ -4814,6 +4843,16 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		return jbjb_silsenabled_widget;
 	}	
 	
+	private BooleanOptionWidget jbjb_awaenabled_widget;
+	
+	private void setjbjb_awaenabled_widget(BooleanOptionWidget widget) {
+		jbjb_awaenabled_widget = widget;
+	}
+	
+	public BooleanOptionWidget getjbjb_awaenabled_widget() {
+		return jbjb_awaenabled_widget;
+	}	
+	
 	private BooleanOptionWidget jbjb_aenabled_widget;
 	
 	private void setjbjb_aenabled_widget(BooleanOptionWidget widget) {
@@ -4862,6 +4901,16 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 	
 	public BooleanOptionWidget getjbjb_truse_older_type_assigner_widget() {
 		return jbjb_truse_older_type_assigner_widget;
+	}	
+	
+	private BooleanOptionWidget jbjb_truse_precise_typing_widget;
+	
+	private void setjbjb_truse_precise_typing_widget(BooleanOptionWidget widget) {
+		jbjb_truse_precise_typing_widget = widget;
+	}
+	
+	public BooleanOptionWidget getjbjb_truse_precise_typing_widget() {
+		return jbjb_truse_precise_typing_widget;
 	}	
 	
 	private BooleanOptionWidget jbjb_trcompare_type_assigners_widget;
@@ -7910,7 +7959,7 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		if (isInDefList(defKey)) {
 			defaultBool = getBoolDef(defKey);	
 		} else {
-			defaultBool = false;
+			defaultBool = true;
 		}
 
 		setInput_Optionsprocess_multiple_dex_widget(new BooleanOptionWidget(editGroupInput_Options, SWT.NONE, new OptionData("Process all DEX files in APK", "", "","process-multiple-dex", "\nAndroid APKs can have more than one default classes.dex. By \ndefault Soot loads only classes from the default one. This \noption enables loading of all DEX files from an APK.", defaultBool)));
@@ -9056,6 +9105,47 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 
 
 
+	private Composite jbjb_awaCreate(Composite parent) {
+		String defKey;
+		String defaultString;
+		boolean defaultBool = false;
+	    String defaultArray;
+       
+		Group editGroupjbjb_awa = new Group(parent, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		editGroupjbjb_awa.setLayout(layout);
+	
+	 	editGroupjbjb_awa.setText("Array Writer Aggregregator");
+	 	
+		editGroupjbjb_awa.setData("id", "jbjb_awa");
+		
+		String descjbjb_awa = "Reorder array writes to save local variables";	
+		if (descjbjb_awa.length() > 0) {
+			Label descLabeljbjb_awa = new Label(editGroupjbjb_awa, SWT.WRAP);
+			descLabeljbjb_awa.setText(descjbjb_awa);
+		}
+		OptionData [] data;	
+		
+		
+		
+
+		defKey = "p phase-option"+" "+"jb.awa"+" "+"enabled";
+		defKey = defKey.trim();
+
+		if (isInDefList(defKey)) {
+			defaultBool = getBoolDef(defKey);	
+		} else {
+			defaultBool = true;
+		}
+
+		setjbjb_awaenabled_widget(new BooleanOptionWidget(editGroupjbjb_awa, SWT.NONE, new OptionData("Enabled", "p phase-option", "jb.awa","enabled", "\n", defaultBool)));
+
+
+		return editGroupjbjb_awa;
+	}
+
+
+
 	private Composite jbjb_aCreate(Composite parent) {
 		String defKey;
 		String defaultString;
@@ -9194,6 +9284,17 @@ public class PhaseOptionsDialog extends AbstractOptionsDialog implements Selecti
 		}
 
 		setjbjb_truse_older_type_assigner_widget(new BooleanOptionWidget(editGroupjbjb_tr, SWT.NONE, new OptionData("Use older type assigner", "p phase-option", "jb.tr","use-older-type-assigner", "\nThis enables the older type assigner that was in use until May \n2008. The current type assigner is a reimplementation by Ben \nBellamy that uses an entirely new and faster algorithm which \nalways assigns the most narrow type possible. If \ncompare-type-assigners is on, this option causes the older type \nassigner to execute first. (Otherwise the newer one is executed \nfirst.)", defaultBool)));
+
+		defKey = "p phase-option"+" "+"jb.tr"+" "+"use-precise-typing";
+		defKey = defKey.trim();
+
+		if (isInDefList(defKey)) {
+			defaultBool = getBoolDef(defKey);	
+		} else {
+			defaultBool = false;
+		}
+
+		setjbjb_truse_precise_typing_widget(new BooleanOptionWidget(editGroupjbjb_tr, SWT.NONE, new OptionData("Use precise typing", "p phase-option", "jb.tr","use-precise-typing", "\nWhen precise typing is enabled, Soot try to find the global best \ntyping, i.e., the typing with the least amount of assignments. \nThis might cause Soot require excessive amounts of computation \nresources (memory and CPU runtime).", defaultBool)));
 
 		defKey = "p phase-option"+" "+"jb.tr"+" "+"compare-type-assigners";
 		defKey = defKey.trim();

--- a/src/main/generated/options/soot/options/JBTROptions.java
+++ b/src/main/generated/options/soot/options/JBTROptions.java
@@ -60,6 +60,19 @@ public class JBTROptions {
     }
 
     /**
+     * Use precise typing --
+     * Uses a more precise type assigner, which is much slower.
+     *
+     * When precise typing is enabled, Soot try to find the global best 
+     * typing, i.e., the typing with the least amount of assignments. 
+     * This might cause Soot require excessive amounts of computation 
+     * resources (memory and CPU runtime).
+     */
+    public boolean use_precise_typing() {
+        return soot.PhaseOptions.getBoolean(options, "use-precise-typing");
+    }
+
+    /**
      * Compare type assigners --
      * Compares Ben Bellamy's and the older type assigner.
      *

--- a/src/main/generated/options/soot/options/Options.java
+++ b/src/main/generated/options/soot/options/Options.java
@@ -2101,6 +2101,7 @@ public class Options extends OptionsBase {
                     + "\n\nRecognized options (with default values):\n"
                     + padOpt("enabled (true)", "")
                     + padOpt("use-older-type-assigner (false)", "Enables the older type assigner")
+                    + padOpt("use-precise-typing (false)", "Uses a more precise type assigner, which is much slower")
                     + padOpt("compare-type-assigners (false)", "Compares Ben Bellamy's and the older type assigner")
                     + padOpt("ignore-nullpointer-dereferences (false)", "Ignores virtual method calls on base objects that may only be null");
 
@@ -2920,6 +2921,7 @@ public class Options extends OptionsBase {
             return String.join(" ", 
                     "enabled",
                     "use-older-type-assigner",
+                    "use-precise-typing",
                     "compare-type-assigners",
                     "ignore-nullpointer-dereferences"
             );
@@ -3553,6 +3555,7 @@ public class Options extends OptionsBase {
             return ""
                     + "enabled:true "
                     + "use-older-type-assigner:false "
+                    + "use-precise-typing:false "
                     + "compare-type-assigners:false "
                     + "ignore-nullpointer-dereferences:false ";
 

--- a/src/main/java/soot/jimple/toolkits/typing/TypeAssigner.java
+++ b/src/main/java/soot/jimple/toolkits/typing/TypeAssigner.java
@@ -121,12 +121,12 @@ public class TypeAssigner extends BodyTransformer {
     // In a final release this guard, and anything in the first branch, would probably be removed.
     //
     if (opt.compare_type_assigners()) {
-      compareTypeAssigners(jb, opt.use_older_type_assigner());
+      compareTypeAssigners(jb, opt.use_older_type_assigner(), opt);
     } else {
       if (opt.use_older_type_assigner()) {
         soot.jimple.toolkits.typing.TypeResolver.resolve(jb, Scene.v());
       } else {
-        (new soot.jimple.toolkits.typing.fast.TypeResolver(jb)).inferTypes();
+        (new soot.jimple.toolkits.typing.fast.TypeResolver(jb, opt)).inferTypes();
       }
     }
 
@@ -229,7 +229,7 @@ public class TypeAssigner extends BodyTransformer {
 
   }
 
-  private void compareTypeAssigners(JimpleBody jb, boolean useOlderTypeAssigner) {
+  private void compareTypeAssigners(JimpleBody jb, boolean useOlderTypeAssigner, JBTROptions opt) {
     int size = jb.getUnits().size();
     JimpleBody oldJb, newJb;
     long oldTime, newTime;
@@ -237,7 +237,7 @@ public class TypeAssigner extends BodyTransformer {
       // Use old type assigner last
       newJb = (JimpleBody) jb.clone();
       newTime = System.currentTimeMillis();
-      (new soot.jimple.toolkits.typing.fast.TypeResolver(newJb)).inferTypes();
+      (new soot.jimple.toolkits.typing.fast.TypeResolver(newJb, opt)).inferTypes();
       newTime = System.currentTimeMillis() - newTime;
       oldTime = System.currentTimeMillis();
       soot.jimple.toolkits.typing.TypeResolver.resolve(jb, Scene.v());
@@ -250,7 +250,7 @@ public class TypeAssigner extends BodyTransformer {
       soot.jimple.toolkits.typing.TypeResolver.resolve(oldJb, Scene.v());
       oldTime = System.currentTimeMillis() - oldTime;
       newTime = System.currentTimeMillis();
-      (new soot.jimple.toolkits.typing.fast.TypeResolver(jb)).inferTypes();
+      (new soot.jimple.toolkits.typing.fast.TypeResolver(jb, opt)).inferTypes();
       newTime = System.currentTimeMillis() - newTime;
       newJb = jb;
     }

--- a/src/main/java/soot/jimple/toolkits/typing/fast/BytecodeHierarchy.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/BytecodeHierarchy.java
@@ -296,5 +296,10 @@ public class BytecodeHierarchy implements IHierarchy {
       this.next = next;
       this.type = type;
     }
+
+    @Override
+    public String toString() {
+      return "Type: " + type + " Next: " + next;
+    }
   }
 }

--- a/src/main/java/soot/jimple/toolkits/typing/fast/PartialConstantTyping.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/PartialConstantTyping.java
@@ -71,7 +71,7 @@ class PartialConstantTyping implements ITyping {
 
   @Override
   public Map<Local, Type> getMap() {
-    //This is expensive, so we try to avoid it
+    // This is expensive, so we try to avoid it
     final Map<Local, Type> innerMap = inner.getMap();
     Map<Local, Type> m = new HashMap<>(constantTypings.size() + innerMap.size());
     m.putAll(constantTypings);
@@ -86,7 +86,7 @@ class PartialConstantTyping implements ITyping {
   @Override
   public ITyping createCloneTyping() {
     PartialConstantTyping clone = new PartialConstantTyping(inner.createCloneTyping());
-    //we share the constant typings.
+    // we share the constant typings.
     clone.constantTypings = constantTypings;
     return clone;
   }

--- a/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/main/java/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -31,6 +31,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import soot.ArrayType;
 import soot.BooleanType;
@@ -58,6 +60,7 @@ import soot.Type;
 import soot.Unit;
 import soot.UnitPatchingChain;
 import soot.Value;
+import soot.ValueBox;
 import soot.jimple.ArrayRef;
 import soot.jimple.AssignStmt;
 import soot.jimple.BinopExpr;
@@ -75,7 +78,10 @@ import soot.jimple.SpecialInvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.toolkits.typing.Util;
 import soot.jimple.toolkits.typing.fast.UseChecker.UseCheckerCache;
+import soot.options.JBTROptions;
 import soot.toolkits.scalar.LocalDefs;
+import soot.util.HashMultiMap;
+import soot.util.MultiMap;
 
 /**
  * New Type Resolver by Ben Bellamy (see 'Efficient Local Type Inference' at OOPSLA 08).
@@ -90,6 +96,15 @@ import soot.toolkits.scalar.LocalDefs;
  */
 public class TypeResolver {
   private static final int SINGLE_THREAD_LIMIT = 100000;
+  private static final Function<? super Local, ? extends Collection<Unit>> CREATE_NEW_SET
+      = new Function<Local, Collection<Unit>>() {
+
+        @Override
+        public Collection<Unit> apply(Local t) {
+          return new HashSet<>();
+        }
+
+      };
   private static int NUM_CORES = Math.max(1, Runtime.getRuntime().availableProcessors() - 2);
 
   protected final JimpleBody jb;
@@ -100,11 +115,15 @@ public class TypeResolver {
   private BitSet simple;
   private final LocalGenerator localGenerator;
   private final UseCheckerCache useCheckerCache;
+  private final JBTROptions opt;
 
-  public TypeResolver(JimpleBody jb) {
+  private MultiMap<Local, Unit> localToUses;
+
+  public TypeResolver(JimpleBody jb, JBTROptions opt) {
     this.jb = jb;
     this.localGenerator = Scene.v().createLocalGenerator(jb);
     this.useCheckerCache = new UseCheckerCache(jb);
+    this.opt = opt;
 
   }
 
@@ -702,6 +721,8 @@ public class TypeResolver {
         Type told = tg.get(v);
 
         boolean isFirstType = true;
+        if (stmt.getRightOp().toString().equals("$u68"))
+          System.out.println();
         for (Type t_ : ef.eval(tg, stmt.getRightOp(), stmt)) {
           if (lhs instanceof ArrayRef) {
             /*
@@ -736,6 +757,56 @@ public class TypeResolver {
           boolean addFirstDecision = false;
 
           lcas = reduceToAllowedTypesForLocal(lcas, v);
+          if (!opt.use_precise_typing() && lcas.size() > 1) {
+            BitSet dependsV = this.depends.get(v);
+            if (dependsV == null) {
+              if (localToUses == null) {
+                localToUses = new HashMultiMap<>();
+                for (Unit sstmt : this.jb.getUnits()) {
+                  Iterator<ValueBox> it = sstmt.getUseBoxesIterator();
+                  while (it.hasNext()) {
+                    ValueBox vb = it.next();
+                    Value b = vb.getValue();
+                    if (b instanceof Local) {
+                      Local l = (Local) b;
+                      localToUses.put(l, sstmt);
+                    }
+                  }
+                }
+
+              }
+              // no other local is dependent on our local, meaning that we can reduce the lcas set immediately
+              int castCount = Integer.MAX_VALUE;
+              Collection<Type> newLCAS = null;
+              Collection<Unit> uses = localToUses.get(v);
+              if (uses.isEmpty()) {
+                newLCAS = Collections.singletonList(lcas.iterator().next());
+              } else {
+                for (Type t : lcas) {
+                  UseChecker uc = createUseChecker(this.jb);
+                  CastInsertionUseVisitor uv = createCastInsertionUseVisitor(tg, h, true, castCount);
+                  uc.check(tg, uv, uses.iterator());
+                  int g = uv.getCount();
+                  if (g < castCount) {
+                    castCount = g;
+
+                    if (castCount == 0) {
+                      // We can't be better than this
+                      newLCAS = Collections.singletonList(t);
+                      break;
+                    }
+                    newLCAS = new ArrayList<>();
+                    newLCAS.add(t);
+                  } else if (g == castCount && newLCAS != null) {
+                    // tie break
+                    newLCAS.add(t);
+                  }
+                }
+                lcas = newLCAS;
+              }
+            }
+
+          }
           for (Type t : lcas) {
             if (!typesEqual(t, told)) {
               BitSet dependsV = this.depends.get(v);

--- a/src/main/xml/options/soot_options.xml
+++ b/src/main/xml/options/soot_options.xml
@@ -1783,6 +1783,17 @@
                         </long_desc>
                     </boolopt>
                     <boolopt>
+                        <name>Use precise typing</name>
+                        <alias>use-precise-typing</alias>
+                        <default>false</default>
+                        <short_desc>Uses a more precise type assigner, which is much slower</short_desc>
+                        <long_desc>
+                            When precise typing is enabled, Soot try to find the global best typing, i.e., 
+                            the typing with the least amount of assignments. This might cause Soot 
+                            require excessive amounts of computation resources (memory and CPU runtime).
+                        </long_desc>
+                    </boolopt>
+                    <boolopt>
                         <name>Compare type assigners</name>
                         <alias>compare-type-assigners</alias>
                         <default>false</default>


### PR DESCRIPTION
In some cases (https://github.com/soot-oss/soot/issues/2228), a lot of typings are generated for many different variables which may result in an excessive amount of resources being spent on computing the typings. This commit changes the behavior so that the LCAS types are being pruned in a greedy way in some cases, improving the performance of the type assigner greatly.
However, this greedy algorithm might result in a global-suboptimal typing (more casts). Therefore, the commit introduces a new option that allows to disable this behavior.