### PR TITLE
Fix concurrent modification in StaticInliner

### DIFF
--- a/src/main/java/soot/jimple/toolkits/invoke/StaticInliner.java
+++ b/src/main/java/soot/jimple/toolkits/invoke/StaticInliner.java
@@ -146,7 +146,8 @@ public class StaticInliner extends SceneTransformer {
 
   private void computeAverageMethodSizeAndSaveOriginalSizes() {
     // long sum = 0, count = 0;
-    for (SootClass c : Scene.v().getApplicationClasses()) {
+    for (Iterator<SootClass> classesIt = Scene.v().getApplicationClasses().snapshotIterator(); classesIt.hasNext();) {
+      SootClass c = classesIt.next();
       for (Iterator<SootMethod> methodsIt = c.methodIterator(); methodsIt.hasNext();) {
         SootMethod m = methodsIt.next();
         if (m.isConcrete()) {

--- a/src/test/java/soot/jimple/toolkits/invoke/StaticInlinerTest.java
+++ b/src/test/java/soot/jimple/toolkits/invoke/StaticInlinerTest.java
@@ -1,0 +1,61 @@
+package soot.jimple.toolkits.invoke;
+
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 2026 Mustafa Senoglu
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import soot.G;
+import soot.Modifier;
+import soot.Scene;
+import soot.SootClass;
+import soot.SootMethod;
+import soot.VoidType;
+import soot.jimple.Jimple;
+
+public class StaticInlinerTest {
+
+  @Test
+  public void bodyResolutionCanAddApplicationClass() throws Exception {
+    G.reset();
+
+    SootClass initialClass = new SootClass("InitialClass", Modifier.PUBLIC);
+    SootMethod method = new SootMethod("method", Collections.emptyList(), VoidType.v(), Modifier.PUBLIC);
+    initialClass.addMethod(method);
+    Scene.v().addClass(initialClass);
+    initialClass.setApplicationClass();
+
+    method.setSource((resolvedMethod, phaseName) -> {
+      SootClass resolvedClass = new SootClass("ResolvedClass", Modifier.PUBLIC);
+      Scene.v().addClass(resolvedClass);
+      resolvedClass.setApplicationClass();
+      return Jimple.v().newBody(resolvedMethod);
+    });
+
+    Method computeSizes = StaticInliner.class.getDeclaredMethod("computeAverageMethodSizeAndSaveOriginalSizes");
+    computeSizes.setAccessible(true);
+    computeSizes.invoke(StaticInliner.v());
+  }
+}


### PR DESCRIPTION
Fixes #1206.

`computeAverageMethodSizeAndSaveOriginalSizes()` retrieves method bodies while iterating over the application-class chain. Resolving a body can add another application class, which invalidates the live iterator and causes the reported `ConcurrentModificationException`.

Use the chain's snapshot iterator so body resolution cannot invalidate the traversal. The regression test reproduces the failure with a method source that adds an application class while its body is being resolved.

Tests:
- 347 unit tests passed
- 97 system tests passed
- Checkstyle passed with 0 violations
- License header check passed