### PR TITLE
Fix ASM Method source

### DIFF
--- a/src/main/java/soot/LambdaMetaFactory.java
+++ b/src/main/java/soot/LambdaMetaFactory.java
@@ -156,6 +156,7 @@ public class LambdaMetaFactory {
         appendType(finalName, i);
       }
       finalName.append('_').append(bytecodeOffset);
+      finalName.append("$$lambda");
 
       return finalName.toString();
     }

--- a/src/main/java/soot/asm/AsmMethodSource.java
+++ b/src/main/java/soot/asm/AsmMethodSource.java
@@ -262,6 +262,7 @@ import soot.UnknownType;
 import soot.Value;
 import soot.ValueBox;
 import soot.VoidType;
+import soot.asm.Operand.OperandType;
 import soot.dexpler.Util;
 import soot.jimple.AddExpr;
 import soot.jimple.ArrayRef;
@@ -350,7 +351,11 @@ public class AsmMethodSource implements MethodSource {
 
   private Multimap<LabelNode, UnitBox> trapHandlers;
   private JimpleBody body;
-  private Map<AbstractInsnNode, Integer> lineNumberMap;
+  private Map<AbstractInsnNode, LocationMetadata> locationMap;
+
+  private static class LocationMetadata {
+    public int lineNumber = -1, bytecodeOffset = -1;
+  }
 
   public AsmMethodSource(int maxLocals, InsnList insns, List<LocalVariableNode> localVars,
       List<TryCatchBlockNode> tryCatchBlocks, String module) {
@@ -397,8 +402,6 @@ public class AsmMethodSource implements MethodSource {
   private OperandStack operandStack;
 
   private LinkedListMultimap<LabelNode, UnitBox> labels;
-
-  private int bytecodeOffset = -1;
 
   private Local getLocal(int idx) {
     if (idx >= maxLocals) {
@@ -459,14 +462,18 @@ public class AsmMethodSource implements MethodSource {
   }
 
   protected void setUnit(AbstractInsnNode insn, Unit u) {
-    if (lineNumberMap != null) {
-      Integer ln = lineNumberMap.get(insn);
-      if (ln != null && ln >= 0) {
-        setLineNumber(u, ln);
+    if (locationMap != null) {
+      LocationMetadata l = locationMap.get(insn);
+      if (l != null) {
+        int ln = l.lineNumber;
+        if (ln >= 0) {
+          setLineNumber(u, ln);
+        }
+        int bo = l.bytecodeOffset;
+        if (bo >= 0) {
+          setByteCodeOffset(u, bo);
+        }
       }
-    }
-    if (bytecodeOffset != -1) {
-      setByteCodeOffset(u, bytecodeOffset);
     }
 
     insnToStmt.put(insn, u);
@@ -481,7 +488,7 @@ public class AsmMethodSource implements MethodSource {
     } else if (((BytecodeOffsetTag) offsetTag).getBytecodeOffset() != bytecodeOffset) {
       throw new RuntimeException("Bytecode offset tag mismatch");
     }
-    
+
   }
 
   protected void setLineNumber(Unit u, int lineNumber) {
@@ -893,6 +900,7 @@ public class AsmMethodSource implements MethodSource {
     merging.mergeInputs(val);
     ReturnStmt ret = Jimple.v().newReturnStmt(val.toImmediate());
     setUnit(insn, ret);
+    handleStackLeftover();
   }
 
   private void convertInsn(InsnNode insn) {
@@ -933,6 +941,7 @@ public class AsmMethodSource implements MethodSource {
       convertReturnInsn(insn);
     } else if (op == RETURN) {
       if (!insnToStmt.containsKey(insn)) {
+        handleStackLeftover();
         setUnit(insn, Jimple.v().newReturnVoidStmt());
       }
     } else if (op == ATHROW) {
@@ -952,6 +961,27 @@ public class AsmMethodSource implements MethodSource {
       setUnit(insn, ts);
     } else {
       throw new AssertionError("Unknown insn op: " + op);
+    }
+  }
+
+  private void handleStackLeftover() {
+    while (!operandStack.isEmpty()) {
+      Operand leftover = operandStack.peek();
+      if (leftover == null) {
+        break;
+      }
+      OperandType type = leftover.type;
+
+      if (type == OperandType.DOUBLE || type == OperandType.DOUBLE) {
+        operandStack.popDual();
+      } else {
+        operandStack.pop();
+      }
+
+      if (leftover.value instanceof InvokeExpr) {
+        InvokeStmt invokeStmt = Jimple.v().newInvokeStmt(leftover.value);
+        setUnit(leftover.insn, invokeStmt);
+      }
     }
   }
 
@@ -1307,9 +1337,9 @@ public class AsmMethodSource implements MethodSource {
     if (PhaseOptions.getBoolean(PhaseOptions.v().getPhaseOptions("jb"), "model-lambdametafactory")) {
       String bsmMethodRefStr = bsmMethodRef.toString();
       if (bsmMethodRefStr.equals(METAFACTORY_SIGNATURE) || bsmMethodRefStr.equals(ALT_METAFACTORY_SIGNATURE)) {
-        bootstrap_model
-            = LambdaMetaFactory.v().makeLambdaHelper(bsmMethodArgs, insn.bsm.getTag(), insn.name,
-                types, body.getMethod(), bytecodeOffset);
+        int bytecodeOffset = getBytecodeOffset(insn);
+        bootstrap_model = LambdaMetaFactory.v().makeLambdaHelper(bsmMethodArgs, insn.bsm.getTag(), insn.name, types,
+            body.getMethod(), bytecodeOffset);
       }
     }
 
@@ -1356,6 +1386,29 @@ public class AsmMethodSource implements MethodSource {
      * assign all read ops in case the method modifies any of the fields
      */
     addReadOperandAssignments();
+  }
+
+  /**
+   * Searches backwards for the bytecode offset
+   * 
+   * @param insn
+   *          the instruction node
+   * @return the bytecode offset or -1
+   */
+  private int getBytecodeOffset(AbstractInsnNode insn) {
+    if (locationMap == null) {
+      return -1;
+    }
+    LocationMetadata info;
+    AbstractInsnNode i = insn;
+    while (i != null) {
+      info = locationMap.get(i);
+      if (info != null && info.bytecodeOffset > 0) {
+        return info.bytecodeOffset;
+      }
+      i = i.getPrevious();
+    }
+    return -1;
   }
 
   private SootMethodRef toSootMethodRef(Handle methodHandle) {
@@ -1662,6 +1715,9 @@ public class AsmMethodSource implements MethodSource {
     if (Options.v().keep_line_number()) {
       setLineNumberMap();
     }
+    if (Options.v().keep_offset()) {
+      setBytecodeOffsetMap();
+    }
 
     do {
       BranchedInsnInfo edge = worklist.pollLast();
@@ -1742,15 +1798,14 @@ public class AsmMethodSource implements MethodSource {
           case LINE:
             // was already handled in setLineNumberMap()
             continue;
+          case BytecodeOffsetNode.BYTECODE_OFFSET_TYPE:
+            if (insn instanceof BytecodeOffsetNode) {
+              // was already handled in setBytecodeOffsetMap()
+              break;
+            }
           case FRAME:
             // we can ignore it
             continue;
-          case BytecodeOffsetNode.BYTECODE_OFFSET_TYPE:
-            if (insn instanceof BytecodeOffsetNode) {
-              BytecodeOffsetNode bytecodeOffset = (BytecodeOffsetNode) insn;
-              this.bytecodeOffset = bytecodeOffset.bytecodeOffset;
-              break;
-            }
           default:
             throw new RuntimeException("Unknown instruction type: " + type);
         }
@@ -1790,7 +1845,10 @@ public class AsmMethodSource implements MethodSource {
   }
 
   private void setLineNumberMap() {
-    lineNumberMap = new HashMap<>(instructions.size() * 2 + 1);
+    if (locationMap == null) {
+      locationMap = new HashMap<>(instructions.size() * 2 + 1);
+    }
+
     AbstractInsnNode current = instructions.getFirst();
 
     int lastNumber = -1;
@@ -1799,7 +1857,25 @@ public class AsmMethodSource implements MethodSource {
         LineNumberNode ln = (LineNumberNode) current;
         lastNumber = ln.line;
       } else if (lastNumber >= 0) {
-        lineNumberMap.put(current, lastNumber);
+        locationMap.computeIfAbsent(current, (x) -> new LocationMetadata()).lineNumber = lastNumber;
+      }
+      current = current.getNext();
+    }
+  }
+
+  private void setBytecodeOffsetMap() {
+    if (locationMap == null) {
+      locationMap = new HashMap<>(instructions.size() * 2 + 1);
+    }
+    AbstractInsnNode current = instructions.getFirst();
+
+    int lastOffset = -1;
+    while (current != null) {
+      if (current instanceof BytecodeOffsetNode) {
+        BytecodeOffsetNode ln = (BytecodeOffsetNode) current;
+        lastOffset = ln.bytecodeOffset;
+      } else if (lastOffset >= 0) {
+        locationMap.computeIfAbsent(current, (x) -> new LocationMetadata()).bytecodeOffset = lastOffset;
       }
       current = current.getNext();
     }
@@ -2035,7 +2111,7 @@ public class AsmMethodSource implements MethodSource {
     labels = null;
     insnToStmt = null;
     body = null;
-    lineNumberMap = null;
+    locationMap = null;
 
     // We want to have somewhat correct ordering of the locals
     // (the asm backend's code depends on this)

--- a/src/main/java/soot/asm/OperandStack.java
+++ b/src/main/java/soot/asm/OperandStack.java
@@ -106,6 +106,10 @@ public class OperandStack {
   public Operand popStackConstDual() {
     return popDual();
   }
+  
+  public boolean isEmpty() {
+    return stack.isEmpty();
+  }
 
   public List<Operand> getStack() {
     return stack;

--- a/src/main/java/soot/toolkits/exceptions/TrapTightener.java
+++ b/src/main/java/soot/toolkits/exceptions/TrapTightener.java
@@ -184,7 +184,7 @@ public final class TrapTightener extends TrapTransformer {
         changed = true;
       }
     }
-    if (changed) {
+    if (changed && !"false".equalsIgnoreCase(PhaseOptions.v().getPhaseOptions("jb.uce").get("enabled"))) {
       UnreachableCodeEliminator.v().transform(body);
     }
 

--- a/src/systemTest/java/soot/jimple/ASMLineNumberTest.java
+++ b/src/systemTest/java/soot/jimple/ASMLineNumberTest.java
@@ -23,6 +23,7 @@ package soot.jimple;
  */
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteSource;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 
@@ -38,6 +39,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
@@ -83,6 +87,8 @@ import soot.util.backend.ASMBackendUtils;
 public class ASMLineNumberTest extends AbstractTestingFramework {
 
   private static final boolean DEBUG = false;
+
+  final AtomicInteger checkedMethods = new AtomicInteger();
 
   private abstract static class LineNumberStmt {
     public int lineNumber;
@@ -181,8 +187,15 @@ public class ASMLineNumberTest extends AbstractTestingFramework {
         File pck = new File(tmp, packageName);
         pck.mkdirs();
         String n = getSimpleClassName(name);
+        ByteSource bs;
+        try {
+          bs = c.asByteSource();
+        } catch (Exception e) {
+          // ignore
+          continue;
+        }
         try (FileOutputStream fos = new FileOutputStream(new File(pck, n + ".class"))) {
-          c.asByteSource().copyTo(fos);
+          bs.copyTo(fos);
         }
       }
       testLineNumbers(tmp);
@@ -216,9 +229,11 @@ public class ASMLineNumberTest extends AbstractTestingFramework {
 
     Scene.v().loadNecessaryClasses();
     performMatching(classFolder);
+    System.out.println(String.format("ASMLineNumberTest: Checked %d methods", checkedMethods.get()));
   }
 
   private void performMatching(File classFolder) throws IOException, InterruptedException {
+    ThreadPoolExecutor exec = new ThreadPoolExecutor(2, 4, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
     for (SootClass c : new ArrayList<>(Scene.v().getApplicationClasses())) {
       File packageFolder = new File(classFolder, c.getPackageName().replace('.', File.separatorChar));
       File clFile = new File(packageFolder, getSimpleClassName(c.getName()) + ".class");
@@ -263,7 +278,9 @@ public class ASMLineNumberTest extends AbstractTestingFramework {
 
         // Iterate over every method found in the class
         for (MethodNode method : classNode.methods) {
-          analyzeMethod(classNode.name, method);
+          exec.execute(() -> {
+            analyzeMethod(classNode.name, method);
+          });
         }
 
       } catch (IOException e) {
@@ -271,9 +288,11 @@ public class ASMLineNumberTest extends AbstractTestingFramework {
       }
 
     }
+    exec.shutdown();
+    exec.awaitTermination(1, TimeUnit.DAYS);
   }
 
-  private static void analyzeMethod(String className, MethodNode method) {
+  private void analyzeMethod(String className, MethodNode method) {
     SootClass cl = Scene.v().getSootClass(AsmUtil.toQualifiedName(className));
     if (cl.isPhantomClass()) {
       return;
@@ -338,6 +357,7 @@ public class ASMLineNumberTest extends AbstractTestingFramework {
       }
 
     }
+    checkedMethods.incrementAndGet();
   }
 
   public static String methodNodeToString(MethodNode methodNode) {
@@ -368,7 +388,9 @@ public class ASMLineNumberTest extends AbstractTestingFramework {
         }
         return s;
       }
-      rest.append(s.toString()).append("\n");
+      if (DEBUG) {
+        rest.append(s.toString()).append("\n");
+      }
     }
     throw new IllegalArgumentException("Could not find the next statement in " + rest);
   }

--- a/src/systemTest/java/soot/jimple/ASMLineNumberTest.java
+++ b/src/systemTest/java/soot/jimple/ASMLineNumberTest.java
@@ -1,0 +1,376 @@
+package soot.jimple;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2026 Marc Miltenberger
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import org.apache.commons.io.ByteBuffers;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceMethodVisitor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
+import soot.Body;
+import soot.G;
+import soot.Scene;
+import soot.SootClass;
+import soot.SootMethod;
+import soot.SootMethodRef;
+import soot.Type;
+import soot.Unit;
+import soot.UnitPatchingChain;
+import soot.asm.AsmUtil;
+import soot.asm.BytecodeOffsetNode;
+import soot.options.Options;
+import soot.tagkit.BytecodeOffsetTag;
+import soot.tagkit.LineNumberTag;
+import soot.testing.framework.AbstractTestingFramework;
+import soot.util.backend.ASMBackendUtils;
+
+/**
+ * This test checks whether the line number agree with ASM. Note that we currently only check invocation statements since
+ * they are easy to align between ASM and Jimple code.
+ */
+@PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*" })
+public class ASMLineNumberTest extends AbstractTestingFramework {
+
+  private static final boolean DEBUG = false;
+
+  private abstract static class LineNumberStmt {
+    public int lineNumber;
+    public int pc;
+
+    public LineNumberStmt(int lineNumber, int pc) {
+      this.lineNumber = lineNumber;
+      this.pc = pc;
+    }
+
+    public abstract boolean matchesJimpleStmt(Stmt s);
+
+    protected static void appendType(StringBuilder sb, Type p) {
+      sb.append(ASMBackendUtils.toTypeDesc(p));
+    }
+
+    public void assertMatchesJimpleStmt(Stmt stmt) {
+      if (!matchesJimpleStmt(stmt)) {
+        throw new AssertionError(stmt + " does not match " + this.toString());
+      }
+      if (lineNumber == -1) {
+        return;
+      }
+
+      LineNumberTag lt = (LineNumberTag) stmt.getTag(LineNumberTag.NAME);
+      if (lt == null) {
+        throw new AssertionError("No line number");
+      }
+      if (this.lineNumber != lt.getLineNumber()) {
+        throw new AssertionError("Wrong line number");
+      }
+      BytecodeOffsetTag bo = (BytecodeOffsetTag) stmt.getTag(BytecodeOffsetTag.NAME);
+      if (bo == null) {
+        throw new AssertionError("No bytecode offset");
+      }
+      if (this.pc != bo.getBytecodeOffset()) {
+        throw new AssertionError("Wrong bytecode offset");
+      }
+    }
+
+  }
+
+  private static class MethodCallStmt extends LineNumberStmt {
+    private String desc;
+    private String name;
+
+    public MethodCallStmt(int linenumber, int pc, String name, String desc) {
+      super(linenumber, pc);
+      this.name = name;
+      this.desc = desc;
+    }
+
+    @Override
+    public boolean matchesJimpleStmt(Stmt s) {
+      InvokeExpr inv = s.getInvokeExprUnsafe();
+      if (inv == null) {
+        return false;
+      }
+      SootMethodRef mr = inv.getMethodRef();
+      if (!mr.getName().equals(name)) {
+        return false;
+      }
+      StringBuilder sb = new StringBuilder();
+      sb.append("(");
+      for (Type p : mr.getParameterTypes()) {
+        appendType(sb, p);
+      }
+      sb.append(')');
+      appendType(sb, mr.getReturnType());
+      return desc.equals(sb.toString());
+    }
+
+    @Override
+    public String toString() {
+      return "Method call: " + name + " " + desc;
+    }
+
+  }
+
+  @Test
+  public void testLineNumbers() throws Exception {
+    testLineNumbersFromClass(ByteBuffers.class);
+  }
+
+  private void testLineNumbersFromClass(Class<?> clz) throws Exception {
+    ImmutableSet<ClassInfo> classes = ClassPath.from(ClassLoader.getSystemClassLoader()).getAllClasses();
+
+    File tmp = File.createTempFile("tmp", "class");
+    try {
+      tmp.delete();
+      tmp.mkdirs();
+
+      for (ClassInfo c : classes) {
+        String name = c.getName();
+        String packageName = c.getPackageName().replace('.', File.separatorChar);
+        File pck = new File(tmp, packageName);
+        pck.mkdirs();
+        String n = getSimpleClassName(name);
+        try (FileOutputStream fos = new FileOutputStream(new File(pck, n + ".class"))) {
+          c.asByteSource().copyTo(fos);
+        }
+      }
+      testLineNumbers(tmp);
+    } catch (Throwable t) {
+      t.printStackTrace();
+      throw t;
+    } finally {
+      FileUtils.deleteQuietly(tmp);
+    }
+  }
+
+  private static String getSimpleClassName(String name) {
+    String n = name;
+    int idx = n.lastIndexOf('.');
+    if (idx != -1) {
+      n = n.substring(idx + 1);
+    }
+    return n;
+  }
+
+  private void testLineNumbers(File classFolder) throws Exception {
+    G.reset();
+
+    // unreachable code eliminator can make the comparison more difficult since it removes code
+    // this happens often in generated finally blocks.
+    Options.v().setPhaseOption("jb.uce", "enabled:false");
+    Options.v().set_keep_line_number(true);
+    Options.v().set_keep_offset(true);
+    Options.v().set_allow_phantom_refs(true);
+    Options.v().set_process_dir(Arrays.asList(classFolder.getAbsolutePath()));
+
+    Scene.v().loadNecessaryClasses();
+    performMatching(classFolder);
+  }
+
+  private void performMatching(File classFolder) throws IOException, InterruptedException {
+    for (SootClass c : new ArrayList<>(Scene.v().getApplicationClasses())) {
+      File packageFolder = new File(classFolder, c.getPackageName().replace('.', File.separatorChar));
+      File clFile = new File(packageFolder, getSimpleClassName(c.getName()) + ".class");
+      if (!clFile.exists()) {
+        continue;
+      }
+
+      try (InputStream is = new FileInputStream(clFile)) {
+        final AtomicInteger currentOffset = new AtomicInteger();
+        ClassReader reader = new ClassReader(is) {
+          @Override
+          protected void readBytecodeInstructionOffset(int bytecodeOffset) {
+            super.readBytecodeInstructionOffset(bytecodeOffset);
+            currentOffset.set(bytecodeOffset);
+          }
+
+        };
+
+        ClassNode classNode = new ClassNode(Opcodes.ASM9) {
+          @Override
+          public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+              String[] exceptions) {
+            MethodNode method = (MethodNode) super.visitMethod(access, name, descriptor, signature, exceptions);
+            method.instructions = new InsnList() {
+
+              @Override
+              public void add(AbstractInsnNode insnNode) {
+                int offset = currentOffset.get();
+                super.add(new BytecodeOffsetNode(offset));
+                super.add(insnNode);
+              }
+            };
+            return method;
+          }
+        };
+
+        // Read the class layout into the Tree representation
+        reader.accept(classNode, ClassReader.SKIP_FRAMES);
+        if (!classNode.name.equals(c.getName().replace('.', '/'))) {
+          continue;
+        }
+
+        // Iterate over every method found in the class
+        for (MethodNode method : classNode.methods) {
+          analyzeMethod(classNode.name, method);
+        }
+
+      } catch (IOException e) {
+        System.err.println("Error reading class file: " + e.getMessage());
+      }
+
+    }
+  }
+
+  private static void analyzeMethod(String className, MethodNode method) {
+    SootClass cl = Scene.v().getSootClass(AsmUtil.toQualifiedName(className));
+    if (cl.isPhantomClass()) {
+      return;
+    }
+    StringBuilder sb = new StringBuilder();
+    List<Type> types = AsmUtil.toJimpleDesc(method.desc, com.google.common.base.Optional.absent());
+    sb.append(types.get(types.size() - 1));
+    sb.append(" ");
+    sb.append(method.name);
+    sb.append("(");
+    boolean first = true;
+    for (int i = 0; i < types.size() - 1; i++) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(',');
+      }
+      sb.append(types.get(i));
+    }
+    sb.append(")");
+    SootMethod m = cl.getMethod(sb.toString());
+    ;
+    if (!m.isConcrete()) {
+      return;
+    }
+    Body body = m.retrieveActiveBody();
+    UnitPatchingChain chain = body.getUnits();
+    Queue<Unit> allUnits = new ArrayDeque<>(chain);
+    int currentLineNumber = -1, currentBytecodeOffset = -1;
+    StringBuilder matched = new StringBuilder();
+
+    String dbgAsm;
+    if (DEBUG) {
+      dbgAsm = methodNodeToString(method);
+    }
+
+    for (int i = 0; i < method.instructions.size(); i++) {
+      AbstractInsnNode insn = method.instructions.get(i);
+
+      if (insn instanceof LineNumberNode) {
+        LineNumberNode lineNode = (LineNumberNode) insn;
+        currentLineNumber = lineNode.line;
+      }
+      if (insn instanceof BytecodeOffsetNode) {
+        BytecodeOffsetNode boNode = (BytecodeOffsetNode) insn;
+        currentBytecodeOffset = boNode.bytecodeOffset;
+      }
+
+      if (insn instanceof MethodInsnNode) {
+        MethodInsnNode minsn = (MethodInsnNode) insn;
+
+        MethodCallStmt mc = new MethodCallStmt(currentLineNumber, currentBytecodeOffset, minsn.name, minsn.desc);
+        Stmt stmt = getNextStmt(allUnits,
+            x -> x.containsInvokeExpr()
+                && !x.getInvokeExpr().getMethodRef().getDeclaringClass().getName().equals("soot.dummy.InvokeDynamic")
+                && !x.getInvokeExpr().getMethodRef().getName().equals("bootstrap$"));
+        mc.assertMatchesJimpleStmt(stmt);
+
+        if (DEBUG) {
+          matched.append(stmt.toString() + " <-> " + mc.toString() + " has line number " + currentLineNumber).append("\n");
+        }
+      }
+
+    }
+  }
+
+  public static String methodNodeToString(MethodNode methodNode) {
+    Textifier textifier = new Textifier();
+    TraceMethodVisitor traceMethodVisitor = new TraceMethodVisitor(textifier);
+
+    methodNode.accept(traceMethodVisitor);
+    StringWriter stringWriter = new StringWriter();
+    try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+
+      textifier.print(printWriter);
+      IOUtils.closeQuietly(stringWriter);
+    }
+    return stringWriter.toString();
+  }
+
+  private static Stmt getNextStmt(Queue<Unit> queue, Predicate<Stmt> predicateFilter) {
+    Queue<Unit> old = queue;
+    ArrayDeque d = (ArrayDeque) queue;
+    queue = d.clone();
+    StringBuilder rest = new StringBuilder();
+    while (!queue.isEmpty()) {
+      Unit p = queue.poll();
+      Stmt s = (Stmt) p;
+      if (predicateFilter.test(s)) {
+        while (old.size() != queue.size()) {
+          old.poll();
+        }
+        return s;
+      }
+      rest.append(s.toString()).append("\n");
+    }
+    throw new IllegalArgumentException("Could not find the next statement in " + rest);
+  }
+
+}


### PR DESCRIPTION
When the return value of a called method is not used, the invocation instructions might be missing from the final Jimple code. Also added a test that checks whether the line numbers/bytecode offsets are retained correctly.