### PR TITLE
respect `jb.dae` flag in AsmMethodSource

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -2026,7 +2026,9 @@ public class AsmMethodSource implements MethodSource {
     // b = (B) a;
     // return b;
     castAndReturnInliner.transform(jb);
-    DeadAssignmentEliminator.v().transform(jb);
+    if (!"false".equalsIgnoreCase(PhaseOptions.v().getPhaseOptions("jb.dae").get("enabled"))) {
+      DeadAssignmentEliminator.v().transform(jb);
+    }
 
     try {
       PackManager.v().getPack("jb").apply(jb);
@@ -2035,7 +2037,9 @@ public class AsmMethodSource implements MethodSource {
     }
     TrapTightener.removeInvalidTraps(jb);
     LocalPacker.v().transform(jb);
-    DeadAssignmentEliminator.v().transform(jb);
+    if (!"false".equalsIgnoreCase(PhaseOptions.v().getPhaseOptions("jb.dae").get("enabled"))) {
+      DeadAssignmentEliminator.v().transform(jb);
+    }
     UnconditionalBranchFolder.v().transform(jb);
 
     jb.ensureUniqueLocalNames();


### PR DESCRIPTION
currently the DeadAssignmentEliminator runs unconditionally in AsmMethodSource. This is undesirable in certain cases, for example when static analysis tools using soot do not want this optimization (as is the case for a tool I've contributed to recently). The option is already there, so might as well respect it.