### PR TITLE
Fix #1001: handle JEP 181 nest-based access control (NestHost/NestMem…

### DIFF
--- a/src/main/java/soot/AbstractASMBackend.java
+++ b/src/main/java/soot/AbstractASMBackend.java
@@ -75,6 +75,8 @@ import soot.tagkit.EnclosingMethodTag;
 import soot.tagkit.Host;
 import soot.tagkit.InnerClassAttribute;
 import soot.tagkit.InnerClassTag;
+import soot.tagkit.NestHostTag;
+import soot.tagkit.NestMembersTag;
 import soot.tagkit.OuterClassTag;
 import soot.tagkit.SignatureTag;
 import soot.tagkit.SourceFileTag;
@@ -320,6 +322,10 @@ public abstract class AbstractASMBackend {
       }
     }
 
+    // Retrieve information about the nest host (JEP 181) if present. Per ASM's expected visit order this must be
+    // emitted before the outer class reference.
+    generateNestHostReference();
+
     // Retrieve information about outer class if present
     if (sc.hasOuterClass() || sc.hasTag(EnclosingMethodTag.NAME) || sc.hasTag(OuterClassTag.NAME)) {
       generateOuterClassReference();
@@ -330,6 +336,9 @@ public abstract class AbstractASMBackend {
 
     // Retrieve information about attributes
     generateAttributes();
+
+    // Retrieve information about the nest members (JEP 181) if present.
+    generateNestMemberReferences();
 
     // Retrieve information about inner classes
     generateInnerClassReferences();
@@ -511,6 +520,30 @@ public abstract class AbstractASMBackend {
       String innerName = ASMBackendUtils.slashify(ict.getShortName());
       int access = ict.getAccessFlags();
       cv.visitInnerClass(name, outerClassName, innerName, access);
+    }
+  }
+
+  /**
+   * Emits the {@code NestHost} attribute (JEP 181, Nest-Based Access Control) if the class declares one.
+   */
+  protected void generateNestHostReference() {
+    NestHostTag t = (NestHostTag) sc.getTag(NestHostTag.NAME);
+    if (t != null) {
+      cv.visitNestHost(ASMBackendUtils.slashify(t.getHost()));
+    }
+  }
+
+  /**
+   * Emits the {@code NestMembers} attribute (JEP 181, Nest-Based Access Control) if the class declares any nest members.
+   */
+  protected void generateNestMemberReferences() {
+    NestMembersTag t = (NestMembersTag) sc.getTag(NestMembersTag.NAME);
+    if (t != null) {
+      List<String> sortedMembers = new ArrayList<>(t.getNestMembers());
+      Collections.sort(sortedMembers);
+      for (String member : sortedMembers) {
+        cv.visitNestMember(ASMBackendUtils.slashify(member));
+      }
     }
   }
 

--- a/src/main/java/soot/asm/SootClassBuilder.java
+++ b/src/main/java/soot/asm/SootClassBuilder.java
@@ -57,6 +57,8 @@ import soot.tagkit.FloatConstantValueTag;
 import soot.tagkit.InnerClassTag;
 import soot.tagkit.IntegerConstantValueTag;
 import soot.tagkit.LongConstantValueTag;
+import soot.tagkit.NestHostTag;
+import soot.tagkit.NestMembersTag;
 import soot.tagkit.PermittedSubclassesTag;
 import soot.tagkit.SignatureTag;
 import soot.tagkit.SourceFileTag;
@@ -265,6 +267,19 @@ public class SootClassBuilder extends ClassVisitor {
     PermittedSubclassesTag p
         = (PermittedSubclassesTag) klass.getOrComputeTag(PermittedSubclassesTag.NAME, () -> new PermittedSubclassesTag());
     p.addPermittedSubClass(permittedSubclass);
+  }
+
+  @Override
+  public void visitNestHost(String nestHost) {
+    // JEP 181 (Nest-Based Access Control): record the host of the nest this class belongs to.
+    klass.addTag(new NestHostTag(nestHost));
+  }
+
+  @Override
+  public void visitNestMember(String nestMember) {
+    // JEP 181 (Nest-Based Access Control): record a member of the nest hosted by this class.
+    NestMembersTag t = (NestMembersTag) klass.getOrComputeTag(NestMembersTag.NAME, () -> new NestMembersTag());
+    t.addNestMember(nestMember);
   }
 
   @Override

--- a/src/main/java/soot/tagkit/NestHostTag.java
+++ b/src/main/java/soot/tagkit/NestHostTag.java
@@ -1,0 +1,57 @@
+package soot.tagkit;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2026 Soot contributors
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+/**
+ * Represents the {@code NestHost} class-file attribute introduced by JEP 181 (Nest-Based Access Control). It records the
+ * host of the nest that the annotated class belongs to.
+ */
+public class NestHostTag implements Tag {
+
+  public static final String NAME = "NestHostTag";
+
+  private final String host;
+
+  public NestHostTag(String host) {
+    this.host = host;
+  }
+
+  /**
+   * Returns the internal name of the nest host.
+   * 
+   * @return the nest host
+   */
+  public String getHost() {
+    return this.host;
+  }
+
+  @Override
+  public String toString() {
+    return "Nest host: " + host;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/src/main/java/soot/tagkit/NestMembersTag.java
+++ b/src/main/java/soot/tagkit/NestMembersTag.java
@@ -1,0 +1,68 @@
+package soot.tagkit;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2026 Soot contributors
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Represents the {@code NestMembers} class-file attribute introduced by JEP 181 (Nest-Based Access Control). It records the
+ * classes that are authorized to be members of the nest hosted by the annotated class.
+ */
+public class NestMembersTag implements Tag {
+
+  public static final String NAME = "NestMembersTag";
+
+  private final Set<String> members = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+  /**
+   * Adds a nest member.
+   * 
+   * @param member
+   *          the internal name of the nest member
+   * @return true if the member was added successfully, otherwise false
+   */
+  public boolean addNestMember(String member) {
+    return this.members.add(member);
+  }
+
+  /**
+   * Returns all nest members.
+   * 
+   * @return all nest members
+   */
+  public Set<String> getNestMembers() {
+    return this.members;
+  }
+
+  @Override
+  public String toString() {
+    return "Nest members: " + members;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/src/test/java/soot/asm/NestBasedAccessControlTest.java
+++ b/src/test/java/soot/asm/NestBasedAccessControlTest.java
@@ -1,0 +1,180 @@
+package soot.asm;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2026 Soot contributors
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import soot.G;
+import soot.Scene;
+import soot.SootClass;
+import soot.options.Options;
+import soot.tagkit.NestHostTag;
+import soot.tagkit.NestMembersTag;
+
+/**
+ * Tests that Soot reads and writes the {@code NestHost} and {@code NestMembers} class-file attributes introduced by JEP 181
+ * (Nest-Based Access Control).
+ *
+ * @author Soot contributors
+ */
+public class NestBasedAccessControlTest {
+
+  private File classDir;
+
+  @Before
+  public void setUp() throws IOException {
+    classDir = Files.createTempDir();
+    // Host class declaring two nest members.
+    writeClass("NestHost", generateHostClass());
+    // Member class declaring its nest host.
+    writeClass("NestHost$Member", generateMemberClass());
+  }
+
+  private void writeClass(String internalName, byte[] bytecode) throws IOException {
+    File classFile = new File(classDir, internalName + ".class");
+    Files.write(bytecode, classFile);
+  }
+
+  private byte[] generateHostClass() {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V11, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, "NestHost", null, Type.getInternalName(Object.class),
+        null);
+    cw.visitNestMember("NestHost$Member");
+    cw.visitNestMember("NestHost$Other");
+    cw.visitInnerClass("NestHost$Member", "NestHost", "Member", Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC);
+    cw.visitInnerClass("NestHost$Other", "NestHost", "Other", Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC);
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+
+  private byte[] generateMemberClass() {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V11, Opcodes.ACC_SUPER, "NestHost$Member", null, Type.getInternalName(Object.class), null);
+    cw.visitNestHost("NestHost");
+    cw.visitInnerClass("NestHost$Member", "NestHost", "Member", Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC);
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+
+  private SootClass loadClass(String className) {
+    G.reset();
+    Options.v().set_process_dir(Collections.singletonList(classDir.getAbsolutePath()));
+    Options.v().set_allow_phantom_refs(true);
+    Options.v().set_output_format(Options.output_format_none);
+    Options.v().setPhaseOption("cg", "enabled:false");
+    Scene.v().loadNecessaryClasses();
+    SootClass sc = Scene.v().forceResolve(className, SootClass.BODIES);
+    assertNotNull(sc);
+    return sc;
+  }
+
+  @Test
+  public void nestMembersAttributeIsReadIntoTag() {
+    SootClass host = loadClass("NestHost");
+    NestMembersTag tag = (NestMembersTag) host.getTag(NestMembersTag.NAME);
+    assertNotNull("Expected a NestMembersTag on the nest host class", tag);
+    assertTrue(tag.getNestMembers().contains("NestHost$Member"));
+    assertTrue(tag.getNestMembers().contains("NestHost$Other"));
+    assertEquals(2, tag.getNestMembers().size());
+    // A nest host does not declare a NestHost attribute for itself.
+    assertNull(host.getTag(NestHostTag.NAME));
+  }
+
+  @Test
+  public void nestHostAttributeIsReadIntoTag() {
+    SootClass member = loadClass("NestHost$Member");
+    NestHostTag tag = (NestHostTag) member.getTag(NestHostTag.NAME);
+    assertNotNull("Expected a NestHostTag on the nest member class", tag);
+    assertEquals("NestHost", tag.getHost());
+    // A nest member does not declare NestMembers.
+    assertNull(member.getTag(NestMembersTag.NAME));
+  }
+
+  @Test
+  public void nestAttributesRoundTripThroughBackend() throws IOException {
+    // Load both classes and write them back out through the ASM backend.
+    G.reset();
+    File outDir = Files.createTempDir();
+    Options.v().set_process_dir(Collections.singletonList(classDir.getAbsolutePath()));
+    Options.v().set_allow_phantom_refs(true);
+    Options.v().set_output_dir(outDir.getAbsolutePath());
+    Options.v().set_output_format(Options.output_format_class);
+    Options.v().setPhaseOption("cg", "enabled:false");
+    Scene.v().loadNecessaryClasses();
+    Scene.v().forceResolve("NestHost", SootClass.BODIES);
+    Scene.v().forceResolve("NestHost$Member", SootClass.BODIES);
+    soot.PackManager.v().writeOutput();
+
+    // Re-read the generated host class and verify the NestMembers attribute survived.
+    List<String> writtenMembers = readNestMembers(new File(outDir, "NestHost.class"));
+    assertTrue(writtenMembers.contains("NestHost$Member"));
+    assertTrue(writtenMembers.contains("NestHost$Other"));
+
+    // Re-read the generated member class and verify the NestHost attribute survived.
+    String writtenHost = readNestHost(new File(outDir, "NestHost$Member.class"));
+    assertEquals("NestHost", writtenHost);
+  }
+
+  private List<String> readNestMembers(File classFile) throws IOException {
+    final List<String> members = new ArrayList<>();
+    ClassReader cr = new ClassReader(Files.toByteArray(classFile));
+    cr.accept(new ClassVisitor(Opcodes.ASM9) {
+      @Override
+      public void visitNestMember(String nestMember) {
+        members.add(nestMember);
+      }
+    }, 0);
+    return members;
+  }
+
+  private String readNestHost(File classFile) throws IOException {
+    final String[] host = new String[1];
+    ClassReader cr = new ClassReader(Files.toByteArray(classFile));
+    cr.accept(new ClassVisitor(Opcodes.ASM9) {
+      @Override
+      public void visitNestHost(String nestHost) {
+        host[0] = nestHost;
+      }
+    }, 0);
+    return host[0];
+  }
+}


### PR DESCRIPTION
Updated todo list

Here's a shorter PR description:

---

**Title:** Fix #1001: Handle JEP 181 Nest-Based Access Control

**Description:**

Fixes #1001.

JDK 11's [JEP 181](https://openjdk.org/jeps/181) added the `NestHost` and `NestMembers` class-file attributes. Soot previously dropped them on a read/write round-trip. This PR adds full support, following the existing `PermittedSubclassesTag` (JEP 360) pattern.

**Changes**
- New `NestHostTag` and `NestMembersTag` (`soot.tagkit`).
- Reader (`SootClassBuilder`): `visitNestHost` / `visitNestMember` populate the tags.
- Writer (`AbstractASMBackend`): emits `visitNestHost` / `visitNestMember` in ASM's expected order (members sorted for deterministic output).

**Testing**
- Added `NestBasedAccessControlTest` (3 tests): verifies both attributes are read into tags and survive a round-trip through the ASM backend. All pass; build green.