### PR TITLE
Fix #1002: model JEP 309 dynamic constants as dynamicinvoke of the co…

### DIFF
--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -1121,16 +1121,54 @@ public class AsmMethodSource implements MethodSource {
         v = MethodHandle.v(toSootFieldRef(h), h.getTag());
       }
     } else if (val instanceof ConstantDynamic) {
-      ConstantDynamic cd = (ConstantDynamic) val;
-      if (MethodHandle.isMethodRef(cd.getBootstrapMethod().getTag())) {
-        v = MethodHandle.v(toSootMethodRef(cd.getBootstrapMethod()), cd.getBootstrapMethod().getTag());
-      } else {
-        v = MethodHandle.v(toSootFieldRef(cd.getBootstrapMethod()), cd.getBootstrapMethod().getTag());
-      }
+      // JEP 309: dynamic class-file constants (CONSTANT_Dynamic). Soot does not resolve these
+      // to their computed value. We model them gracefully as a dynamic invocation of their
+      // bootstrap method, which preserves the declared constant type as well as the bootstrap
+      // method and its static arguments, and warn that the value is not resolved.
+      v = toSootDynamicConstant((ConstantDynamic) val);
     } else {
       throw new AssertionError("Unknown constant type: " + val.getClass());
     }
     return v;
+  }
+
+  /**
+   * Models a JEP 309 dynamic class-file constant (CONSTANT_Dynamic). Soot cannot resolve the value that the constant's
+   * bootstrap method would compute at run time, so the constant is represented as a dynamic invocation of its bootstrap
+   * method. The resulting expression carries the constant's declared type, the bootstrap method reference and the static
+   * bootstrap arguments, so that downstream analyses can at least reason about the type and the bootstrap linkage. A
+   * warning is issued because the actual constant value is not resolved.
+   *
+   * @param cd
+   *          the dynamic constant to model
+   * @return a {@link soot.jimple.DynamicInvokeExpr} approximating the dynamic constant
+   */
+  private Value toSootDynamicConstant(ConstantDynamic cd) {
+    logger.warn(
+        "Encountered dynamic class-file constant (JEP 309) '{}' of type '{}' in method {}. "
+            + "Soot does not resolve the computed value and models it as a dynamic invocation of its bootstrap method.",
+        cd.getName(), cd.getDescriptor(), body.getMethod().getSignature());
+
+    Handle bsm = cd.getBootstrapMethod();
+    SootMethodRef bsmMethodRef = toSootMethodRef(bsm);
+
+    int argCount = cd.getBootstrapMethodArgumentCount();
+    List<Value> bsmArgs = new ArrayList<>(argCount);
+    for (int i = 0; i < argCount; i++) {
+      bsmArgs.add(toSootValue(cd.getBootstrapMethodArgument(i)));
+    }
+
+    Type constType = AsmUtil.toJimpleType(cd.getDescriptor(),
+        Optional.fromNullable(this.body.getMethod().getDeclaringClass().moduleName));
+
+    // A dynamic constant takes no dynamic arguments; it resolves to a single value of its declared type. We model it on
+    // the synthetic invokedynamic dummy class, mirroring how genuine invokedynamic call sites are handled.
+    SootClass bclass = Scene.v().getSootClass(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME);
+    SootMethodRef methodRef
+        = Scene.v().makeMethodRef(bclass, cd.getName(), Collections.<Type>emptyList(), constType, true);
+
+    return Jimple.v().newDynamicInvokeExpr(bsmMethodRef, bsmArgs, methodRef, bsm.getTag(),
+        Collections.<Value>emptyList());
   }
 
   private void convertLookupSwitchInsn(LookupSwitchInsnNode insn) {

--- a/src/test/java/soot/asm/ConstantDynamicTest.java
+++ b/src/test/java/soot/asm/ConstantDynamicTest.java
@@ -1,0 +1,193 @@
+package soot.asm;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997 - 2018 Raja Vallée-Rai and others
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ConstantDynamic;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import soot.Body;
+import soot.G;
+import soot.IntType;
+import soot.RefType;
+import soot.Scene;
+import soot.SootMethod;
+import soot.Unit;
+import soot.Value;
+import soot.ValueBox;
+import soot.jimple.IntConstant;
+import soot.jimple.DynamicInvokeExpr;
+import soot.options.Options;
+
+/**
+ * Tests that Soot gracefully handles JEP 309 dynamic class-file constants (CONSTANT_Dynamic). Since {@code javac} does not
+ * emit dynamic constants, the test classes are generated directly with ASM.
+ *
+ * @see <a href="https://github.com/soot-oss/soot/issues/1002">soot-oss/soot#1002</a>
+ */
+public class ConstantDynamicTest {
+
+  private static final String CLASS_NAME = "DynamicConstantHolder";
+  private static final String INTERNAL_NAME = "DynamicConstantHolder";
+
+  /**
+   * Bootstrap method descriptor for a {@code CONSTANT_Dynamic} entry: {@code (Lookup, String, Class) -> Object}.
+   */
+  private static final String BSM_DESC
+      = "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;";
+
+  /**
+   * Generates a class that references two dynamic constants (one of reference type without bootstrap arguments and one of
+   * primitive type with a single static bootstrap argument) and returns the directory the class was written to.
+   */
+  private File generateClassWithDynamicConstants() throws Exception {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V11, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, INTERNAL_NAME, null,
+        "java/lang/Object", null);
+
+    // Bootstrap method: static Object bsm(Lookup, String, Class). Soot never resolves/executes it,
+    // it only needs to be referenceable so the body simply returns null.
+    MethodVisitor bsm = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "bsm", BSM_DESC, null, null);
+    bsm.visitCode();
+    bsm.visitInsn(Opcodes.ACONST_NULL);
+    bsm.visitInsn(Opcodes.ARETURN);
+    bsm.visitMaxs(0, 0);
+    bsm.visitEnd();
+
+    Handle bsmHandle = new Handle(Opcodes.H_INVOKESTATIC, INTERNAL_NAME, "bsm", BSM_DESC, false);
+
+    // String getStringConstant() { return <dynamic String constant>; }
+    ConstantDynamic stringConstant = new ConstantDynamic("stringConstant", "Ljava/lang/String;", bsmHandle);
+    MethodVisitor m1
+        = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "getStringConstant", "()Ljava/lang/String;", null, null);
+    m1.visitCode();
+    m1.visitLdcInsn(stringConstant);
+    m1.visitInsn(Opcodes.ARETURN);
+    m1.visitMaxs(0, 0);
+    m1.visitEnd();
+
+    // int getIntConstant() { return <dynamic int constant with static arg 42>; }
+    ConstantDynamic intConstant
+        = new ConstantDynamic("intConstant", "I", bsmHandle, Integer.valueOf(42));
+    MethodVisitor m2 = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "getIntConstant", "()I", null, null);
+    m2.visitCode();
+    m2.visitLdcInsn(intConstant);
+    m2.visitInsn(Opcodes.IRETURN);
+    m2.visitMaxs(0, 0);
+    m2.visitEnd();
+
+    cw.visitEnd();
+
+    File tempDir = Files.createTempDir();
+    Files.write(cw.toByteArray(), new File(tempDir, "DynamicConstantHolder.class"));
+    return tempDir;
+  }
+
+  private void setupSoot(File classDir) {
+    G.reset();
+    Options.v().set_prepend_classpath(true);
+    Options.v().set_process_dir(Collections.singletonList(classDir.getAbsolutePath()));
+    Options.v().set_src_prec(Options.src_prec_class);
+    Options.v().set_output_format(Options.output_format_none);
+    Options.v().set_allow_phantom_refs(true);
+    Options.v().setPhaseOption("cg", "enabled:false");
+    Scene.v().loadNecessaryClasses();
+  }
+
+  private static DynamicInvokeExpr findDynamicInvoke(Body body) {
+    for (Unit u : body.getUnits()) {
+      for (ValueBox vb : u.getUseBoxes()) {
+        Value v = vb.getValue();
+        if (v instanceof DynamicInvokeExpr) {
+          return (DynamicInvokeExpr) v;
+        }
+      }
+    }
+    return null;
+  }
+
+  @Test
+  public void referenceTypedDynamicConstantIsModelledGracefully() throws Exception {
+    File classDir = generateClassWithDynamicConstants();
+    setupSoot(classDir);
+
+    SootMethod method = Scene.v().getSootClass(CLASS_NAME).getMethodByName("getStringConstant");
+    // Reading the body must not throw: the dynamic constant is handled gracefully.
+    Body body = method.retrieveActiveBody();
+
+    DynamicInvokeExpr indy = findDynamicInvoke(body);
+    assertNotNull("Dynamic constant should be modelled as a dynamic invocation", indy);
+    // The declared type of the constant must be preserved.
+    assertEquals(RefType.v("java.lang.String"), indy.getType());
+    // The bootstrap method of the constant must be retained.
+    assertEquals("bsm", indy.getBootstrapMethodRef().getName());
+    // A dynamic constant carries no dynamic arguments.
+    assertEquals(0, indy.getArgCount());
+  }
+
+  @Test
+  public void primitiveTypedDynamicConstantRetainsBootstrapArguments() throws Exception {
+    File classDir = generateClassWithDynamicConstants();
+    setupSoot(classDir);
+
+    SootMethod method = Scene.v().getSootClass(CLASS_NAME).getMethodByName("getIntConstant");
+    Body body = method.retrieveActiveBody();
+
+    DynamicInvokeExpr indy = findDynamicInvoke(body);
+    assertNotNull("Dynamic constant should be modelled as a dynamic invocation", indy);
+    // The declared primitive type of the constant must be preserved.
+    assertEquals(IntType.v(), indy.getType());
+    // The static bootstrap argument of the constant must be retained.
+    assertEquals(1, indy.getBootstrapArgCount());
+    assertEquals(IntConstant.v(42), indy.getBootstrapArg(0));
+  }
+
+  @Test
+  public void allDynamicConstantsAreConvertibleWithoutError() throws Exception {
+    File classDir = generateClassWithDynamicConstants();
+    setupSoot(classDir);
+
+    boolean sawDynamicInvoke = false;
+    for (Iterator<SootMethod> it = Scene.v().getSootClass(CLASS_NAME).getMethods().iterator(); it.hasNext();) {
+      SootMethod m = it.next();
+      Body body = m.retrieveActiveBody();
+      if (findDynamicInvoke(body) != null) {
+        sawDynamicInvoke = true;
+      }
+    }
+    assertTrue("At least one method should contain a modelled dynamic constant", sawDynamicInvoke);
+  }
+}


### PR DESCRIPTION
Fixes #1002.

JDK 11's JEP 309 introduced `CONSTANT_Dynamic` (loadable dynamic constants).
Previously, when such a constant was loaded via `LDC`, `AsmMethodSource` modeled it
as a `MethodHandle` pointing at the bootstrap method. That is semantically wrong:
the value produced by the `LDC` has the constant's *declared type* (e.g. `int`,
`String`, …), not `MethodHandle`, which yields type-incorrect Jimple.

### Changes
- `toSootValue` now delegates `ConstantDynamic` handling to a new
  `toSootDynamicConstant(...)` which:
  - emits a warning that the computed value is not resolved, and
  - models the constant as a `DynamicInvokeExpr` on the synthetic
    `soot.dummy.InvokeDynamic` class, preserving the constant's declared type,
    its bootstrap method reference, and its (recursively converted) static
    bootstrap arguments.
- Added `ConstantDynamicTest`, which generates class files with ASM containing
  reference-typed (no args) and primitive-typed (with a static arg) dynamic
  constants and asserts they are read without error and modeled with the correct
  type and bootstrap arguments.

### Testing
`mvn -Dtest=ConstantDynamicTest test` → 3/3 passing.