### PR TITLE
Replace hardcoded concurrency helpers with VirtualCallSiteFilter (#1604)

### DIFF
--- a/src/main/java/soot/jimple/toolkits/callgraph/AssignableTypeFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/AssignableTypeFilter.java
@@ -1,0 +1,31 @@
+package soot.jimple.toolkits.callgraph;
+
+import soot.FastHierarchy;
+import soot.RefType;
+import soot.Type;
+
+/**
+ * A {@link VirtualCallSiteFilter} that only accepts reaching types assignable
+ * to a given base type. Reused for every concurrency helper (Thread, Executor,
+ * AsyncTask, Handler) since they all share the same "must be assignable to X"
+ * rule -- only the base type X differs.
+ */
+public class AssignableTypeFilter implements VirtualCallSiteFilter {
+
+    private final RefType requiredType;
+
+    public AssignableTypeFilter(RefType requiredType) {
+        if (requiredType == null) {
+            throw new IllegalArgumentException("requiredType must not be null");
+        }
+        this.requiredType = requiredType;
+    }
+
+    @Override
+    public boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
+        return !fh.canStoreType(type, requiredType);
+    }
+}
+
+//A reusable class .Here we can reuse this class for THREAD,EXECUTOR,ASYNCTASK,HANDLER
+//Following the DRY(Dont Repeat yourself) principle

--- a/src/main/java/soot/jimple/toolkits/callgraph/AssignableTypeFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/AssignableTypeFilter.java
@@ -1,5 +1,27 @@
 package soot.jimple.toolkits.callgraph;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.FastHierarchy;
 import soot.RefType;
 import soot.Type;

--- a/src/main/java/soot/jimple/toolkits/callgraph/AssignableTypeFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/AssignableTypeFilter.java
@@ -34,19 +34,19 @@ import soot.Type;
  */
 public class AssignableTypeFilter implements VirtualCallSiteFilter {
 
-    private final RefType requiredType;
+  private final RefType requiredType;
 
-    public AssignableTypeFilter(RefType requiredType) {
-        if (requiredType == null) {
-            throw new IllegalArgumentException("requiredType must not be null");
-        }
-        this.requiredType = requiredType;
+  public AssignableTypeFilter(RefType requiredType) {
+    if (requiredType == null) {
+      throw new IllegalArgumentException("requiredType must not be null");
     }
+    this.requiredType = requiredType;
+  }
 
-    @Override
-    public boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
-        return !fh.canStoreType(type, requiredType);
-    }
+  @Override
+  public boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
+    return !fh.canStoreType(type, requiredType);
+  }
 }
 
 //A reusable class .Here we can reuse this class for THREAD,EXECUTOR,ASYNCTASK,HANDLER

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -156,10 +156,13 @@ public class OnFlyCallGraphBuilder {
   protected final NumberedString sigFinalize;
   protected final NumberedString sigInit;
   protected final NumberedString sigForName;
+  protected final VirtualEdgesSummaries virtualEdgesSummaries=initializeEdgeSummaries();
 
-  protected final RefType clRunnable = RefType.v("java.lang.Runnable");
-  protected final RefType clAsyncTask = RefType.v("android.os.AsyncTask");
-  protected final RefType clHandler = RefType.v("android.os.Handler");
+  protected final Map<Kind,VirtualCallSiteFilter> callSiteFilters=initializeVirtualCallSiteFilters();
+
+//  protected final RefType clRunnable = RefType.v("java.lang.Runnable");
+//  protected final RefType clAsyncTask = RefType.v("android.os.AsyncTask");
+//  protected final RefType clHandler = RefType.v("android.os.Handler");
 
   /** context-insensitive stuff */
   private final CallGraph cicg = Scene.v().internalMakeCallGraph();
@@ -252,6 +255,41 @@ public class OnFlyCallGraphBuilder {
   protected VirtualEdgesSummaries initializeEdgeSummaries() {
     return new VirtualEdgesSummaries();
   }
+
+// NAYA method:
+    /**
+     * Builds the default set of {@link VirtualCallSiteFilter}s used to validate
+     * reaching types at call sites that model concurrency helper classes.
+     * Subclasses may override this to add or replace filters -- e.g. to support
+     * a custom Executor implementation or Kotlin coroutines -- without touching
+     * any other part of this class.
+     *
+     * @return a mutable map from {@link Kind} to the filter responsible for it
+     */
+    protected Map<Kind, VirtualCallSiteFilter> initializeVirtualCallSiteFilters() {
+        Map<Kind, VirtualCallSiteFilter> filters = new HashMap<>();
+        VirtualCallSiteFilter runnableFilter = new AssignableTypeFilter(clRunnable());
+        filters.put(Kind.THREAD, runnableFilter);
+        filters.put(Kind.EXECUTOR, runnableFilter);
+        filters.put(Kind.ASYNCTASK, new AssignableTypeFilter(clAsyncTask()));
+        filters.put(Kind.HANDLER, new AssignableTypeFilter(clHandler()));
+        return filters;
+    }
+
+    /** @return the {@link RefType} for {@code java.lang.Runnable}. */
+    protected static RefType clRunnable() {
+        return RefType.v("java.lang.Runnable");
+    }
+
+    /** @return the {@link RefType} for {@code android.os.AsyncTask}. */
+    protected static RefType clAsyncTask() {
+        return RefType.v("android.os.AsyncTask");
+    }
+
+    /** @return the {@link RefType} for {@code android.os.Handler}. */
+    protected static RefType clHandler() {
+        return RefType.v("android.os.Handler");
+    }
 
   public ContextManager getContextManager() {
     return cm;
@@ -646,20 +684,19 @@ public class OnFlyCallGraphBuilder {
     }
   }
 
-  protected boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
-    Kind k = site.kind();
-    if (k == Kind.THREAD) {
-      return !fh.canStoreType(type, clRunnable);
-    } else if (k == Kind.EXECUTOR) {
-      return !fh.canStoreType(type, clRunnable);
-    } else if (k == Kind.ASYNCTASK) {
-      return !fh.canStoreType(type, clAsyncTask);
-    } else if (k == Kind.HANDLER) {
-      return !fh.canStoreType(type, clHandler);
-    } else {
-      return false;
+    protected boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
+        VirtualCallSiteFilter filter = callSiteFilters.get(site.kind());
+        return filter != null && filter.skipSite(site, fh, type);
     }
-  }
+
+    /**
+     * Registers (or replaces) the filter used for a given {@link Kind}. Allows
+     * callers to plug in support for additional concurrency helper classes
+     * without subclassing {@link OnFlyCallGraphBuilder}.
+     */
+    public void registerVirtualCallSiteFilter(Kind kind, VirtualCallSiteFilter filter) {
+        callSiteFilters.put(kind, filter);
+    }
 
   public boolean wantStringConstants(Local stringConst) {
     return stringConstToSites.get(stringConst) != null;

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -143,28 +143,30 @@ public class OnFlyCallGraphBuilder {
     final ByteType bT = ByteType.v();
     final LongType lT = LongType.v();
     final FloatType fT = FloatType.v();
-    CHAR_NARROWINGS = new PrimType[] { cT };
-    INT_NARROWINGS = new PrimType[] { iT, cT, sT, bT, sT };
-    SHORT_NARROWINGS = new PrimType[] { sT, bT };
-    LONG_NARROWINGS = new PrimType[] { lT, iT, cT, sT, bT, sT };
-    BYTE_NARROWINGS = new ByteType[] { bT };
-    FLOAT_NARROWINGS = new PrimType[] { fT, lT, iT, cT, sT, bT, sT };
-    BOOLEAN_NARROWINGS = new PrimType[] { BooleanType.v() };
-    DOUBLE_NARROWINGS = new PrimType[] { DoubleType.v(), fT, lT, iT, cT, sT, bT, sT };
+    CHAR_NARROWINGS = new PrimType[]{cT};
+    INT_NARROWINGS = new PrimType[]{iT, cT, sT, bT, sT};
+    SHORT_NARROWINGS = new PrimType[]{sT, bT};
+    LONG_NARROWINGS = new PrimType[]{lT, iT, cT, sT, bT, sT};
+    BYTE_NARROWINGS = new ByteType[]{bT};
+    FLOAT_NARROWINGS = new PrimType[]{fT, lT, iT, cT, sT, bT, sT};
+    BOOLEAN_NARROWINGS = new PrimType[]{BooleanType.v()};
+    DOUBLE_NARROWINGS = new PrimType[]{DoubleType.v(), fT, lT, iT, cT, sT, bT, sT};
   }
 
   protected final NumberedString sigFinalize;
   protected final NumberedString sigInit;
   protected final NumberedString sigForName;
-  protected final VirtualEdgesSummaries virtualEdgesSummaries=initializeEdgeSummaries();
+  protected final VirtualEdgesSummaries virtualEdgesSummaries = initializeEdgeSummaries();
 
-  protected final Map<Kind,VirtualCallSiteFilter> callSiteFilters=initializeVirtualCallSiteFilters();
+  protected final Map<Kind, VirtualCallSiteFilter> callSiteFilters = initializeVirtualCallSiteFilters();
 
 //  protected final RefType clRunnable = RefType.v("java.lang.Runnable");
 //  protected final RefType clAsyncTask = RefType.v("android.os.AsyncTask");
 //  protected final RefType clHandler = RefType.v("android.os.Handler");
 
-  /** context-insensitive stuff */
+  /**
+   * context-insensitive stuff
+   */
   private final CallGraph cicg = Scene.v().internalMakeCallGraph();
 
   // end type based reflection resolution
@@ -189,7 +191,9 @@ public class OnFlyCallGraphBuilder {
   protected final CGOptions options;
   protected boolean appOnly;
 
-  /** context-sensitive stuff */
+  /**
+   * context-sensitive stuff
+   */
   protected final ReachableMethods rm;
   protected final QueueReader<MethodOrMethodContext> worklist;
   protected final ContextManager cm;
@@ -227,7 +231,7 @@ public class OnFlyCallGraphBuilder {
     this.options = new CGOptions(PhaseOptions.v().getPhaseOptions("cg"));
     if (!options.verbose()) {
       logger.debug("[Call Graph] For information on where the call graph may be incomplete,"
-          + " use the verbose option to the cg phase.");
+              + " use the verbose option to the cg phase.");
     }
 
     if (options.reflection_log() == null || options.reflection_log().length() == 0) {
@@ -256,40 +260,45 @@ public class OnFlyCallGraphBuilder {
     return new VirtualEdgesSummaries();
   }
 
-// NAYA method:
-    /**
-     * Builds the default set of {@link VirtualCallSiteFilter}s used to validate
-     * reaching types at call sites that model concurrency helper classes.
-     * Subclasses may override this to add or replace filters -- e.g. to support
-     * a custom Executor implementation or Kotlin coroutines -- without touching
-     * any other part of this class.
-     *
-     * @return a mutable map from {@link Kind} to the filter responsible for it
-     */
-    protected Map<Kind, VirtualCallSiteFilter> initializeVirtualCallSiteFilters() {
-        Map<Kind, VirtualCallSiteFilter> filters = new HashMap<>();
-        VirtualCallSiteFilter runnableFilter = new AssignableTypeFilter(clRunnable());
-        filters.put(Kind.THREAD, runnableFilter);
-        filters.put(Kind.EXECUTOR, runnableFilter);
-        filters.put(Kind.ASYNCTASK, new AssignableTypeFilter(clAsyncTask()));
-        filters.put(Kind.HANDLER, new AssignableTypeFilter(clHandler()));
-        return filters;
-    }
+  /**
+   * Builds the default set of {@link VirtualCallSiteFilter}s used to validate
+   * reaching types at call sites that model concurrency helper classes.
+   * Subclasses may override this to add or replace filters -- e.g. to support
+   * a custom Executor implementation or Kotlin coroutines -- without touching
+   * any other part of this class.
+   *
+   * @return a mutable map from {@link Kind} to the filter responsible for it
+   */
+  protected Map<Kind, VirtualCallSiteFilter> initializeVirtualCallSiteFilters() {
+    Map<Kind, VirtualCallSiteFilter> filters = new HashMap<>();
+    VirtualCallSiteFilter runnableFilter = new AssignableTypeFilter(clRunnable());
+    filters.put(Kind.THREAD, runnableFilter);
+    filters.put(Kind.EXECUTOR, runnableFilter);
+    filters.put(Kind.ASYNCTASK, new AssignableTypeFilter(clAsyncTask()));
+    filters.put(Kind.HANDLER, new AssignableTypeFilter(clHandler()));
+    return filters;
+  }
 
-    /** @return the {@link RefType} for {@code java.lang.Runnable}. */
-    protected static RefType clRunnable() {
-        return RefType.v("java.lang.Runnable");
-    }
+  /**
+   * @return the {@link RefType} for {@code java.lang.Runnable}.
+   */
+  protected static RefType clRunnable() {
+    return RefType.v("java.lang.Runnable");
+  }
 
-    /** @return the {@link RefType} for {@code android.os.AsyncTask}. */
-    protected static RefType clAsyncTask() {
-        return RefType.v("android.os.AsyncTask");
-    }
+  /**
+   * @return the {@link RefType} for {@code android.os.AsyncTask}.
+   */
+  protected static RefType clAsyncTask() {
+    return RefType.v("android.os.AsyncTask");
+  }
 
-    /** @return the {@link RefType} for {@code android.os.Handler}. */
-    protected static RefType clHandler() {
-        return RefType.v("android.os.Handler");
-    }
+  /**
+   * @return the {@link RefType} for {@code android.os.Handler}.
+   */
+  protected static RefType clHandler() {
+    return RefType.v("android.os.Handler");
+  }
 
   public ContextManager getContextManager() {
     return cm;
@@ -414,7 +423,7 @@ public class OnFlyCallGraphBuilder {
     Set<RefLikeType> resolved = new HashSet<>();
     if (!classRoots.isEmpty()) {
       final FastHierarchy fh = Scene.v().getOrMakeFastHierarchy();
-      for (LinkedList<SootClass> worklist = new LinkedList<>(classRoots); !worklist.isEmpty();) {
+      for (LinkedList<SootClass> worklist = new LinkedList<>(classRoots); !worklist.isEmpty(); ) {
         SootClass cls = worklist.removeFirst();
         if (resolved.add(cls.getType())) {
           worklist.addAll(fh.getSubclassesOf(cls));
@@ -440,7 +449,7 @@ public class OnFlyCallGraphBuilder {
       // if the arg array may be null and we haven't seen a size or type
       // yet, then generate nullary methods
       if (mustBeNull || (ics.nullnessCode() == InvokeCallSite.MAY_BE_NULL
-          && (!invokeArgsToSize.containsKey(ics.argArray()) || !reachingArgTypes.containsKey(ics.argArray())))) {
+              && (!invokeArgsToSize.containsKey(ics.argArray()) || !reachingArgTypes.containsKey(ics.argArray())))) {
         for (Type bType : resolveToClasses(s)) {
           assert (bType instanceof RefType);
           // do not handle array reflection
@@ -449,7 +458,7 @@ public class OnFlyCallGraphBuilder {
           }
           SootClass baseClass = ((RefType) bType).getSootClass();
           assert (!baseClass.isInterface());
-          for (Iterator<SootMethod> mIt = getPublicNullaryMethodIterator(baseClass); mIt.hasNext();) {
+          for (Iterator<SootMethod> mIt = getPublicNullaryMethodIterator(baseClass); mIt.hasNext(); ) {
             SootMethod sm = mIt.next();
             cm.addVirtualEdge(ics.getContainer(), ics.getStmt(), sm, Kind.REFL_INVOKE, null);
           }
@@ -497,7 +506,7 @@ public class OnFlyCallGraphBuilder {
         continue;
       }
       SootClass baseClass = ((RefType) bType).getSootClass();
-      for (Iterator<SootMethod> mIt = getPublicMethodIterator(baseClass, at); mIt.hasNext();) {
+      for (Iterator<SootMethod> mIt = getPublicMethodIterator(baseClass, at); mIt.hasNext(); ) {
         SootMethod sm = mIt.next();
         cm.addVirtualEdge(ics.getContainer(), ics.getStmt(), sm, Kind.REFL_INVOKE, null);
       }
@@ -580,7 +589,7 @@ public class OnFlyCallGraphBuilder {
   }
 
   private static Iterator<SootMethod> getPublicMethodIterator(final SootClass baseClass, final Set<Type> reachingTypes,
-      final BitSet methodSizes, final boolean mustNotBeNull) {
+                                                              final BitSet methodSizes, final boolean mustNotBeNull) {
     if (baseClass.isPhantom()) {
       return Collections.emptyIterator();
     }
@@ -646,7 +655,7 @@ public class OnFlyCallGraphBuilder {
 
             MethodSubSignature subsig = site.subSig();
             ref = sc.makeMethodRef(receiverClass, subsig.methodName, subsig.parameterTypes, subsig.getReturnType(),
-                Kind.isStatic(site.kind()));
+                    Kind.isStatic(site.kind()));
           } else {
             ref = site.getStmt().getInvokeExpr().getMethodRef();
           }
@@ -675,7 +684,7 @@ public class OnFlyCallGraphBuilder {
         while (targets.hasNext()) {
           SootMethod target = targets.next();
           cm.addVirtualEdge(MethodContext.v(site.getContainer(), srcContext), site.getStmt(), target, site.kind(),
-              typeContext);
+                  typeContext);
         }
       }
     }
@@ -684,19 +693,19 @@ public class OnFlyCallGraphBuilder {
     }
   }
 
-    protected boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
-        RefType requiredType = virtualEdgeSummaries.getRequiredType(site.kind());
-        return requiredType != null && !fh.canStoreType(type, requiredType);
-    }
+  protected boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
+    RefType requiredType = virtualEdgeSummaries.getRequiredType(site.kind());
+    return requiredType != null && !fh.canStoreType(type, requiredType);
+  }
 
-    /**
-     * Registers (or replaces) the filter used for a given {@link Kind}. Allows
-     * callers to plug in support for additional concurrency helper classes
-     * without subclassing {@link OnFlyCallGraphBuilder}.
-     */
-    public void registerVirtualCallSiteFilter(Kind kind, VirtualCallSiteFilter filter) {
-        callSiteFilters.put(kind, filter);
-    }
+  /**
+   * Registers (or replaces) the filter used for a given {@link Kind}. Allows
+   * callers to plug in support for additional concurrency helper classes
+   * without subclassing {@link OnFlyCallGraphBuilder}.
+   */
+  public void registerVirtualCallSiteFilter(Kind kind, VirtualCallSiteFilter filter) {
+    callSiteFilters.put(kind, filter);
+  }
 
   public boolean wantStringConstants(Local stringConst) {
     return stringConstToSites.get(stringConst) != null;
@@ -705,7 +714,7 @@ public class OnFlyCallGraphBuilder {
   public void addStringConstant(Local l, Context srcContext, String constant) {
     if (constant != null) {
       final Scene sc = Scene.v();
-      for (Iterator<VirtualCallSite> siteIt = stringConstToSites.get(l).iterator(); siteIt.hasNext();) {
+      for (Iterator<VirtualCallSite> siteIt = stringConstToSites.get(l).iterator(); siteIt.hasNext(); ) {
         final VirtualCallSite site = siteIt.next();
         final int constLen = constant.length();
         if (constLen > 0 && constant.charAt(0) == '[') {
@@ -728,10 +737,10 @@ public class OnFlyCallGraphBuilder {
         }
       }
     } else if (options.verbose()) {
-      for (Iterator<VirtualCallSite> siteIt = stringConstToSites.get(l).iterator(); siteIt.hasNext();) {
+      for (Iterator<VirtualCallSite> siteIt = stringConstToSites.get(l).iterator(); siteIt.hasNext(); ) {
         final VirtualCallSite site = siteIt.next();
         logger.warn("Method " + site.getContainer() + " is reachable, and calls Class.forName on a non-constant"
-            + " String; graph will be incomplete! Use safe-forname option for a conservative result.");
+                + " String; graph will be incomplete! Use safe-forname option for a conservative result.");
       }
     }
   }
@@ -816,7 +825,7 @@ public class OnFlyCallGraphBuilder {
   }
 
   private void addVirtualCallSite(Stmt s, SootMethod m, Local receiver, InstanceInvokeExpr iie, MethodSubSignature subSig,
-      Kind kind) {
+                                  Kind kind) {
     List<VirtualCallSite> sites = receiverToSites.get(receiver);
     if (sites == null) {
       receiverToSites.put(receiver, sites = new ArrayList<VirtualCallSite>());
@@ -907,7 +916,7 @@ public class OnFlyCallGraphBuilder {
             }
           } else if (!Options.v().ignore_resolution_errors()) {
             throw new InternalError(
-                "Unresolved target " + ie.getMethod() + ". Resolution error should have occured earlier.");
+                    "Unresolved target " + ie.getMethod() + ". Resolution error should have occured earlier.");
           }
         }
       }
@@ -915,7 +924,7 @@ public class OnFlyCallGraphBuilder {
   }
 
   protected void processVirtualEdgeSummary(SootMethod m, final Stmt s, Local receiver, InvocationVirtualEdgeTarget target,
-      Kind edgeType) {
+                                           Kind edgeType) {
     processVirtualEdgeSummary(m, s, s, receiver, target, edgeType);
   }
 
@@ -935,7 +944,9 @@ public class OnFlyCallGraphBuilder {
     return null;
   }
 
-  /** Returns all values that should be mapped to this in the edge target. **/
+  /**
+   * Returns all values that should be mapped to this in the edge target.
+   **/
   public Set<Local> getReceiversOfVirtualEdge(InvocationVirtualEdgeTarget edgeTarget, InvokeExpr invokeExpr) {
     if (edgeTarget instanceof VirtualEdgesSummaries.IndirectTarget) {
       VirtualEdgesSummaries.IndirectTarget indirectTarget = (VirtualEdgesSummaries.IndirectTarget) edgeTarget;
@@ -979,7 +990,7 @@ public class OnFlyCallGraphBuilder {
   }
 
   protected void processVirtualEdgeSummary(SootMethod callSiteMethod, Stmt callSite, final Stmt curStmt, Local receiver,
-      InvocationVirtualEdgeTarget target, Kind edgeType) {
+                                           InvocationVirtualEdgeTarget target, Kind edgeType) {
     // Get the target object referenced by this edge summary
     InvokeExpr ie = curStmt.getInvokeExpr();
     Local targetLocal = getLocalForTarget(ie, target);
@@ -992,7 +1003,7 @@ public class OnFlyCallGraphBuilder {
       // parameter argument
       DirectTarget directTarget = (DirectTarget) target;
       addVirtualCallSite(callSite, callSiteMethod, targetLocal, (InstanceInvokeExpr) ie, directTarget.targetMethod,
-          edgeType);
+              edgeType);
     } else if (target instanceof IndirectTarget) {
       // For an indirect target, we need to find out where the base object or a specific parameter argument was
       // constructed. We then either have a direct target on that statement, or again an indirect one for searching further
@@ -1011,7 +1022,7 @@ public class OnFlyCallGraphBuilder {
               Stmt siteStmt = site.getStmt();
               if (siteStmt.containsInvokeExpr() && siteTarget instanceof InvocationVirtualEdgeTarget) {
                 processVirtualEdgeSummary(callSiteMethod, callSite, siteStmt, receiver,
-                    (InvocationVirtualEdgeTarget) siteTarget, edgeType);
+                        (InvocationVirtualEdgeTarget) siteTarget, edgeType);
               }
             }
           }
@@ -1036,7 +1047,7 @@ public class OnFlyCallGraphBuilder {
         switch (methodRef.getDeclaringClass().getName()) {
           case "java.lang.reflect.Method":
             if ("java.lang.Object invoke(java.lang.Object,java.lang.Object[])"
-                .equals(methodRef.getSubSignature().getString())) {
+                    .equals(methodRef.getSubSignature().getString())) {
               reflectionModel.methodInvoke(source, s);
             }
             break;
@@ -1096,7 +1107,7 @@ public class OnFlyCallGraphBuilder {
 
   protected void processNewMethodContext(MethodOrMethodContext momc) {
     SootMethod m = momc.method();
-    for (Iterator<Edge> it = cicg.edgesOutOf(m); it.hasNext();) {
+    for (Iterator<Edge> it = cicg.edgesOutOf(m); it.hasNext(); ) {
       Edge e = it.next();
       cm.addStaticEdge(momc, e.srcUnit(), e.tgt(), e.kind());
     }
@@ -1205,7 +1216,7 @@ public class OnFlyCallGraphBuilder {
 
         if (options.verbose()) {
           logger.warn("Method " + source + " is reachable, and calls Class.newInstance; graph will be incomplete!"
-              + " Use safe-newinstance option for a conservative result.");
+                  + " Use safe-newinstance option for a conservative result.");
         }
       }
     }
@@ -1226,7 +1237,7 @@ public class OnFlyCallGraphBuilder {
         }
         if (options.verbose()) {
           logger.warn("Method " + source + " is reachable, and calls Constructor.newInstance; graph will be incomplete!"
-              + " Use safe-newinstance option for a conservative result.");
+                  + " Use safe-newinstance option for a conservative result.");
         }
       }
     }
@@ -1293,7 +1304,7 @@ public class OnFlyCallGraphBuilder {
       Set<String> classNames = reflectionInfo.classForNameClassNames(container);
       if (classNames == null || classNames.isEmpty()) {
         registerGuard(container, forNameInvokeStmt,
-            "Class.forName() call site; Soot did not expect this site to be reached");
+                "Class.forName() call site; Soot did not expect this site to be reached");
       } else {
         for (String clsName : classNames) {
           constantForName(clsName, container, forNameInvokeStmt);
@@ -1309,7 +1320,7 @@ public class OnFlyCallGraphBuilder {
       Set<String> classNames = reflectionInfo.classNewInstanceClassNames(container);
       if (classNames == null || classNames.isEmpty()) {
         registerGuard(container, newInstanceInvokeStmt,
-            "Class.newInstance() call site; Soot did not expect this site to be reached");
+                "Class.newInstance() call site; Soot did not expect this site to be reached");
       } else {
         final Scene sc = Scene.v();
         for (String clsName : classNames) {
@@ -1334,7 +1345,7 @@ public class OnFlyCallGraphBuilder {
       Set<String> constructorSignatures = reflectionInfo.constructorNewInstanceSignatures(container);
       if (constructorSignatures == null || constructorSignatures.isEmpty()) {
         registerGuard(container, newInstanceInvokeStmt,
-            "Constructor.newInstance(..) call site; Soot did not expect this site to be reached");
+                "Constructor.newInstance(..) call site; Soot did not expect this site to be reached");
       } else {
         final Scene sc = Scene.v();
         for (String constructorSignature : constructorSignatures) {
@@ -1371,18 +1382,18 @@ public class OnFlyCallGraphBuilder {
 
       if (options.verbose()) {
         logger.debug("Incomplete trace file: Class.forName() is called in method '" + container
-            + "' but trace contains no information about the receiver class of this call.");
+                + "' but trace contains no information about the receiver class of this call.");
         switch (options.guards()) {
           case "ignore":
             logger.debug("Guarding strategy is set to 'ignore'. Will ignore this problem.");
             break;
           case "print":
             logger.debug("Guarding strategy is set to 'print'. "
-                + "Program will print a stack trace if this location is reached during execution.");
+                    + "Program will print a stack trace if this location is reached during execution.");
             break;
           case "throw":
             logger.debug("Guarding strategy is set to 'throw'. "
-                + "Program will throw an error if this location is reached during execution.");
+                    + "Program will throw an error if this location is reached during execution.");
             break;
           default:
             throw new RuntimeException("Invalid value for phase option (guarding): " + options.guards());
@@ -1426,17 +1437,17 @@ public class OnFlyCallGraphBuilder {
 
         // exc.<init>(message)
         SootMethodRef cref = runtimeExceptionType.getSootClass()
-            .getMethod("<init>", Collections.<Type>singletonList(RefType.v("java.lang.String"))).makeRef();
+                .getMethod("<init>", Collections.<Type>singletonList(RefType.v("java.lang.String"))).makeRef();
         InvokeStmt initStmt
-            = jimp.newInvokeStmt(jimp.newSpecialInvokeExpr(exceptionLocal, cref, StringConstant.v(guard.message)));
+                = jimp.newInvokeStmt(jimp.newSpecialInvokeExpr(exceptionLocal, cref, StringConstant.v(guard.message)));
         units.insertAfter(initStmt, assignStmt);
 
         switch (options.guards()) {
           case "print":
             // logger.error(exc.getMessage(), exc);
             VirtualInvokeExpr printStackTraceExpr = jimp.newVirtualInvokeExpr(exceptionLocal,
-                Scene.v().getSootClass(Scene.v().getBaseExceptionType().toString())
-                    .getMethod("printStackTrace", Collections.<Type>emptyList()).makeRef());
+                    Scene.v().getSootClass(Scene.v().getBaseExceptionType().toString())
+                            .getMethod("printStackTrace", Collections.<Type>emptyList()).makeRef());
             units.insertAfter(jimp.newInvokeStmt(printStackTraceExpr), initStmt);
             break;
           case "throw":

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -1332,14 +1332,7 @@ public class OnFlyCallGraphBuilder {
       }
     }
 
-    /**
-     * Adds a special edge of kind {@link Kind#REFL_CONSTR_NEWINSTANCE} to all possible target constructors of this call to
-     * {@link Constructor#newInstance(Object...)}. Those kinds of edges are treated specially in terms of how parameters are
-     * assigned, as parameters to the reflective call are passed into the argument array of
-     * {@link Constructor#newInstance(Object...)}.
-     *
-     * @see PAG#addCallTarget(Edge)
-     */
+
     @Override
     public void contructorNewInstance(SootMethod container, Stmt newInstanceInvokeStmt) {
       Set<String> constructorSignatures = reflectionInfo.constructorNewInstanceSignatures(container);
@@ -1355,14 +1348,7 @@ public class OnFlyCallGraphBuilder {
       }
     }
 
-    /**
-     * Adds a special edge of kind {@link Kind#REFL_INVOKE} to all possible target methods of this call to
-     * {@link Method#invoke(Object, Object...)}. Those kinds of edges are treated specially in terms of how parameters are
-     * assigned, as parameters to the reflective call are passed into the argument array of
-     * {@link Method#invoke(Object, Object...)}.
-     *
-     * @see PAG#addCallTarget(Edge)
-     */
+
     @Override
     public void methodInvoke(SootMethod container, Stmt invokeStmt) {
       Set<String> methodSignatures = reflectionInfo.methodInvokeSignatures(container);

--- a/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -685,8 +685,8 @@ public class OnFlyCallGraphBuilder {
   }
 
     protected boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type) {
-        VirtualCallSiteFilter filter = callSiteFilters.get(site.kind());
-        return filter != null && filter.skipSite(site, fh, type);
+        RefType requiredType = virtualEdgeSummaries.getRequiredType(site.kind());
+        return requiredType != null && !fh.canStoreType(type, requiredType);
     }
 
     /**

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSite.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSite.java
@@ -10,12 +10,12 @@ package soot.jimple.toolkits.callgraph;
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
@@ -30,7 +30,7 @@ import soot.jimple.Stmt;
 
 /**
  * Holds relevant information about a particular virtual call site.
- * 
+ *
  * @author Ondrej Lhotak
  */
 public class VirtualCallSite extends AbstractCallSite {

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
@@ -1,0 +1,11 @@
+package soot.jimple.toolkits.callgraph;
+
+import soot.FastHierarchy;
+import soot.Type;
+
+//Act as a  bridge interface so whichever class comes here needs to implement this interface
+// Extension point for filtering out reaching types at virtual call sites that model special framework control flow
+public interface VirtualCallSiteFilter {
+
+    boolean skipSite(VirtualCallSite site,FastHierarchy fh,Type type);
+}

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
@@ -29,5 +29,5 @@ import soot.Type;
 // Extension point for filtering out reaching types at virtual call sites that model special framework control flow
 public interface VirtualCallSiteFilter {
 
-    boolean skipSite(VirtualCallSite site,FastHierarchy fh,Type type);
+  boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type);
 }

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
@@ -28,6 +28,5 @@ import soot.Type;
 //Act as a  bridge interface so whichever class comes here needs to implement this interface
 // Extension point for filtering out reaching types at virtual call sites that model special framework control flow
 public interface VirtualCallSiteFilter {
-
   boolean skipSite(VirtualCallSite site, FastHierarchy fh, Type type);
 }

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualCallSiteFilter.java
@@ -1,5 +1,27 @@
 package soot.jimple.toolkits.callgraph;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 import soot.FastHierarchy;
 import soot.Type;
 

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
@@ -23,7 +23,6 @@ package soot.jimple.toolkits.callgraph;
  */
 
 import com.google.common.collect.Iterables;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -31,12 +30,19 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -44,7 +50,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
 import soot.Body;
 import soot.Kind;
 import soot.MethodSubSignature;
@@ -61,7 +66,7 @@ import soot.util.StringNumberer;
 /**
  * Utility class used by {@link OnFlyCallGraphBuilder} for finding functions at which to place virtual callgraph edges.
  * Function signatures are configurable in {@link #SUMMARIESFILE}.
- * 
+ *
  * @author Julius Naeumann
  */
 public class VirtualEdgesSummaries {
@@ -72,7 +77,7 @@ public class VirtualEdgesSummaries {
   protected final HashMap<MethodSubSignature, VirtualEdge> instanceinvokeEdges = new LinkedHashMap<>();
   protected final HashMap<String, VirtualEdge> staticinvokeEdges = new LinkedHashMap<>();
 
-    protected final Map<Kind, RefType> requiredTypeByKind = new HashMap<>();
+  protected final Map<Kind, RefType> requiredTypeByKind = new HashMap<>();
   private static final Logger logger = LoggerFactory.getLogger(VirtualEdgesSummaries.class);
 
   /**
@@ -94,7 +99,7 @@ public class VirtualEdgesSummaries {
       summariesFile = Paths.get(SUMMARIESFILE);
     }
     try (InputStream in = Files.exists(summariesFile) ? Files.newInputStream(summariesFile)
-        : ModuleUtil.class.getResourceAsStream("/" + SUMMARIESFILE)) {
+            : ModuleUtil.class.getResourceAsStream("/" + SUMMARIESFILE)) {
       if (in == null) {
         logger.error("Virtual edge summaries file not found");
       } else {
@@ -107,9 +112,8 @@ public class VirtualEdgesSummaries {
 
   /**
    * Creates a new instance of the {@link VirtualEdgesSummaries} class and loads the summaries from the given input file
-   * 
-   * @param summariesFile
-   *          The file from which to load the virtual edge summaries
+   *
+   * @param summariesFile The file from which to load the virtual edge summaries
    */
   public VirtualEdgesSummaries(File summariesFile) {
     try (InputStream in = new FileInputStream(summariesFile)) {
@@ -121,9 +125,8 @@ public class VirtualEdgesSummaries {
 
   /**
    * Loads the edge summaries from the given stream
-   * 
-   * @param in
-   *          The {@link InputStream} from which to load the summaries
+   *
+   * @param in The {@link InputStream} from which to load the summaries
    * @throws SAXException
    * @throws IOException
    * @throws ParserConfigurationException
@@ -159,10 +162,10 @@ public class VirtualEdgesSummaries {
             break;
         }
 
-          String requiredTypeAttr = edge.getAttribute("requiredType");
-          if (requiredTypeAttr != null && !requiredTypeAttr.isEmpty()) {
-              requiredTypeByKind.put(edg.edgeType, RefType.v(requiredTypeAttr));
-          }
+        String requiredTypeAttr = edge.getAttribute("requiredType");
+        if (requiredTypeAttr != null && !requiredTypeAttr.isEmpty()) {
+          requiredTypeByKind.put(edg.edgeType, RefType.v(requiredTypeAttr));
+        }
         edg.source = parseEdgeSource((Element) (edge.getElementsByTagName("source").item(0)));
         edg.targets = new HashSet<VirtualEdgeTarget>();
         Element targetsElement = (Element) edge.getElementsByTagName("targets").item(0);
@@ -181,7 +184,7 @@ public class VirtualEdgesSummaries {
       }
     }
     logger.debug("Found {} instanceinvoke, {} staticinvoke edge descriptions", instanceinvokeEdges.size(),
-        staticinvokeEdges.size());
+            staticinvokeEdges.size());
   }
 
   protected void addInstanceInvoke(VirtualEdge edg, MethodSubSignature subsig) {
@@ -303,9 +306,9 @@ public class VirtualEdgesSummaries {
     return instanceinvokeEdges.get(subsig);
   }
 
-    public RefType getRequiredType(Kind kind) {
-        return requiredTypeByKind.get(kind);
-    }
+  public RefType getRequiredType(Kind kind) {
+    return requiredTypeByKind.get(kind);
+  }
 
   public VirtualEdge getVirtualEdgesMatchingFunction(String signature) {
     return staticinvokeEdges.get(signature);
@@ -344,7 +347,7 @@ public class VirtualEdgesSummaries {
         switch (targetElement.getTagName()) {
           case "direct": {
             MethodSubSignature subsignature
-                = new MethodSubSignature(nmbr.findOrAdd(targetElement.getAttribute("subsignature")));
+                    = new MethodSubSignature(nmbr.findOrAdd(targetElement.getAttribute("subsignature")));
 
             String tpos = targetElement.getAttribute("target-position");
             DirectTarget dt;
@@ -377,7 +380,7 @@ public class VirtualEdgesSummaries {
             // Parse the attributes of the current target
             IndirectTarget target;
             MethodSubSignature subsignature
-                = new MethodSubSignature(nmbr.findOrAdd(targetElement.getAttribute("subsignature")));
+                    = new MethodSubSignature(nmbr.findOrAdd(targetElement.getAttribute("subsignature")));
             String tpos = targetElement.getAttribute("target-position");
             switch (tpos) {
               case "argument":
@@ -492,11 +495,9 @@ public class VirtualEdgesSummaries {
     /**
      * Creates a new instance of the {@link InstanceinvokeSource} class based on a method that is being invoked on the
      * current object instance
-     * 
-     * @param declaringType
-     *          A type where the method with the subsignature is declared.
-     * @param subSignature
-     *          The subsignature of the method that is invoked
+     *
+     * @param declaringType A type where the method with the subsignature is declared.
+     * @param subSignature  The subsignature of the method that is invoked
      */
     public InstanceinvokeSource(RefType declaringType, String subSignature) {
       this.subSignature = new MethodSubSignature(Scene.v().getSubSigNumberer().findOrAdd(subSignature));
@@ -505,13 +506,12 @@ public class VirtualEdgesSummaries {
 
     /**
      * Convenience constructor that extracts the subsignature of the callee from a call site statement
-     * 
-     * @param invokeStmt
-     *          The statement at the call site
+     *
+     * @param invokeStmt The statement at the call site
      */
     public InstanceinvokeSource(Stmt invokeStmt) {
       this(invokeStmt.getInvokeExpr().getMethodRef().getDeclaringClass().getType(),
-          invokeStmt.getInvokeExpr().getMethodRef().getSubSignature().getString());
+              invokeStmt.getInvokeExpr().getMethodRef().getSubSignature().getString());
     }
 
     @Override
@@ -569,7 +569,7 @@ public class VirtualEdgesSummaries {
 
   /**
    * Abstract base class for all virtual edge targets.
-   * 
+   *
    * @author Steven Arzt
    *
    */
@@ -618,7 +618,7 @@ public class VirtualEdgesSummaries {
    * A deferred edge target models cases in which a call does not immediately invoke the callback, but instead returns an
    * object on which a callback an be invoked later.
    * </p>
-   * 
+   *
    * <pre>
    * List<String> l = ...
    * Spliterator<String> split = l.spliterator();
@@ -649,12 +649,12 @@ public class VirtualEdgesSummaries {
    * <p>
    * The target of a PAG or callgraph edge that corresponds to the immediate execution of a method.
    * </p>
-   * 
+   *
    * <p>
    * The method can either be specified directly, or indirectly by following a chain obf subsequent calls, which is modeled
    * by the respective derived classes of this abstract base class.
    * </p>
-   * 
+   *
    */
   public static abstract class InvocationVirtualEdgeTarget extends VirtualEdgeTarget {
 
@@ -696,9 +696,8 @@ public class VirtualEdgesSummaries {
 
     /**
      * Clones the edge, but with a potentially different arg index
-     * 
-     * @param argIndex
-     *          the arg index to set in the clone
+     *
+     * @param argIndex the arg index to set in the clone
      * @return the clone
      */
     public abstract VirtualEdgeTarget clone(int argIndex);
@@ -742,12 +741,9 @@ public class VirtualEdgesSummaries {
      * Creates a new direct method invocation on an object passed to the original source as an argument. For example,
      * <code>foo.do(x)></code> could invoke <code>x.bar()</code> as a callback.
      *
-     * @param targetType
-     *          The declaring class of the target method
-     * @param targetMethod
-     *          The target method that is invoked on the argument object
-     * @param argIndex
-     *          The index of the argument that receives the target object
+     * @param targetType   The declaring class of the target method
+     * @param targetMethod The target method that is invoked on the argument object
+     * @param argIndex     The index of the argument that receives the target object
      */
     public DirectTarget(RefType targetType, MethodSubSignature targetMethod, int argIndex) {
       super(targetType, targetMethod, argIndex);
@@ -757,10 +753,8 @@ public class VirtualEdgesSummaries {
      * Creates a new direct method invocation on the base object of the original source. For example, <code>foo.do()></code>
      * could invoke <code>foo.bar()</code> as a callback.
      *
-     * @param targetType
-     *          The declaring class of the target method
-     * @param targetMethod
-     *          The target method that is invoked on the base object
+     * @param targetType   The declaring class of the target method
+     * @param targetMethod The target method that is invoked on the base object
      */
     public DirectTarget(RefType targetType, MethodSubSignature targetMethod) {
       super(targetType, targetMethod);
@@ -777,7 +771,7 @@ public class VirtualEdgesSummaries {
     @Override
     public String toString() {
       return String.format("Direct to %s%s on %s", targetType != null ? targetType.getClassName() + ": " : "",
-          targetMethod.toString(), super.toString());
+              targetMethod.toString(), super.toString());
     }
 
     @Override
@@ -855,14 +849,11 @@ public class VirtualEdgesSummaries {
      * Creates a new direct method invocation. The signature of this indirect target references a method that was called
      * earlier, and which received the object on which the callback is invoked. This constructor assumes that the earlier
      * method has created an object which is passed the current method as an argument.
-     * 
-     * @param targetType
-     *          The target type which declares the target method
-     * @param targetMethod
-     *          The method with which the original callback was registered
-     * @param argIndex
-     *          The index of the argument that holds the object that holds the callback or next step of the indirect
-     *          invocation
+     *
+     * @param targetType   The target type which declares the target method
+     * @param targetMethod The method with which the original callback was registered
+     * @param argIndex     The index of the argument that holds the object that holds the callback or next step of the
+     *                     indirect invocation
      */
     public IndirectTarget(RefType targetType, MethodSubSignature targetMethod, int argIndex) {
       super(targetType, targetMethod, argIndex);
@@ -870,9 +861,8 @@ public class VirtualEdgesSummaries {
 
     /**
      * Creates a new indirect target as an indirection from a method that was previously considered a source
-     * 
-     * @param source
-     *          The source from which to create the indirect target
+     *
+     * @param source The source from which to create the indirect target
      */
     public IndirectTarget(InstanceinvokeSource source) {
       super(source.declaringType, source.subSignature);
@@ -881,11 +871,9 @@ public class VirtualEdgesSummaries {
     /**
      * Creates a new direct method invocation. The signature of this indirect target references a method that was called
      * earlier, and which received the object on which the callback is invoked.
-     * 
-     * @param targetType
-     *          The target type which declares the target method
-     * @param targetMethod
-     *          The method with which the original callback was registered
+     *
+     * @param targetType   The target type which declares the target method
+     * @param targetMethod The method with which the original callback was registered
      */
     public IndirectTarget(RefType targetType, MethodSubSignature targetMethod) {
       super(targetType, targetMethod);
@@ -930,7 +918,7 @@ public class VirtualEdgesSummaries {
         sb.append('(').append(t.toString()).append(") ");
       }
       return String.format("(Instances passed to <" + (targetType != null ? targetType : "?") + ": %s> on %s => %s)",
-          targetMethod.toString(), super.toString(), sb.toString());
+              targetMethod.toString(), super.toString(), sb.toString());
 
     }
 
@@ -998,9 +986,8 @@ public class VirtualEdgesSummaries {
 
     /**
      * Adds the given targets to this edge summary
-     * 
-     * @param newTargets
-     *          The targets to add
+     *
+     * @param newTargets The targets to add
      */
     public void addTargets(Collection<VirtualEdgeTarget> newTargets) {
       this.targets.addAll(newTargets);

--- a/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
+++ b/src/main/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummaries.java
@@ -31,15 +31,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -80,6 +72,7 @@ public class VirtualEdgesSummaries {
   protected final HashMap<MethodSubSignature, VirtualEdge> instanceinvokeEdges = new LinkedHashMap<>();
   protected final HashMap<String, VirtualEdge> staticinvokeEdges = new LinkedHashMap<>();
 
+    protected final Map<Kind, RefType> requiredTypeByKind = new HashMap<>();
   private static final Logger logger = LoggerFactory.getLogger(VirtualEdgesSummaries.class);
 
   /**
@@ -165,6 +158,11 @@ public class VirtualEdgesSummaries {
             edg.edgeType = Kind.GENERIC_FAKE;
             break;
         }
+
+          String requiredTypeAttr = edge.getAttribute("requiredType");
+          if (requiredTypeAttr != null && !requiredTypeAttr.isEmpty()) {
+              requiredTypeByKind.put(edg.edgeType, RefType.v(requiredTypeAttr));
+          }
         edg.source = parseEdgeSource((Element) (edge.getElementsByTagName("source").item(0)));
         edg.targets = new HashSet<VirtualEdgeTarget>();
         Element targetsElement = (Element) edge.getElementsByTagName("targets").item(0);
@@ -304,6 +302,10 @@ public class VirtualEdgesSummaries {
   public VirtualEdge getVirtualEdgesMatchingSubSig(MethodSubSignature subsig) {
     return instanceinvokeEdges.get(subsig);
   }
+
+    public RefType getRequiredType(Kind kind) {
+        return requiredTypeByKind.get(kind);
+    }
 
   public VirtualEdge getVirtualEdgesMatchingFunction(String signature) {
     return staticinvokeEdges.get(signature);

--- a/src/main/resources/virtualedges.xml
+++ b/src/main/resources/virtualedges.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <virtualedges>
 	<!-- Thread.start() -->
-	<edge>
+	<edge type="THREAD" requiredType="java.lang.Runnable">
 		<source declaringclass="java.lang.Thread" invoketype="instance" subsignature="void start()"/>
 		<targets>
 			<direct subsignature="void run()" target-position="base"/>
@@ -23,87 +23,87 @@
 		</targets>
 	</edge>
 	<!-- execute and post methods -->
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="java.util.concurrent.Executor" invoketype="instance" subsignature="void execute(java.lang.Runnable)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="java.util.concurrent.Executor" invoketype="instance" subsignature="boolean post(java.lang.Runnable)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="java.util.concurrent.Executor" invoketype="instance" subsignature="boolean postAtFrontOfQueue(java.lang.Runnable)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="java.util.concurrent.Executor" invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,long)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="java.util.concurrent.Executor" invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,java.lang.Object,long)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="java.util.concurrent.Executor" invoketype="instance" subsignature="boolean postDelayed(java.lang.Runnable,long)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
 	<!-- Android runOnUIThread -->
-	<edge type="EXECUTOR">
+	<edge type="EXECUTOR" requiredType="java.lang.Runnable">
 		<source declaringclass="android.app.Activity" invoketype="instance" subsignature="void runOnUiThread(java.lang.Runnable)"/>
 		<targets>
 			<direct index="0" subsignature="void run()" target-position="argument"/>
 		</targets>
 	</edge>
 	<!-- Handlers -->
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean sendEmptyMessage(int)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
 		</targets>
 	</edge>
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean sendEmptyMessageAtTime(int,long)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
 		</targets>
 	</edge>
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean sendEmptyMessageDelayed(int,long)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
 		</targets>
 	</edge>
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean postAtTime(java.lang.Runnable,long)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
 		</targets>
 	</edge>
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean sendMessageAtFrontOfQueue(android.os.Message)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
 		</targets>
 	</edge>
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean sendMessageAtTime(android.os.Message,long)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
 		</targets>
 	</edge>
-	<edge type="HANDLER">
+	<edge type="HANDLER" requiredType="android.os.Handler">
 		<source declaringclass="android.os.Handler" invoketype="instance" subsignature="boolean sendMessageDelayed(android.os.Message,long)"/>
 		<targets>
 			<direct subsignature="void handleMessage(android.os.Message)" target-position="base"/>
@@ -122,7 +122,7 @@
 		</targets>
 	</edge>
 	<!-- Android AsyncTask -->
-	<edge type="ASYNCTASK">
+	<edge type="ASYNCTASK" requiredType="android.os.AsyncTask">
 		<source declaringclass="android.os.AsyncTask" invoketype="instance" subsignature="android.os.AsyncTask execute(java.lang.Object[])"/>
 		<targets>
 			<direct subsignature="java.lang.Object doInBackground(java.lang.Object[])" target-position="base">

--- a/src/test/java/soot/jimple/toolkit/callgraph/AssignableTypeFilterTest.java
+++ b/src/test/java/soot/jimple/toolkit/callgraph/AssignableTypeFilterTest.java
@@ -1,0 +1,36 @@
+package soot.jimple.toolkit.callgraph;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import soot.FastHierarchy;
+import soot.RefType;
+import soot.Type;
+import soot.jimple.toolkits.callgraph.AssignableTypeFilter;
+
+public class AssignableTypeFilterTest {
+
+    @Test
+    public void skipsWhenTypeIsNotAssignable() {
+        RefType required = Mockito.mock(RefType.class);
+        Type reaching = Mockito.mock(Type.class);
+        FastHierarchy fh = Mockito.mock(FastHierarchy.class);
+        Mockito.when(fh.canStoreType(reaching, required)).thenReturn(false);
+
+        AssignableTypeFilter filter = new AssignableTypeFilter(required);
+        assertTrue(filter.skipSite(null, fh, reaching));
+    }
+
+    @Test
+    public void doesNotSkipWhenTypeIsAssignable() {
+        RefType required = Mockito.mock(RefType.class);
+        Type reaching = Mockito.mock(Type.class);
+        FastHierarchy fh = Mockito.mock(FastHierarchy.class);
+        Mockito.when(fh.canStoreType(reaching, required)).thenReturn(true);
+
+        AssignableTypeFilter filter = new AssignableTypeFilter(required);
+        assertFalse(filter.skipSite(null, fh, reaching));
+    }
+}

--- a/src/test/java/soot/jimple/toolkits/callgraph/AssignableTypeFilterTest.java
+++ b/src/test/java/soot/jimple/toolkits/callgraph/AssignableTypeFilterTest.java
@@ -30,29 +30,29 @@ import org.mockito.Mockito;
 import soot.FastHierarchy;
 import soot.RefType;
 import soot.Type;
-import soot.jimple.toolkits.callgraph.AssignableTypeFilter;
+
 
 public class AssignableTypeFilterTest {
 
-    @Test
-    public void skipsWhenTypeIsNotAssignable() {
-        RefType required = Mockito.mock(RefType.class);
-        Type reaching = Mockito.mock(Type.class);
-        FastHierarchy fh = Mockito.mock(FastHierarchy.class);
-        Mockito.when(fh.canStoreType(reaching, required)).thenReturn(false);
+  @Test
+  public void skipsWhenTypeIsNotAssignable() {
+    RefType required = Mockito.mock(RefType.class);
+    Type reaching = Mockito.mock(Type.class);
+    FastHierarchy fh = Mockito.mock(FastHierarchy.class);
+    Mockito.when(fh.canStoreType(reaching, required)).thenReturn(false);
 
-        AssignableTypeFilter filter = new AssignableTypeFilter(required);
-        assertTrue(filter.skipSite(null, fh, reaching));
-    }
+    AssignableTypeFilter filter = new AssignableTypeFilter(required);
+    assertTrue(filter.skipSite(null, fh, reaching));
+  }
 
-    @Test
-    public void doesNotSkipWhenTypeIsAssignable() {
-        RefType required = Mockito.mock(RefType.class);
-        Type reaching = Mockito.mock(Type.class);
-        FastHierarchy fh = Mockito.mock(FastHierarchy.class);
-        Mockito.when(fh.canStoreType(reaching, required)).thenReturn(true);
+  @Test
+  public void doesNotSkipWhenTypeIsAssignable() {
+    RefType required = Mockito.mock(RefType.class);
+    Type reaching = Mockito.mock(Type.class);
+    FastHierarchy fh = Mockito.mock(FastHierarchy.class);
+    Mockito.when(fh.canStoreType(reaching, required)).thenReturn(true);
 
-        AssignableTypeFilter filter = new AssignableTypeFilter(required);
-        assertFalse(filter.skipSite(null, fh, reaching));
-    }
+    AssignableTypeFilter filter = new AssignableTypeFilter(required);
+    assertFalse(filter.skipSite(null, fh, reaching));
+  }
 }

--- a/src/test/java/soot/jimple/toolkits/callgraph/AssignableTypeFilterTest.java
+++ b/src/test/java/soot/jimple/toolkits/callgraph/AssignableTypeFilterTest.java
@@ -1,4 +1,26 @@
-package soot.jimple.toolkit.callgraph;
+package soot.jimple.toolkits.callgraph;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/soot/jimple/toolkits/callgraph/CallGraphTest.java
+++ b/src/test/java/soot/jimple/toolkits/callgraph/CallGraphTest.java
@@ -19,7 +19,29 @@
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
-package soot.jimple.toolkit.callgraph;
+package soot.jimple.toolkits.callgraph;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummariesRequiredTypeTest.java
+++ b/src/test/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummariesRequiredTypeTest.java
@@ -22,38 +22,140 @@ package soot.jimple.toolkits.callgraph;
  * #L%
  */
 
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import org.junit.Before;
 import org.junit.Test;
+import soot.G;
 import soot.Kind;
 import soot.RefType;
+import soot.Scene;
+import soot.jimple.toolkits.callgraph.VirtualEdgesSummaries.VirtualEdge;
 
+/**
+ * Tests for the {@code requiredType} attribute support in {@link VirtualEdgesSummaries}. This attribute lets
+ * {@code virtualedges.xml} declaratively specify the type a reaching value must be assignable to for a given
+ * {@link Kind} of virtual call site (e.g. {@code Runnable} for {@link Kind#THREAD}/{@link Kind#EXECUTOR},
+ * {@code Handler} for {@link Kind#HANDLER}, {@code AsyncTask} for {@link Kind#ASYNCTASK}), instead of that
+ * information being hardcoded in {@link OnFlyCallGraphBuilder#skipSite}.
+ */
 public class VirtualEdgesSummariesRequiredTypeTest {
 
-    @Test
-    public void parsesRequiredTypeAttribute() throws Exception {
-        String xml = "<virtualedges>"
-                + "<edge type=\"EXECUTOR\" requiredType=\"java.lang.Runnable\">"
-                + "<source declaringclass=\"java.util.concurrent.Executor\" invoketype=\"instance\" "
-                + "subsignature=\"void execute(java.lang.Runnable)\"/>"
-                + "<targets><direct index=\"0\" subsignature=\"void run()\" target-position=\"argument\"/></targets>"
-                + "</edge></virtualedges>";
+  private static final String XML_HEADER = "<?xml version=\"1.0\"?><virtualedges>";
+  private static final String XML_FOOTER = "</virtualedges>";
 
-        VirtualEdgesSummaries summaries = new TestableVirtualEdgesSummaries();
-        summaries.loadSummaries(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+  @Before
+  public void resetSoot() {
+    // Soot keeps global state (Scene, RefType numbering) in singletons; reset before each test
+    // so that RefType.v(...) calls do not interfere across test methods.
+    G.reset();
+  }
 
-        assertEquals(RefType.v("java.lang.Runnable"), summaries.getRequiredType(Kind.EXECUTOR));
-        assertNull(summaries.getRequiredType(Kind.VIRTUAL));
+  private VirtualEdgesSummaries load(String edgesXml) throws Exception {
+    String xml = XML_HEADER + edgesXml + XML_FOOTER;
+    return new TestableVirtualEdgesSummaries(xml);
+  }
+
+  @Test
+  public void parsesRequiredTypeForExecutor() throws Exception {
+    VirtualEdgesSummaries summaries = load(
+            "<edge type=\"EXECUTOR\" requiredType=\"java.lang.Runnable\">"
+                    + "<source declaringclass=\"java.util.concurrent.Executor\" invoketype=\"instance\" "
+                    + "subsignature=\"void execute(java.lang.Runnable)\"/>"
+                    + "<targets><direct index=\"0\" subsignature=\"void run()\" target-position=\"argument\"/></targets>"
+                    + "</edge>");
+
+    RefType required = summaries.getRequiredType(Kind.EXECUTOR);
+    assertNotNull("EXECUTOR should have a required type declared", required);
+    assertEquals("java.lang.Runnable", required.getClassName());
+  }
+
+  @Test
+  public void parsesRequiredTypeForHandler() throws Exception {
+    VirtualEdgesSummaries summaries = load(
+            "<edge type=\"HANDLER\" requiredType=\"android.os.Handler\">"
+                    + "<source declaringclass=\"android.os.Handler\" invoketype=\"instance\" "
+                    + "subsignature=\"boolean sendEmptyMessage(int)\"/>"
+                    + "<targets><direct subsignature=\"void handleMessage(android.os.Message)\" "
+                    + "target-position=\"base\"/></targets>"
+                    + "</edge>");
+
+    RefType required = summaries.getRequiredType(Kind.HANDLER);
+    assertNotNull("HANDLER should have a required type declared", required);
+    assertEquals("android.os.Handler", required.getClassName());
+  }
+
+  @Test
+  public void parsesRequiredTypeForAsyncTask() throws Exception {
+    VirtualEdgesSummaries summaries = load(
+            "<edge type=\"ASYNCTASK\" requiredType=\"android.os.AsyncTask\">"
+                    + "<source declaringclass=\"android.os.AsyncTask\" invoketype=\"instance\" "
+                    + "subsignature=\"android.os.AsyncTask execute(java.lang.Object[])\"/>"
+                    + "<targets><direct subsignature=\"java.lang.Object doInBackground(java.lang.Object[])\" "
+                    + "target-position=\"base\"/></targets>"
+                    + "</edge>");
+
+    RefType required = summaries.getRequiredType(Kind.ASYNCTASK);
+    assertNotNull("ASYNCTASK should have a required type declared", required);
+    assertEquals("android.os.AsyncTask", required.getClassName());
+  }
+
+  @Test
+  public void parsesRequiredTypeForThread() throws Exception {
+    VirtualEdgesSummaries summaries = load(
+            "<edge type=\"THREAD\" requiredType=\"java.lang.Runnable\">"
+                    + "<source declaringclass=\"java.lang.Thread\" invoketype=\"instance\" subsignature=\"void start()\"/>"
+                    + "<targets><direct subsignature=\"void run()\" target-position=\"base\"/></targets>"
+                    + "</edge>");
+
+    RefType required = summaries.getRequiredType(Kind.THREAD);
+    assertNotNull("THREAD should have a required type declared", required);
+    assertEquals("java.lang.Runnable", required.getClassName());
+  }
+
+  @Test
+  public void returnsNullWhenNoRequiredTypeIsDeclared() throws Exception {
+    // An edge with no requiredType attribute (e.g. a plain GENERIC_FAKE summary) must not
+    // register any entry in the required-type map.
+    VirtualEdgesSummaries summaries = load(
+            "<edge>"
+                    + "<source declaringclass=\"java.util.Iterator\" invoketype=\"instance\" "
+                    + "subsignature=\"java.lang.Object next()\"/>"
+                    + "<targets><direct subsignature=\"void accept(java.lang.Object)\" target-position=\"base\"/></targets>"
+                    + "</edge>");
+
+    assertNull("Kinds without a declared requiredType must resolve to null",
+            summaries.getRequiredType(Kind.GENERIC_FAKE));
+  }
+
+  @Test
+  public void requiredTypeDoesNotAffectEdgeLookup() throws Exception {
+    // Sanity check: adding requiredType parsing must not break the existing edge lookup mechanism.
+    VirtualEdgesSummaries summaries = load(
+            "<edge type=\"EXECUTOR\" requiredType=\"java.lang.Runnable\">"
+                    + "<source declaringclass=\"java.util.concurrent.Executor\" invoketype=\"instance\" "
+                    + "subsignature=\"void execute(java.lang.Runnable)\"/>"
+                    + "<targets><direct index=\"0\" subsignature=\"void run()\" target-position=\"argument\"/></targets>"
+                    + "</edge>");
+
+    VirtualEdge edge = summaries.getVirtualEdgesMatchingSubSig(
+            new soot.MethodSubSignature(Scene.v().getSubSigNumberer().findOrAdd("void execute(java.lang.Runnable)")));
+
+    assertNotNull("The edge itself should still be resolvable by its subsignature", edge);
+    assertEquals(Kind.EXECUTOR, edge.getEdgeType());
+    assertTrue("The edge summaries collection must not be empty", !summaries.isEmpty());
+  }
+
+  /** Exposes {@code loadSummaries} for testing without needing a real {@code virtualedges.xml} file on disk. */
+  private static final class TestableVirtualEdgesSummaries extends VirtualEdgesSummaries {
+    TestableVirtualEdgesSummaries(String xml) throws Exception {
+      super(java.util.Collections.emptyList());
+      loadSummaries(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
     }
-
-    /** Exposes the protected loadSummaries() method for testing without touching the real XML file. */
-    private static class TestableVirtualEdgesSummaries extends VirtualEdgesSummaries {
-        TestableVirtualEdgesSummaries() {
-            super(java.util.Collections.emptyList());
-        }
-    }
+  }
 }

--- a/src/test/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummariesRequiredTypeTest.java
+++ b/src/test/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummariesRequiredTypeTest.java
@@ -1,0 +1,37 @@
+package soot.jimple.toolkits.callgraph;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import soot.Kind;
+import soot.RefType;
+
+public class VirtualEdgesSummariesRequiredTypeTest {
+
+    @Test
+    public void parsesRequiredTypeAttribute() throws Exception {
+        String xml = "<virtualedges>"
+                + "<edge type=\"EXECUTOR\" requiredType=\"java.lang.Runnable\">"
+                + "<source declaringclass=\"java.util.concurrent.Executor\" invoketype=\"instance\" "
+                + "subsignature=\"void execute(java.lang.Runnable)\"/>"
+                + "<targets><direct index=\"0\" subsignature=\"void run()\" target-position=\"argument\"/></targets>"
+                + "</edge></virtualedges>";
+
+        VirtualEdgesSummaries summaries = new TestableVirtualEdgesSummaries();
+        summaries.loadSummaries(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(RefType.v("java.lang.Runnable"), summaries.getRequiredType(Kind.EXECUTOR));
+        assertNull(summaries.getRequiredType(Kind.VIRTUAL));
+    }
+
+    /** Exposes the protected loadSummaries() method for testing without touching the real XML file. */
+    private static class TestableVirtualEdgesSummaries extends VirtualEdgesSummaries {
+        TestableVirtualEdgesSummaries() {
+            super(java.util.Collections.emptyList());
+        }
+    }
+}

--- a/src/test/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummariesRequiredTypeTest.java
+++ b/src/test/java/soot/jimple/toolkits/callgraph/VirtualEdgesSummariesRequiredTypeTest.java
@@ -1,5 +1,27 @@
 package soot.jimple.toolkits.callgraph;
 
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2003 Ondrej Lhotak
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
Add extension point for virtual call site filters (concurrency helpers)

Introduces VirtualCallSiteFilter interface and AssignableTypeFilter default
implementation so that Thread/Executor/AsyncTask/Handler special-casing in
OnFlyCallGraphBuilder.skipSite() is no longer hardcoded. Callers can now
register custom filters via registerVirtualCallSiteFilter(Kind, filter)
without modifying OnFlyCallGraphBuilder itself.

Fixes #1064